### PR TITLE
Enable continuous deployment of Control Panel API branches to Kubernetes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk update && apk add py2-pip
+            apk update && apk add curl py2-pip
             pip install docker-compose==1.15.0
 
       - restore_cache:
@@ -58,3 +58,10 @@ jobs:
             docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} quay.io
             docker tag app "quay.io/mojanalytics/control-panel:${CIRCLE_BRANCH}"
             docker push "quay.io/mojanalytics/control-panel:${CIRCLE_BRANCH}"
+
+      - deploy:
+          name: Deploy to Kubernetes
+          command: |
+            curl ${JENKINS_URL}/job/control-panel/build \
+              --data token=${JENKINS_JOB_TRIGGER_TOKEN}
+              --user ${JENKINS_USER}:${JENKINS_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk update && apk add curl curl-dev py2-pip
-            pip install docker-compose==1.15.0
+            apk update && apk add --no-progress curl curl-dev py2-pip
+            pip install docker-compose==1.15.0 | cat
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - deploy:
           name: Deploy to Kubernetes
           command: |
-            curl ${JENKINS_URL}/job/control-panel/buildWithParameters \
+            curl ${JENKINS_URL}/job/control-panel/job/${CIRCLE_BRANCH}/buildWithParameters \
               --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
               --data BRANCH=${CIRCLE_BRANCH} \
               --user ${JENKINS_USER}:${JENKINS_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk update && apk add curl py2-pip
+            apk update && apk add curl curl-dev py2-pip
             pip install docker-compose==1.15.0
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
       - deploy:
           name: Deploy to Kubernetes
           command: |
-            curl ${JENKINS_URL}/job/control-panel/build \
-              --data token=${JENKINS_JOB_TRIGGER_TOKEN}
+            curl ${JENKINS_URL}/job/control-panel/buildWithParameters \
+              --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
+              --data BRANCH=${CIRCLE_BRANCH} \
               --user ${JENKINS_USER}:${JENKINS_TOKEN}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,9 @@ pipeline {
 
   parameters {
     string(
-      name: "VERSION",
-      description: "Version number of the control-panel to deploy",
-      defaultValue: "0.1.0"
+      name: "BRANCH",
+      description: "Git branch or commit to deploy",
+      defaultValue: env.BRANCH_NAME
     )
   }
 
@@ -22,10 +22,11 @@ pipeline {
       steps {
         helm.upgrade(
           release: "cpanel",
-          chart: "mojanalytics/cpanel-${params.VERSION}",
+          chart: "mojanalytics/cpanel-0.1.0",
           values: "config/chart-env-config/${env.ENV}/cpanel.yml",
           overrides: [
-            "API.Environment.DEBUG": "True"
+            "API.Environment.DEBUG": "True",
+            "API.Image.Tag": params.BRANCH
           ]
         )
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,35 @@
+#!groovy
+
+pipeline {
+
+  parameters {
+    string(
+      name: "VERSION",
+      description: "Version number of the control-panel to deploy",
+      defaultValue: "0.1.0"
+    )
+  }
+
+  agent any
+
+  environment {
+    DOCKER_REGISTRY="quay.io/mojanalytics/control-panel"
+  }
+
+  stages {
+
+    stage("Deploy") {
+      steps {
+        helm.upgrade(
+          release: "cpanel",
+          chart: "mojanalytics/cpanel-${params.VERSION}",
+          values: "config/chart-env-config/${env.ENV}/cpanel.yml",
+          overrides: [
+            "API.Environment.DEBUG": "True"
+          ]
+        )
+      }
+    }
+
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,23 +12,13 @@ pipeline {
 
   agent any
 
-  environment {
-    DOCKER_REGISTRY="quay.io/mojanalytics/control-panel"
-  }
-
   stages {
 
     stage("Deploy") {
       steps {
-        helm.upgrade(
-          release: "cpanel",
-          chart: "mojanalytics/cpanel-0.1.0",
-          values: "config/chart-env-config/${env.ENV}/cpanel.yml",
-          overrides: [
-            "API.Environment.DEBUG": "True",
-            "API.Image.Tag": params.BRANCH
-          ]
-        )
+        script {
+          deploy.controlpanel(debug: true, tag: params.BRANCH)
+        }
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,14 +2,6 @@
 
 pipeline {
 
-  parameters {
-    string(
-      name: "BRANCH",
-      description: "Git branch or commit to deploy",
-      defaultValue: env.BRANCH_NAME
-    )
-  }
-
   agent any
 
   stages {
@@ -17,7 +9,7 @@ pipeline {
     stage("Deploy") {
       steps {
         script {
-          deploy.controlpanel(debug: true, tag: params.BRANCH)
+          deploy.controlpanel(debug: true)
         }
       }
     }


### PR DESCRIPTION
## What

* Add Circle CI config, to build a docker image for a Github PR, run tests, push to quay.io and trigger a Jenkins build
* Add `Jenkinsfile` to deploy docker image to Kubernetes cluster using helm

## How to review

1. Create a PR for `analytics-platform-control-panel`
2. See Circle CI build of PR branch (eg: https://circleci.com/gh/ministryofjustice/analytics-platform-control-panel/155)
3. See Jenkins build triggered by Circle CI (eg: https://jenkins.services.dev.mojanalytics.xyz/job/control-panel/job/continuous-deployment/9/)
4. See control panel API is deployed (eg: https://control-panel.services.dev.mojanalytics.xyz/)

See [Trello ticket #342](https://trello.com/c/jxufKhNR)

Also see https://github.com/ministryofjustice/analytics-platform-jenkins-lib/pull/19