### PR TITLE
Fix login button in Swagger UI

### DIFF
--- a/control_panel_api/settings.py
+++ b/control_panel_api/settings.py
@@ -114,3 +114,6 @@ REST_FRAMEWORK = {
     ],
     'PAGE_SIZE': 10
 }
+
+LOGIN_URL = 'rest_framework:login'
+LOGOUT_URL = 'rest_framework:logout'


### PR DESCRIPTION
The Swagger UI relies on the `LOGIN_URL` and `LOGOUT_URL` in the
settings to work properly.