### PR TITLE
Added swagger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ python manage.py runserver
 ```
 
 Go to http://localhost:8000/
+
+# Documentation
+
+You can see the documentation and interact with the API by visiting [http://localhost:8000/](http://localhost:8000/).

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -7,16 +7,16 @@ from control_panel_api.models import Project, User
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
-        fields = ('url', 'username', 'email', 'groups')
+        fields = ('id', 'url', 'username', 'email', 'groups')
 
 
 class GroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Group
-        fields = ('url', 'name')
+        fields = ('id', 'url', 'name')
 
 
 class ProjectSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Project
-        fields = ('url', 'name', 'slug', 'repository')
+        fields = ('id', 'url', 'name', 'slug', 'repository')

--- a/control_panel_api/settings.py
+++ b/control_panel_api/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     # 'django.contrib.messages',
     'django.contrib.staticfiles',  # TODO - remove this?
     'rest_framework',
+    'rest_framework_swagger',
     'control_panel_api',
 ]
 

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -22,6 +22,8 @@ class UserViewTest(APITestCase):
         self.assertIn('url', response.data)
         self.assertIn('username', response.data)
         self.assertIn('groups', response.data)
+        self.assertIn('id', response.data)
+        self.assertEqual(5, len(response.data))
 
     def test_delete(self):
         response = self.client.delete(reverse('user-detail', (self.user.id,)))

--- a/control_panel_api/urls.py
+++ b/control_panel_api/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 from rest_framework import routers
+from rest_framework_swagger.views import get_swagger_view
 from control_panel_api import views
 
 
@@ -8,8 +9,10 @@ router.register(r'users', views.UserViewSet)
 router.register(r'groups', views.GroupViewSet)
 router.register(r'projects', views.ProjectViewSet)
 
+schema_view = get_swagger_view(title='Control Panel API')
 
 urlpatterns = [
+    url(r'^$', schema_view),
     url(r'^', include(router.urls)),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 django
 djangorestframework
+django-rest-swagger
 psycopg2
 model-mommy==1.3.2


### PR DESCRIPTION
You can see the documentation and interact with the API by visiting [http://localhost:8000/](http://localhost:8000/).

Courtesy of the [django-rest-swagger](https://django-rest-swagger.readthedocs.io/en/latest/) package.


## Ticket
https://trello.com/c/myoSdHTC/333-enable-set-up-swagger-api-docs