### PR TITLE
Add /apps3buckets endpoints

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -122,8 +122,10 @@ class AppS3Bucket(TimeStampedModel):
         (READWRITE, "Read-write"),
     )
 
-    app = models.ForeignKey(App, on_delete=models.CASCADE)
-    s3bucket = models.ForeignKey(S3Bucket, on_delete=models.CASCADE)
+    app = models.ForeignKey(
+        App, related_name='apps3buckets', on_delete=models.CASCADE)
+    s3bucket = models.ForeignKey(
+        S3Bucket, related_name='apps3buckets', on_delete=models.CASCADE)
     access_level = models.CharField(
         max_length=9, choices=ACCESS_LEVELS, default=READONLY)
 

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -1,31 +1,43 @@
 from django.contrib.auth.models import Group
 from rest_framework import serializers
 
-from control_panel_api.models import App, S3Bucket, User
+from control_panel_api.models import (
+    App,
+    AppS3Bucket,
+    S3Bucket,
+    User
+)
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
         fields = ('id', 'url', 'username', 'name', 'email', 'groups')
 
 
-class GroupSerializer(serializers.HyperlinkedModelSerializer):
+class GroupSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Group
         fields = ('id', 'url', 'name')
 
 
-class AppSerializer(serializers.HyperlinkedModelSerializer):
+class AppSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = App
         fields = ('id', 'url', 'name', 'slug', 'repo_url')
 
 
-class S3BucketSerializer(serializers.HyperlinkedModelSerializer):
+class AppS3BucketSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = AppS3Bucket
+        fields = ('id', 'url', 'app', 's3bucket', 'access_level')
+
+
+class S3BucketSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = S3Bucket

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -27,7 +27,7 @@ class AppSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = App
-        fields = ('id', 'url', 'name', 'slug', 'repo_url')
+        fields = ('id', 'url', 'name', 'slug', 'repo_url', 'apps3buckets')
 
 
 class AppS3BucketSerializer(serializers.ModelSerializer):
@@ -41,4 +41,4 @@ class S3BucketSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = S3Bucket
-        fields = ('id', 'url', 'name', 'arn')
+        fields = ('id', 'url', 'name', 'arn', 'apps3buckets')

--- a/control_panel_api/tests/test_filters.py
+++ b/control_panel_api/tests/test_filters.py
@@ -3,6 +3,8 @@ from rest_framework.reverse import reverse
 from rest_framework.status import HTTP_403_FORBIDDEN
 from rest_framework.test import APITestCase
 
+from control_panel_api.models import AppS3Bucket
+
 
 class AppFilterTest(APITestCase):
 
@@ -31,6 +33,55 @@ class AppFilterTest(APITestCase):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse("app-list"))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+
+class AppS3BucketFilterTest(APITestCase):
+
+    def setUp(self):
+        # Create users
+        self.superuser = mommy.make(
+            "control_panel_api.User", is_superuser=True)
+        self.normal_user = mommy.make(
+            "control_panel_api.User", is_superuser=False)
+        # Create some apps
+        self.app_1 = mommy.make(
+            "control_panel_api.App", name="App 1")
+        self.app_2 = mommy.make(
+            "control_panel_api.App", name="App 2")
+        # Create some S3 buckets
+        self.s3bucket_1 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-1")
+        self.s3bucket_2 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-2")
+        # Grant access to these S3 buckets
+        self.apps3bucket_1 = mommy.make(
+            "control_panel_api.AppS3Bucket",
+            app=self.app_1,
+            s3bucket=self.s3bucket_1,
+            access_level=AppS3Bucket.READONLY,
+        )
+        self.apps3bucket_2 = mommy.make(
+            "control_panel_api.AppS3Bucket",
+            app=self.app_2,
+            s3bucket=self.s3bucket_2,
+            access_level=AppS3Bucket.READONLY,
+        )
+
+    def test_superuser_sees_everything(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse("apps3bucket-list"))
+        ids = [apps3bucket["id"] for apps3bucket in response.data["results"]]
+
+        self.assertEqual(len(ids), 2)
+        self.assertIn(self.apps3bucket_1.id, ids)
+        self.assertIn(self.apps3bucket_2.id, ids)
+
+    def test_normal_user_sees_nothing(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse("apps3bucket-list"))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 

--- a/control_panel_api/tests/test_filters.py
+++ b/control_panel_api/tests/test_filters.py
@@ -55,15 +55,11 @@ class AppS3BucketFilterTest(APITestCase):
         self.s3bucket_2 = mommy.make(
             "control_panel_api.S3Bucket", name="test-bucket-2")
         # Grant access to these S3 buckets
-        self.apps3bucket_1 = mommy.make(
-            "control_panel_api.AppS3Bucket",
-            app=self.app_1,
+        self.apps3bucket_1 = self.app_1.apps3buckets.create(
             s3bucket=self.s3bucket_1,
             access_level=AppS3Bucket.READONLY,
         )
-        self.apps3bucket_2 = mommy.make(
-            "control_panel_api.AppS3Bucket",
-            app=self.app_2,
+        self.apps3bucket_2 = self.app_2.apps3buckets.create(
             s3bucket=self.s3bucket_2,
             access_level=AppS3Bucket.READONLY,
         )

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -129,13 +129,13 @@ class AppS3BucketTestCase(TestCase):
 
     def test_one_record_per_app_per_s3bucket(self):
         # Give app_1 access to bucket_1 (read-only)
-        self.app_1.apps3bucket_set.create(
+        self.app_1.apps3buckets.create(
             s3bucket=self.s3_bucket_1,
             access_level=AppS3Bucket.READONLY,
         )
 
         with self.assertRaises(IntegrityError):
-            self.app_1.apps3bucket_set.create(
+            self.app_1.apps3buckets.create(
                 s3bucket=self.s3_bucket_1,
                 access_level=AppS3Bucket.READWRITE,
             )

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -195,15 +195,11 @@ class AppS3BucketPermissionsTest(APITestCase):
         self.s3bucket_3 = mommy.make(
             "control_panel_api.S3Bucket", name="test-bucket-3")
         # Grant access to these S3 buckets
-        self.apps3bucket_1 = mommy.make(
-            "control_panel_api.AppS3Bucket",
-            app=self.app_1,
+        self.apps3bucket_1 = self.app_1.apps3buckets.create(
             s3bucket=self.s3bucket_1,
             access_level=AppS3Bucket.READONLY,
         )
-        self.apps3bucket_2 = mommy.make(
-            "control_panel_api.AppS3Bucket",
-            app=self.app_2,
+        self.apps3bucket_2 = self.app_2.apps3buckets.create(
             s3bucket=self.s3bucket_2,
             access_level=AppS3Bucket.READONLY,
         )

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -9,6 +9,8 @@ from rest_framework.status import (
 )
 from rest_framework.test import APITestCase
 
+from control_panel_api.models import AppS3Bucket
+
 
 class UserPermissionsTest(APITestCase):
 
@@ -169,6 +171,119 @@ class AppPermissionsTest(APITestCase):
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}
         response = self.client.put(
             reverse('app-detail', (self.app_1.id,)), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+
+class AppS3BucketPermissionsTest(APITestCase):
+
+    def setUp(self):
+        # Create users
+        self.superuser = mommy.make(
+            "control_panel_api.User", is_superuser=True)
+        self.normal_user = mommy.make(
+            "control_panel_api.User", is_superuser=False)
+        # Create some apps
+        self.app_1 = mommy.make(
+            "control_panel_api.App", name="App 1")
+        self.app_2 = mommy.make(
+            "control_panel_api.App", name="App 2")
+        # Create some S3 buckets
+        self.s3bucket_1 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-1")
+        self.s3bucket_2 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-2")
+        self.s3bucket_3 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-3")
+        # Grant access to these S3 buckets
+        self.apps3bucket_1 = mommy.make(
+            "control_panel_api.AppS3Bucket",
+            app=self.app_1,
+            s3bucket=self.s3bucket_1,
+            access_level=AppS3Bucket.READONLY,
+        )
+        self.apps3bucket_2 = mommy.make(
+            "control_panel_api.AppS3Bucket",
+            app=self.app_2,
+            s3bucket=self.s3bucket_2,
+            access_level=AppS3Bucket.READONLY,
+        )
+
+    def test_list_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse('apps3bucket-list'))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_list_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse('apps3bucket-list'))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_detail_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_detail_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.delete(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_delete_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_create_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3bucket_3.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        response = self.client.post(reverse('apps3bucket-list'), data)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    def test_create_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'doesnt': 'matter'}
+        response = self.client.post(reverse('apps3bucket-list'), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_update_as_superuser_responds_OK(self):
+        self.client.force_login(self.superuser)
+
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3bucket_1.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        response = self.client.put(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_update_as_normal_user_responds_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'doesnt': 'matter'}
+        response = self.client.put(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -10,6 +10,12 @@ from rest_framework.status import (
 )
 from rest_framework.test import APITestCase
 
+from control_panel_api.models import (
+    App,
+    AppS3Bucket,
+    S3Bucket,
+)
+
 
 class AuthenticatedClientMixin(object):
 
@@ -106,6 +112,76 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(data['name'], response.data['name'])
 
 
+class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        # Apps
+        self.app_1 = App.objects.create(name="app_1")
+        self.app_2 = App.objects.create(name="app_2")
+
+        # S3 buckets
+        self.s3_bucket_1 = S3Bucket.objects.create(name="test-bucket-1")
+        self.s3_bucket_2 = S3Bucket.objects.create(name="test-bucket-2")
+        self.s3_bucket_3 = S3Bucket.objects.create(name="test-bucket-3")
+
+        # Grant access to buckets
+        self.apps3bucket_1 = self.app_1.apps3buckets.create(
+            s3bucket=self.s3_bucket_1,
+            access_level=AppS3Bucket.READONLY,
+        )
+        self.apps3bucket_2 = self.app_2.apps3buckets.create(
+            s3bucket=self.s3_bucket_2,
+            access_level=AppS3Bucket.READONLY,
+        )
+
+    def test_list(self):
+        response = self.client.get(reverse('apps3bucket-list'))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertEqual(len(response.data['results']), 2)
+
+    def test_detail(self):
+        response = self.client.get(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertIn('id', response.data)
+        self.assertIn('url', response.data)
+        self.assertIn('app', response.data)
+        self.assertIn('s3bucket', response.data)
+        self.assertEqual('readonly', response.data['access_level'])
+        self.assertEqual(5, len(response.data))
+
+    def test_delete(self):
+        response = self.client.delete(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+        response = self.client.get(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
+
+    def test_create(self):
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3_bucket_3.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        response = self.client.post(reverse('apps3bucket-list'), data)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    def test_update(self):
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3_bucket_1.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        response = self.client.put(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertEqual(data['access_level'], response.data['access_level'])
+
+
 class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 
     def setUp(self):
@@ -135,7 +211,8 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('s3bucket-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
 
-        response = self.client.get(reverse('s3bucket-detail', (self.fixture.id,)))
+        response = self.client.get(
+            reverse('s3bucket-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
     def test_create_when_valid_data(self):

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -82,7 +82,8 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('name', response.data)
         self.assertIn('slug', response.data)
         self.assertIn('repo_url', response.data)
-        self.assertEqual(5, len(response.data))
+        self.assertIn('apps3buckets', response.data)
+        self.assertEqual(6, len(response.data))
 
     def test_delete(self):
         response = self.client.delete(
@@ -126,7 +127,8 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('url', response.data)
         self.assertIn('name', response.data)
         self.assertIn('arn', response.data)
-        self.assertEqual(4, len(response.data))
+        self.assertIn('apps3buckets', response.data)
+        self.assertEqual(5, len(response.data))
 
     def test_delete(self):
         response = self.client.delete(

--- a/control_panel_api/urls.py
+++ b/control_panel_api/urls.py
@@ -8,6 +8,7 @@ from control_panel_api import views
 
 router = routers.DefaultRouter()
 router.register(r'apps', views.AppViewSet)
+router.register(r'apps3buckets', views.AppS3BucketViewSet)
 router.register(r'groups', views.GroupViewSet)
 router.register(r's3buckets', views.S3BucketViewSet)
 router.register(r'users', views.UserViewSet)

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -8,6 +8,7 @@ from control_panel_api.filters import (
 )
 from control_panel_api.models import (
     App,
+    AppS3Bucket,
     S3Bucket,
     User,
 )
@@ -17,8 +18,9 @@ from control_panel_api.permissions import (
     UserPermissions,
 )
 from control_panel_api.serializers import (
-    GroupSerializer,
+    AppS3BucketSerializer,
     AppSerializer,
+    GroupSerializer,
     S3BucketSerializer,
     UserSerializer,
 )
@@ -41,6 +43,11 @@ class AppViewSet(viewsets.ModelViewSet):
     serializer_class = AppSerializer
     filter_backends = (AppFilter,)
     permission_classes = (AppPermissions, )
+
+
+class AppS3BucketViewSet(viewsets.ModelViewSet):
+    queryset = AppS3Bucket.objects.all()
+    serializer_class = AppS3BucketSerializer
 
 
 class S3BucketViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## What

Added `/apps3buckets` endpoints  to manipulate `AppS3Bucket` records.

Also added these references to the `/apps` and `/s3buckets` endspoints responses.

### Example responses

`GET /apps/2`

```json
{
  "id": 2,
  "url": "http://localhost:8000/apps/2/",
  "name": "App 2",
  "slug": "app-2",
  "repo_url": "",
  "apps3buckets": [
    4,
    6
  ]
}
```

`GET /s3buckets/8`

```json
{
  "id": 8,
  "url": "http://localhost:8000/s3buckets/8/",
  "name": "test-bucket-1",
  "arn": "arn:aws:s3:::test-bucket-1",
  "apps3buckets": [
    1,
    6
  ]
}
```

`GET /apps3buckets/6`

```json
{
  "id": 6,
  "url": "http://localhost:8000/apps3buckets/6/",
  "app": 2,
  "s3bucket": 8,
  "access_level": "readonly"
}
```

**NOTE**: From the above response we can tell that App `App 2` has `readonly` access to S3bucket `test-bucket-1`.

## Ticket

https://trello.com/c/vJo7HpeK/375-cp-api-add-endpoints-for-app-s3bucket-access-resources