### PR TITLE
Create/Delete AWS IAM roles for apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # analytics-platform-control-panel
 Control panel contains admin functions like creating users and granting access to apps
 
+## How to run the tests
+
+```sh
+python manage.py test --settings=control_panel_api.settings.test
+```
+
 
 # Config
 

--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -40,7 +40,7 @@ def delete_policy(policy_arn):
 def create_role(role_name, assume_role_policy):
     """Creates IAM role with the given name"""
 
-    boto3.client("iam").create_role(
+    aws_api_client("iam").create_role(
         RoleName=role_name,
         AssumeRolePolicyDocument=json.dumps(assume_role_policy)
     )
@@ -50,13 +50,13 @@ def delete_role(role_name):
     """Delete the given IAM role."""
 
     _detach_role_policies(role_name)
-    boto3.client("iam").delete_role(RoleName=role_name)
+    aws_api_client("iam").delete_role(RoleName=role_name)
 
 
 def _detach_role_policies(role_name):
     """Detaches all the policies from the given role"""
 
-    client = boto3.client("iam")
+    client = aws_api_client("iam")
 
     policies = client.list_attached_role_policies(RoleName=role_name)
     for policy in policies["AttachedPolicies"]:

--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -37,6 +37,35 @@ def delete_policy(policy_arn):
     aws_api_client("iam").delete_policy(PolicyArn=policy_arn)
 
 
+def create_role(role_name, assume_role_policy):
+    """Creates IAM role with the given name"""
+
+    boto3.client("iam").create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=json.dumps(assume_role_policy)
+    )
+
+
+def delete_role(role_name):
+    """Delete the given IAM role."""
+
+    _detach_role_policies(role_name)
+    boto3.client("iam").delete_role(RoleName=role_name)
+
+
+def _detach_role_policies(role_name):
+    """Detaches all the policies from the given role"""
+
+    client = boto3.client("iam")
+
+    policies = client.list_attached_role_policies(RoleName=role_name)
+    for policy in policies["AttachedPolicies"]:
+        detach_policy_from_role(
+            role_name=role_name,
+            policy_arn=policy["PolicyArn"],
+        )
+
+
 def detach_policy_from_entities(policy_arn):
     """Get all entities to which policy is attached first then call separate detach operations"""
     entities = aws_api_client("iam").list_entities_for_policy(PolicyArn=policy_arn)

--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -56,9 +56,7 @@ def delete_role(role_name):
 def _detach_role_policies(role_name):
     """Detaches all the policies from the given role"""
 
-    client = aws_api_client("iam")
-
-    policies = client.list_attached_role_policies(RoleName=role_name)
+    policies = aws_api_client("iam").list_attached_role_policies(RoleName=role_name)
     for policy in policies["AttachedPolicies"]:
         detach_policy_from_role(
             role_name=role_name,

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -57,7 +57,7 @@ def _create_app_role(role_name):
             {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": settings.K8S_WORKER_ROLE_ARN,
+                    "AWS": f"{settings.IAM_ARN_BASE}:role/{settings.K8S_WORKER_ROLE_NAME}",
                 },
                 "Action": "sts:AssumeRole",
             }

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -130,7 +130,6 @@ def get_policy_document(bucket_name, readwrite):
 
 def create_bucket(bucket_name):
     """Create an s3 bucket and add logging"""
-    bucket_name = _bucket_name(name)
     aws.create_bucket(
         bucket_name, region=settings.BUCKET_REGION, acl='private')
     aws.put_bucket_logging(bucket_name, target_bucket=settings.LOGS_BUCKET_NAME,

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -14,6 +14,11 @@ def _policy_name(bucket_name, readwrite=False):
     return "{}-{}".format(bucket_name, READ_WRITE if readwrite else READ_ONLY)
 
 
+def _app_role_name(app_slug):
+    """Return the IAM role name for the given `app_slug`"""
+    return "{}_app_{}".format(settings.ENV, app_slug)
+
+
 def _policy_arn(bucket_name, readwrite=False):
     """Return full bucket policy arn e.g. arn:aws:iam::1337:policy/bucketname-readonly"""
     return "{}:policy/{}".format(settings.IAM_ARN_BASE, _policy_name(bucket_name, readwrite))
@@ -27,6 +32,44 @@ def bucket_arn(bucket_name):
 def app_slug(name):
     """Create a valid slug for s3 using standard django slugify but we add some custom"""
     return re.sub(r'_+', '-', slugify(name))
+
+
+def app_create(app_slug):
+    """Creates the IAM role for the given app"""
+    _create_app_role(_app_role_name(app_slug))
+
+
+def _create_app_role(role_name):
+    """Creates the IAM role for the given app"""
+
+    # See: `sts:AssumeRole` required by kube2iam
+    # https://github.com/jtblin/kube2iam#iam-roles
+    assume_role_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ec2.amazonaws.com",
+                },
+                "Action": "sts:AssumeRole",
+            },
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": settings.K8S_WORKER_ROLE_ARN,
+                },
+                "Action": "sts:AssumeRole",
+            }
+        ]
+    }
+
+    aws.create_role(role_name, assume_role_policy)
+
+
+def app_delete(app_slug):
+    """Deletes the IAM role for the given app"""
+    aws.delete_role(_app_role_name(app_slug))
 
 
 def get_policy_document(bucket_name, readwrite):
@@ -87,7 +130,9 @@ def get_policy_document(bucket_name, readwrite):
 
 def create_bucket(bucket_name):
     """Create an s3 bucket and add logging"""
-    aws.create_bucket(bucket_name, region=settings.BUCKET_REGION, acl='private')
+    bucket_name = _bucket_name(name)
+    aws.create_bucket(
+        bucket_name, region=settings.BUCKET_REGION, acl='private')
     aws.put_bucket_logging(bucket_name, target_bucket=settings.LOGS_BUCKET_NAME,
                            target_prefix="{}/".format(bucket_name))
 

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -123,6 +123,6 @@ BUCKET_REGION = os.environ.get('BUCKET_REGION', 'eu-west-1')
 ENV = os.environ.get('ENV', 'dev')
 LOGS_BUCKET_NAME = os.environ.get('LOGS_BUCKET_NAME', 'moj-analytics-s3-logs')
 IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', '')
-K8S_WORKER_ROLE_ARN = os.environ.get('K8S_WORKER_ROLE_ARN', '')
+K8S_WORKER_ROLE_NAME = os.environ.get('K8S_WORKER_ROLE_NAME', '')
 
 AWS_API_CLIENT_HANDLER = boto3.client

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -123,5 +123,6 @@ BUCKET_REGION = os.environ.get('BUCKET_REGION', 'eu-west-1')
 ENV = os.environ.get('ENV', 'dev')
 LOGS_BUCKET_NAME = os.environ.get('LOGS_BUCKET_NAME', 'moj-analytics-s3-logs')
 IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', 'arn:aws:iam::593291632749')
+K8S_WORKER_ROLE_ARN = os.environ.get('K8S_WORKER_ROLE_ARN', '')
 
 AWS_API_CLIENT_HANDLER = boto3.client

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -122,7 +122,7 @@ LOGOUT_URL = 'rest_framework:logout'
 BUCKET_REGION = os.environ.get('BUCKET_REGION', 'eu-west-1')
 ENV = os.environ.get('ENV', 'dev')
 LOGS_BUCKET_NAME = os.environ.get('LOGS_BUCKET_NAME', 'moj-analytics-s3-logs')
-IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', 'arn:aws:iam::593291632749')
+IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', '')
 K8S_WORKER_ROLE_ARN = os.environ.get('K8S_WORKER_ROLE_ARN', '')
 
 AWS_API_CLIENT_HANDLER = boto3.client

--- a/control_panel_api/settings/test.py
+++ b/control_panel_api/settings/test.py
@@ -6,4 +6,5 @@ ENV = 'test'
 AWS_API_CLIENT_HANDLER = MagicMock()
 BUCKET_REGION = 'eu-test-2'
 LOGS_BUCKET_NAME = 'moj-test-logs'
-IAM_ARN_BASE = 'arn:aws:iam::1337'
+IAM_ARN_BASE = 'arn:aws:iam::123'
+K8S_WORKER_ROLE_NAME = 'test-k8s-worker-role'

--- a/control_panel_api/tests/__init__.py
+++ b/control_panel_api/tests/__init__.py
@@ -1,9 +1,12 @@
+K8S_WORKER_ROLE_ARN = "arn:aws:iam::123:role/k8s_worker_role"
+
 POLICY_DOCUMENT_READWRITE = {
     'Version': '2012-10-17',
     'Statement': [
         {'Sid': 'ListBucketsInConsole', 'Effect': 'Allow', 'Action': ['s3:GetBucketLocation', 's3:ListAllMyBuckets'],
          'Resource': 'arn:aws:s3:::*'},
-        {'Sid': 'ListObjects', 'Action': ['s3:ListBucket'], 'Effect': 'Allow', 'Resource': ['arn:aws:s3:::test-bucketname']},
+        {'Sid': 'ListObjects', 'Action': ['s3:ListBucket'], 'Effect': 'Allow', 'Resource': [
+            'arn:aws:s3:::test-bucketname']},
         {'Sid': 'ReadObjects', 'Action': ['s3:GetObject', 's3:GetObjectAcl', 's3:GetObjectVersion'], 'Effect': 'Allow',
          'Resource': 'arn:aws:s3:::test-bucketname/*'},
         {'Sid': 'UpdateRenameAndDeleteObjects',
@@ -17,8 +20,29 @@ POLICY_DOCUMENT_READONLY = {
     'Statement': [
         {'Sid': 'ListBucketsInConsole', 'Effect': 'Allow', 'Action': ['s3:GetBucketLocation', 's3:ListAllMyBuckets'],
          'Resource': 'arn:aws:s3:::*'},
-        {'Sid': 'ListObjects', 'Action': ['s3:ListBucket'], 'Effect': 'Allow', 'Resource': ['arn:aws:s3:::test-bucketname']},
+        {'Sid': 'ListObjects', 'Action': ['s3:ListBucket'], 'Effect': 'Allow', 'Resource': [
+            'arn:aws:s3:::test-bucketname']},
         {'Sid': 'ReadObjects', 'Action': ['s3:GetObject', 's3:GetObjectAcl', 's3:GetObjectVersion'], 'Effect': 'Allow',
          'Resource': 'arn:aws:s3:::test-bucketname/*'}
+    ]
+}
+
+APP_IAM_ROLE_ASSUME_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com",
+            },
+            "Action": "sts:AssumeRole",
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": K8S_WORKER_ROLE_ARN,
+            },
+            "Action": "sts:AssumeRole",
+        }
     ]
 }

--- a/control_panel_api/tests/__init__.py
+++ b/control_panel_api/tests/__init__.py
@@ -1,5 +1,5 @@
 IAM_ARN_BASE = "arn:aws:iam::123"
-K8S_WORKER_ROLE_NAME = "k8s_worker_role"
+K8S_WORKER_ROLE_NAME = "test-k8s-worker-role"
 
 POLICY_DOCUMENT_READWRITE = {
     'Version': '2012-10-17',

--- a/control_panel_api/tests/__init__.py
+++ b/control_panel_api/tests/__init__.py
@@ -1,5 +1,5 @@
-IAM_ARN_BASE = "arn:aws:iam::123"
-K8S_WORKER_ROLE_NAME = "test-k8s-worker-role"
+from django.conf import settings
+
 
 POLICY_DOCUMENT_READWRITE = {
     'Version': '2012-10-17',
@@ -41,7 +41,7 @@ APP_IAM_ROLE_ASSUME_POLICY = {
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": f"{IAM_ARN_BASE}:role/{K8S_WORKER_ROLE_NAME}",
+                "AWS": f"{settings.IAM_ARN_BASE}:role/{settings.K8S_WORKER_ROLE_NAME}",
             },
             "Action": "sts:AssumeRole",
         }

--- a/control_panel_api/tests/__init__.py
+++ b/control_panel_api/tests/__init__.py
@@ -1,4 +1,5 @@
-K8S_WORKER_ROLE_ARN = "arn:aws:iam::123:role/k8s_worker_role"
+IAM_ARN_BASE = "arn:aws:iam::123"
+K8S_WORKER_ROLE_NAME = "k8s_worker_role"
 
 POLICY_DOCUMENT_READWRITE = {
     'Version': '2012-10-17',
@@ -40,7 +41,7 @@ APP_IAM_ROLE_ASSUME_POLICY = {
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": K8S_WORKER_ROLE_ARN,
+                "AWS": f"{IAM_ARN_BASE}:role/{K8S_WORKER_ROLE_NAME}",
             },
             "Action": "sts:AssumeRole",
         }

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -1,4 +1,7 @@
+import json
+
 from unittest.case import TestCase
+from unittest.mock import call
 
 from control_panel_api import aws
 from control_panel_api.aws import aws_api_client
@@ -58,3 +61,39 @@ class AwsTestCase(TestCase):
     def test_detach_policy_from_user(self):
         aws.detach_policy_from_user('policyarn', 'foo')
         aws_api_client.return_value.detach_user_policy.assert_called()
+
+    def test_create_role(self):
+        role_name = "a_role"
+        assume_role_policy = {"test policy": True}
+
+        aws.create_role(role_name, assume_role_policy)
+
+        aws_api_client.return_value.create_role.assert_called_with(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(assume_role_policy),
+        )
+
+    def test_delete_role(self):
+        aws_api_client.return_value.list_attached_role_policies.return_value = {
+            "AttachedPolicies": [
+                {"PolicyArn": "arn_1"},
+                {"PolicyArn": "arn_2"},
+            ],
+        }
+
+        role_name = "a_role"
+        aws.delete_role(role_name)
+
+        expected_detach_calls = [
+            call(RoleName=role_name, PolicyArn='arn_1'),
+            call(RoleName=role_name, PolicyArn='arn_2'),
+        ]
+
+        # Check policies are detached from role
+        aws_api_client.return_value.detach_role_policy.assert_has_calls(
+            expected_detach_calls)
+
+        # Check role is deleted
+        aws_api_client.return_value.delete_role.assert_called_with(
+            RoleName=role_name,
+        )

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -15,6 +15,7 @@ from control_panel_api.models import AppS3Bucket
 
 
 class UserPermissionsTest(APITestCase):
+
     def setUp(self):
         self.superuser = mommy.make(
             'control_panel_api.User', is_superuser=True)
@@ -93,6 +94,7 @@ class UserPermissionsTest(APITestCase):
 
 
 class AppPermissionsTest(APITestCase):
+
     def setUp(self):
         # Create users
         self.superuser = mommy.make(
@@ -129,7 +131,8 @@ class AppPermissionsTest(APITestCase):
         response = self.client.get(reverse('app-detail', (self.app_1.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_delete_as_superuser_responds_OK(self):
+    @patch('boto3.client')
+    def test_delete_as_superuser_responds_OK(self, mock_client):
         self.client.force_login(self.superuser)
 
         response = self.client.delete(
@@ -143,7 +146,8 @@ class AppPermissionsTest(APITestCase):
             reverse('app-detail', (self.app_1.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    def test_create_as_superuser_responds_OK(self):
+    @patch('boto3.client')
+    def test_create_as_superuser_responds_OK(self, mock_client):
         self.client.force_login(self.superuser)
 
         data = {'name': 'foo'}
@@ -284,6 +288,7 @@ class AppS3BucketPermissionsTest(APITestCase):
 
 
 class S3BucketPermissionsTest(APITestCase):
+
     def setUp(self):
         # Create users
         self.superuser = mommy.make(

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -1,11 +1,11 @@
 from unittest.mock import patch, call
 
+from django.conf import settings
 from django.test.testcases import SimpleTestCase
 
 from control_panel_api import services
 from control_panel_api.tests import (
     APP_IAM_ROLE_ASSUME_POLICY,
-    IAM_ARN_BASE,
     POLICY_DOCUMENT_READONLY,
     POLICY_DOCUMENT_READWRITE,
 )
@@ -48,14 +48,14 @@ class ServicesTestCase(SimpleTestCase):
         services.delete_bucket_policies('test-bucketname')
 
         expected_calls = [
-            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readwrite'),
-            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readonly')
+            call(f'{settings.IAM_ARN_BASE}:policy/test-bucketname-readwrite'),
+            call(f'{settings.IAM_ARN_BASE}:policy/test-bucketname-readonly')
         ]
         mock_detach_policy_from_entities.assert_has_calls(expected_calls)
 
         expected_calls = [
-            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readwrite'),
-            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readonly')
+            call(f'{settings.IAM_ARN_BASE}:policy/test-bucketname-readwrite'),
+            call(f'{settings.IAM_ARN_BASE}:policy/test-bucketname-readonly')
         ]
         mock_delete_policy.assert_has_calls(expected_calls)
 
@@ -102,9 +102,9 @@ class NamingTestCase(SimpleTestCase):
                          services._policy_name('bucketname', readwrite=True))
 
     def test_policy_arn(self):
-        self.assertEqual(f'{IAM_ARN_BASE}:policy/bucketname-readonly',
+        self.assertEqual(f'{settings.IAM_ARN_BASE}:policy/bucketname-readonly',
                          services._policy_arn('bucketname', readwrite=False))
-        self.assertEqual(f'{IAM_ARN_BASE}:policy/bucketname-readwrite',
+        self.assertEqual(f'{settings.IAM_ARN_BASE}:policy/bucketname-readwrite',
                          services._policy_arn('bucketname', readwrite=True))
 
     def test_bucket_arn(self):

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -6,7 +6,6 @@ from control_panel_api import services
 from control_panel_api.tests import (
     APP_IAM_ROLE_ASSUME_POLICY,
     IAM_ARN_BASE,
-    K8S_WORKER_ROLE_NAME,
     POLICY_DOCUMENT_READONLY,
     POLICY_DOCUMENT_READWRITE,
 )

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -5,7 +5,8 @@ from django.test.testcases import SimpleTestCase
 from control_panel_api import services
 from control_panel_api.tests import (
     APP_IAM_ROLE_ASSUME_POLICY,
-    K8S_WORKER_ROLE_ARN,
+    IAM_ARN_BASE,
+    K8S_WORKER_ROLE_NAME,
     POLICY_DOCUMENT_READONLY,
     POLICY_DOCUMENT_READWRITE,
 )
@@ -48,14 +49,14 @@ class ServicesTestCase(SimpleTestCase):
         services.delete_bucket_policies('test-bucketname')
 
         expected_calls = [
-            call('arn:aws:iam::1337:policy/test-bucketname-readwrite'),
-            call('arn:aws:iam::1337:policy/test-bucketname-readonly')
+            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readwrite'),
+            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readonly')
         ]
         mock_detach_policy_from_entities.assert_has_calls(expected_calls)
 
         expected_calls = [
-            call('arn:aws:iam::1337:policy/test-bucketname-readwrite'),
-            call('arn:aws:iam::1337:policy/test-bucketname-readonly')
+            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readwrite'),
+            call(f'{IAM_ARN_BASE}:policy/test-bucketname-readonly')
         ]
         mock_delete_policy.assert_has_calls(expected_calls)
 
@@ -102,9 +103,9 @@ class NamingTestCase(SimpleTestCase):
                          services._policy_name('bucketname', readwrite=True))
 
     def test_policy_arn(self):
-        self.assertEqual('arn:aws:iam::1337:policy/bucketname-readonly',
+        self.assertEqual(f'{IAM_ARN_BASE}:policy/bucketname-readonly',
                          services._policy_arn('bucketname', readwrite=False))
-        self.assertEqual('arn:aws:iam::1337:policy/bucketname-readwrite',
+        self.assertEqual(f'{IAM_ARN_BASE}:policy/bucketname-readwrite',
                          services._policy_arn('bucketname', readwrite=True))
 
     def test_bucket_arn(self):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -45,6 +45,14 @@ class AppViewSet(viewsets.ModelViewSet):
     filter_backends = (AppFilter,)
     permission_classes = (AppPermissions,)
 
+    def perform_create(self, serializer):
+        app = serializer.save()
+        services.app_create(app.slug)
+
+    def perform_destroy(self, instance):
+        instance.delete()
+        services.app_delete(instance.slug)
+
 
 class AppS3BucketViewSet(viewsets.ModelViewSet):
     queryset = AppS3Bucket.objects.all()


### PR DESCRIPTION
### What

- When an app is created we create its IAM role in AWS.
- The app role name would follow this pattern: `$ENV_app_$APP_NAME`
- When an app is deleted we delete the corresponding IAM role
- IAM roles will be assumed by the app's k8s pods this means the role
  assume policy needs to contain the k8s worker role ARN as principal
  (See [`sts:AssumeRole` required by kube2iam](https://github.com/jtblin/kube2iam#iam-roles))
- This ARN is passed in the settings via the `K8S_WORKER_ROLE_ARN`
  environment variable
- I'll **need** to update the cpanel helm chart and the cpanel helm chart config
  to pass this setting in order for this to work

### Related code

This is somewhat similar to what we already to in the users lamba functions:

https://github.com/ministryofjustice/analytics-platform-ops/blob/19046f0c10da4cde551bdc6f0847e332b0d92a7d/infra/terraform/modules/data_access/users/users.py#L18

Differences are:
* Here we create an IAM role for the app, not the user, so the IAM role name includes `_app_`
* We do **not** attach the `sts:AssumeRoleWithSAML` to the assume role policy as this role will not be assumed via SAML.

### Notes regarding the tests/design decisions

The code is mainly split in 3 layers:

`views` <=> `services` <=> `aws`

Each layer's tests only test that the right calls to the adiacent layer
are perfomed correctly.

The tests only test the "public" functions treating them as "black boxes"
and testing that given a certain input certain side effects happen.

As a concious design decision the `aws._detach_role_policies()` is "private".
This is (at the moment!) only used internally by `aws.delete_role()` when
(and if!) there will be the need to call it from the outside we'll make it
"public", until that moment this is an internal implementation detail
(which is of course tested) but not leaked into the client code.

**IMPORTANT**: We should try to find a way of mock every boto3 call while
running the tests as a precautionary measure: as it stands it's possible
to accidentaly write tests that could potentially interact with the real AWS
(which is bad). At the moment I renamed my AWS credentials locally to be sure
in this event boto3 would simply raise a "missing credentials" exception.
This is not ideal and we should discuss a possible solution for this.

### Ticket

https://trello.com/c/AULNJYns/359-add-iam-role-for-control-panel-api-app-to-terraform

Title the PR to complete the sentence: "Merging this PR will ..."


## Other resources

* [`users` lambda functions](https://github.com/ministryofjustice/analytics-platform-ops/blob/19046f0c10da4cde551bdc6f0847e332b0d92a7d/infra/terraform/modules/data_access/users/users.py#L18)
* [`sts:AssumeRole` required by kube2iam (k8s daemon used to attach IAM roles to pods)](https://github.com/jtblin/kube2iam#iam-roles)
* [SO question about IAM role not working with more details on AWS' `sts:AssumeRole`](https://stackoverflow.com/questions/21956794/aws-assumerole-authorization-not-working/33850060#33850060)