### PR TITLE
Added skeleton of permissions and filtering for users/apps

### DIFF
--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -1,0 +1,36 @@
+"""
+Custom filters
+
+See: http://www.django-rest-framework.org/api-guide/filtering/#custom-generic-filtering
+"""
+from rest_framework.filters import BaseFilterBackend
+
+from control_panel_api.permissions import is_superuser
+
+
+class AppFilter(BaseFilterBackend):
+    """
+    Filter to get visible apps.
+
+    Currently superusers see everything, others see nothing.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        if is_superuser(request.user):
+            return queryset
+        else:
+            return queryset.none()
+
+
+class UserFilter(BaseFilterBackend):
+    """
+    Filter to get visible users.
+
+    Currently superusers see everything, others see nothing.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        if is_superuser(request.user):
+            return queryset
+        else:
+            return queryset.none()

--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -8,29 +8,33 @@ from rest_framework.filters import BaseFilterBackend
 from control_panel_api.permissions import is_superuser
 
 
-class AppFilter(BaseFilterBackend):
+class SuperusersOnlyFilter(BaseFilterBackend):
+    """
+    Superusers can see everything. Other users can't see anything
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        if is_superuser(request.user):
+            return queryset
+        else:
+            return queryset.none()
+
+
+class AppFilter(SuperusersOnlyFilter):
     """
     Filter to get visible apps.
 
     Currently superusers see everything, others see nothing.
     """
 
-    def filter_queryset(self, request, queryset, view):
-        if is_superuser(request.user):
-            return queryset
-        else:
-            return queryset.none()
+    pass
 
 
-class UserFilter(BaseFilterBackend):
+class UserFilter(SuperusersOnlyFilter):
     """
     Filter to get visible users.
 
     Currently superusers see everything, others see nothing.
     """
 
-    def filter_queryset(self, request, queryset, view):
-        if is_superuser(request.user):
-            return queryset
-        else:
-            return queryset.none()
+    pass

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -1,0 +1,30 @@
+"""
+Custom permissions
+
+See: http://www.django-rest-framework.org/api-guide/permissions/#custom-permissions
+"""
+
+from rest_framework.permissions import BasePermission
+
+
+def is_superuser(user):
+    return user and user.is_superuser
+
+
+class AppPermissions(BasePermission):
+
+    """
+    Allows access only to super users.
+    """
+
+    def has_permission(self, request, view):
+        return is_superuser(request.user)
+
+
+class UserPermissions(BasePermission):
+    """
+    Allows access only to super users.
+    """
+
+    def has_permission(self, request, view):
+        return is_superuser(request.user)

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -11,20 +11,18 @@ def is_superuser(user):
     return user and user.is_superuser
 
 
-class AppPermissions(BasePermission):
-
+class IsSuperuser(BasePermission):
     """
-    Allows access only to super users.
-    """
-
-    def has_permission(self, request, view):
-        return is_superuser(request.user)
-
-
-class UserPermissions(BasePermission):
-    """
-    Allows access only to super users.
+    Only superusers are authorised
     """
 
     def has_permission(self, request, view):
         return is_superuser(request.user)
+
+
+class AppPermissions(IsSuperuser):
+    pass
+
+
+class UserPermissions(IsSuperuser):
+    pass

--- a/control_panel_api/settings.py
+++ b/control_panel_api/settings.py
@@ -113,8 +113,9 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 STATIC_URL = '/static/'
 
 REST_FRAMEWORK = {
+    'DEFAULT_FILTER_BACKENDS': ('control_panel_api.filters.SuperusersOnlyFilter',),
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAdminUser',
+        'control_panel_api.permissions.IsSuperuser',
     ],
     'PAGE_SIZE': 10
 }

--- a/control_panel_api/tests/test_filters.py
+++ b/control_panel_api/tests/test_filters.py
@@ -1,0 +1,58 @@
+from model_mommy import mommy
+from rest_framework.reverse import reverse
+from rest_framework.status import HTTP_403_FORBIDDEN
+from rest_framework.test import APITestCase
+
+
+class AppFilterTest(APITestCase):
+
+    def setUp(self):
+        # Create users
+        self.superuser = mommy.make(
+            "control_panel_api.User", is_superuser=True)
+        self.normal_user = mommy.make(
+            "control_panel_api.User", is_superuser=False)
+        # Create some apps
+        self.app_1 = mommy.make(
+            "control_panel_api.App", name="App 1")
+        self.app_2 = mommy.make(
+            "control_panel_api.App", name="App 2")
+
+    def test_superuser_sees_everything(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse("app-list"))
+        app_ids = [app["id"] for app in response.data["results"]]
+        self.assertEqual(len(app_ids), 2)
+        self.assertIn(self.app_1.id, app_ids)
+        self.assertIn(self.app_2.id, app_ids)
+
+    def test_normal_user_sees_nothing(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse("app-list"))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+
+class UserFilterTest(APITestCase):
+
+    def setUp(self):
+        self.superuser = mommy.make(
+            "control_panel_api.User", is_superuser=True)
+        self.normal_user = mommy.make(
+            "control_panel_api.User", is_superuser=False)
+
+    def test_superuser_sees_everything(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse("user-list"))
+        user_ids = [user["id"] for user in response.data["results"]]
+        self.assertEqual(len(user_ids), 2)
+        self.assertIn(self.superuser.id, user_ids)
+        self.assertIn(self.normal_user.id, user_ids)
+
+    def test_normal_user_sees_nothing(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse("user-list"))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -1,0 +1,172 @@
+from model_mommy import mommy
+from rest_framework.reverse import reverse
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_403_FORBIDDEN,
+    HTTP_404_NOT_FOUND,
+)
+from rest_framework.test import APITestCase
+
+
+class UserPermissionsTest(APITestCase):
+
+    def setUp(self):
+        self.superuser = mommy.make(
+            'control_panel_api.User', is_superuser=True)
+        self.normal_user = mommy.make(
+            'control_panel_api.User', is_superuser=False)
+
+    def test_list_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse('user-list'))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_list_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('user-list'))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_detail_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(
+            reverse('user-detail', (self.normal_user.id,)))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_detail_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(
+            reverse('user-detail', (self.normal_user.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.delete(
+            reverse('user-detail', (self.normal_user.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_delete_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('user-detail', (self.normal_user.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_create_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        data = {'username': 'foo'}
+        response = self.client.post(reverse('user-list'), data)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    def test_create_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'username': 'foo'}
+        response = self.client.post(reverse('user-list'), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_update_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        data = {'username': 'foo'}
+        response = self.client.put(
+            reverse('user-detail', (self.normal_user.id,)), data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_update_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'username': 'foo'}
+        response = self.client.put(
+            reverse('user-detail', (self.normal_user.id,)), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+
+class AppPermissionsTest(APITestCase):
+
+    def setUp(self):
+        # Create users
+        self.superuser = mommy.make(
+            'control_panel_api.User', is_superuser=True)
+        self.normal_user = mommy.make(
+            'control_panel_api.User', is_superuser=False)
+        # Create some apps
+        self.app_1 = mommy.make(
+            "control_panel_api.App", name="App 1")
+        self.app_2 = mommy.make(
+            "control_panel_api.App", name="App 2")
+
+    def test_list_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse('app-list'))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_list_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('app-list'))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_detail_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse('app-detail', (self.app_1.id,)))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_detail_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('app-detail', (self.app_1.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.delete(
+            reverse('app-detail', (self.app_1.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_delete_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('app-detail', (self.app_1.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_create_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        data = {'name': 'foo'}
+        response = self.client.post(reverse('app-list'), data)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    def test_create_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'name': 'foo'}
+        response = self.client.post(reverse('app-list'), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_update_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        data = {'name': 'foo', 'repo_url': 'http://foo.com'}
+        response = self.client.put(
+            reverse('app-detail', (self.app_1.id,)), data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_update_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'name': 'foo', 'repo_url': 'http://foo.com'}
+        response = self.client.put(
+            reverse('app-detail', (self.app_1.id,)), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -13,36 +13,23 @@ from rest_framework.test import APITestCase
 class AuthenticatedClientMixin(object):
 
     def setUp(self):
-        super(AuthenticatedClientMixin, self).setUp()
-
         self.superuser = mommy.make(
             'control_panel_api.User', is_superuser=True)
-        self.normal_user = mommy.make(
-            'control_panel_api.User', is_superuser=False)
+        self.client.force_login(self.superuser)
 
 
 class UserViewTest(AuthenticatedClientMixin, APITestCase):
 
     def setUp(self):
         super(UserViewTest, self).setUp()
-        self.fixture = self.normal_user
+        self.fixture = mommy.make('control_panel_api.User')
 
-    def test_list_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_list(self):
         response = self.client.get(reverse('user-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(response.data['results']), 2)
 
-    def test_list_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.get(reverse('user-list'))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_detail_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_detail(self):
         response = self.client.get(reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertIn('email', response.data)
@@ -53,15 +40,7 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('id', response.data)
         self.assertEqual(6, len(response.data))
 
-    def test_detail_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.get(reverse('user-detail', (self.fixture.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_delete_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_delete(self):
         response = self.client.delete(
             reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
@@ -69,43 +48,17 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    def test_delete_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.delete(
-            reverse('user-detail', (self.fixture.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_create_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_create(self):
         data = {'username': 'foo'}
         response = self.client.post(reverse('user-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    def test_create_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'username': 'foo'}
-        response = self.client.post(reverse('user-list'), data)
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_update_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_update(self):
         data = {'username': 'foo'}
         response = self.client.put(
             reverse('user-detail', (self.fixture.id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['username'], response.data['username'])
-
-    def test_update_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'username': 'foo'}
-        response = self.client.put(
-            reverse('user-detail', (self.fixture.id,)), data)
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
 class AppViewTest(AuthenticatedClientMixin, APITestCase):
@@ -115,22 +68,12 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         mommy.make('control_panel_api.App')
         self.fixture = mommy.make('control_panel_api.App')
 
-    def test_list_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_list(self):
         response = self.client.get(reverse('app-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(response.data['results']), 2)
 
-    def test_list_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.get(reverse('app-list'))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_detail_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_detail(self):
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertIn('id', response.data)
@@ -140,15 +83,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('repo_url', response.data)
         self.assertEqual(5, len(response.data))
 
-    def test_detail_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.get(reverse('app-detail', (self.fixture.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_delete_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_delete(self):
         response = self.client.delete(
             reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
@@ -156,40 +91,14 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    def test_delete_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.delete(
-            reverse('app-detail', (self.fixture.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_create_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_create(self):
         data = {'name': 'foo'}
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    def test_create_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'name': 'foo'}
-        response = self.client.post(reverse('app-list'), data)
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_update_as_superuser_responds_OK(self):
-        self.client.force_login(self.superuser)
-
+    def test_update(self):
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}
         response = self.client.put(
             reverse('app-detail', (self.fixture.id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['name'], response.data['name'])
-
-    def test_update_as_normal_user_responds_403(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'name': 'foo', 'repo_url': 'http://foo.com'}
-        response = self.client.put(
-            reverse('app-detail', (self.fixture.id,)), data)
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -27,20 +27,20 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         super(UserViewTest, self).setUp()
         self.fixture = self.normal_user
 
-    def test_list_as_superuser(self):
+    def test_list_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.get(reverse('user-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(response.data['results']), 2)
 
-    def test_list_as_normal_user(self):
+    def test_list_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse('user-list'))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_detail_as_superuser(self):
+    def test_detail_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.get(reverse('user-detail', (self.fixture.id,)))
@@ -53,13 +53,13 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('id', response.data)
         self.assertEqual(6, len(response.data))
 
-    def test_detail_as_normal_user(self):
+    def test_detail_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_delete_as_superuser(self):
+    def test_delete_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.delete(
@@ -69,28 +69,28 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    def test_delete_as_normal_user(self):
+    def test_delete_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.delete(
             reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_create_as_superuser(self):
+    def test_create_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         data = {'username': 'foo'}
         response = self.client.post(reverse('user-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    def test_create_as_normal_user(self):
+    def test_create_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         data = {'username': 'foo'}
         response = self.client.post(reverse('user-list'), data)
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_update_as_superuser(self):
+    def test_update_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         data = {'username': 'foo'}
@@ -99,7 +99,7 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['username'], response.data['username'])
 
-    def test_update_as_normal_user(self):
+    def test_update_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         data = {'username': 'foo'}
@@ -115,20 +115,20 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         mommy.make('control_panel_api.App')
         self.fixture = mommy.make('control_panel_api.App')
 
-    def test_list_as_superuser(self):
+    def test_list_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.get(reverse('app-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(response.data['results']), 2)
 
-    def test_list_as_normal_user(self):
+    def test_list_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse('app-list'))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_detail_as_superuser(self):
+    def test_detail_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
@@ -140,13 +140,13 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('repo_url', response.data)
         self.assertEqual(5, len(response.data))
 
-    def test_detail_as_normal_user(self):
+    def test_detail_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_delete_as_superuser(self):
+    def test_delete_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.delete(
@@ -156,28 +156,28 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    def test_delete_as_normal_user(self):
+    def test_delete_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.delete(
             reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_create_as_superuser(self):
+    def test_create_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         data = {'name': 'foo'}
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    def test_create_as_normal_user(self):
+    def test_create_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         data = {'name': 'foo'}
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_update_as_superuser(self):
+    def test_update_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}
@@ -186,7 +186,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['name'], response.data['name'])
 
-    def test_update_as_normal_user(self):
+    def test_update_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -1,26 +1,48 @@
 from model_mommy import mommy
 from rest_framework.reverse import reverse
-from rest_framework.status import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND, HTTP_201_CREATED
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_403_FORBIDDEN,
+    HTTP_404_NOT_FOUND,
+)
 from rest_framework.test import APITestCase
 
 
 class AuthenticatedClientMixin(object):
+
     def setUp(self):
         super(AuthenticatedClientMixin, self).setUp()
-        self.client.force_login(mommy.make('control_panel_api.User', is_staff=True))
+
+        self.superuser = mommy.make(
+            'control_panel_api.User', is_superuser=True)
+        self.normal_user = mommy.make(
+            'control_panel_api.User', is_superuser=False)
 
 
 class UserViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super(UserViewTest, self).setUp()
-        self.fixture = mommy.make('control_panel_api.User')
+        self.fixture = self.normal_user
 
-    def test_list(self):
+    def test_list_as_superuser(self):
+        self.client.force_login(self.superuser)
+
         response = self.client.get(reverse('user-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(response.data['results']), 2)
 
-    def test_detail(self):
+    def test_list_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('user-list'))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_detail_as_superuser(self):
+        self.client.force_login(self.superuser)
+
         response = self.client.get(reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertIn('email', response.data)
@@ -31,37 +53,84 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('id', response.data)
         self.assertEqual(6, len(response.data))
 
-    def test_delete(self):
-        response = self.client.delete(reverse('user-detail', (self.fixture.id,)))
+    def test_detail_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('user-detail', (self.fixture.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_as_superuser(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.delete(
+            reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
 
         response = self.client.get(reverse('user-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    def test_create(self):
+    def test_delete_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('user-detail', (self.fixture.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_create_as_superuser(self):
+        self.client.force_login(self.superuser)
+
         data = {'username': 'foo'}
         response = self.client.post(reverse('user-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    def test_update(self):
+    def test_create_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
         data = {'username': 'foo'}
-        response = self.client.put(reverse('user-detail', (self.fixture.id,)), data)
+        response = self.client.post(reverse('user-list'), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_update_as_superuser(self):
+        self.client.force_login(self.superuser)
+
+        data = {'username': 'foo'}
+        response = self.client.put(
+            reverse('user-detail', (self.fixture.id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['username'], response.data['username'])
 
+    def test_update_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'username': 'foo'}
+        response = self.client.put(
+            reverse('user-detail', (self.fixture.id,)), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
 
 class AppViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super(AppViewTest, self).setUp()
         mommy.make('control_panel_api.App')
         self.fixture = mommy.make('control_panel_api.App')
 
-    def test_list(self):
+    def test_list_as_superuser(self):
+        self.client.force_login(self.superuser)
+
         response = self.client.get(reverse('app-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(response.data['results']), 2)
 
-    def test_detail(self):
+    def test_list_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('app-list'))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_detail_as_superuser(self):
+        self.client.force_login(self.superuser)
+
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertIn('id', response.data)
@@ -71,20 +140,56 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('repo_url', response.data)
         self.assertEqual(5, len(response.data))
 
-    def test_delete(self):
-        response = self.client.delete(reverse('app-detail', (self.fixture.id,)))
+    def test_detail_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('app-detail', (self.fixture.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_as_superuser(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.delete(
+            reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
 
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    def test_create(self):
+    def test_delete_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('app-detail', (self.fixture.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_create_as_superuser(self):
+        self.client.force_login(self.superuser)
+
         data = {'name': 'foo'}
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    def test_update(self):
+    def test_create_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'name': 'foo'}
+        response = self.client.post(reverse('app-list'), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_update_as_superuser(self):
+        self.client.force_login(self.superuser)
+
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}
-        response = self.client.put(reverse('app-detail', (self.fixture.id,)), data)
+        response = self.client.put(
+            reverse('app-detail', (self.fixture.id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['name'], response.data['name'])
+
+    def test_update_as_normal_user(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'name': 'foo', 'repo_url': 'http://foo.com'}
+        response = self.client.put(
+            reverse('app-detail', (self.fixture.id,)), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -1,7 +1,10 @@
 from django.contrib.auth.models import Group
 from rest_framework import viewsets
 
-from control_panel_api.filters import AppFilter, UserFilter
+from control_panel_api.filters import (
+    AppFilter,
+    UserFilter,
+)
 from control_panel_api.models import App, User
 from control_panel_api.permissions import (
     AppPermissions,

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -1,17 +1,24 @@
 from django.contrib.auth.models import Group
 from rest_framework import viewsets
 
+from control_panel_api.filters import AppFilter, UserFilter
 from control_panel_api.models import App, User
+from control_panel_api.permissions import (
+    AppPermissions,
+    UserPermissions,
+)
 from control_panel_api.serializers import (
     GroupSerializer,
     AppSerializer,
-    UserSerializer
+    UserSerializer,
 )
 
 
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    filter_backends = (UserFilter,)
+    permission_classes = (UserPermissions, )
 
 
 class GroupViewSet(viewsets.ModelViewSet):
@@ -22,3 +29,5 @@ class GroupViewSet(viewsets.ModelViewSet):
 class AppViewSet(viewsets.ModelViewSet):
     queryset = App.objects.all()
     serializer_class = AppSerializer
+    filter_backends = (AppFilter,)
+    permission_classes = (AppPermissions, )


### PR DESCRIPTION
This is currently very simple and assumes superusers (users with
`is_superuser == True`) can do/see everything, others can't do/see
anything.

I also updated the views tests to make requests both as superuser and
as normal user.

This cover one of the use cases:

    As a superuser, I want to be able to create a user

**NOTE**: This is just a start, apps permissions/filters will need to take
in considerations teams/roles/permissions.