### PR TITLE
Remove magic bucket naming and validate on bucket name create

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -34,7 +34,7 @@ class S3Bucket(TimeStampedModel):
     name = models.CharField(unique=True, max_length=63, validators=[
         validators.validate_env_prefix,
         validators.validate_s3_bucket_length,
-        validators.validate_s3_bucket_label,
+        validators.validate_s3_bucket_labels,
     ])
 
     class Meta:

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -1,10 +1,9 @@
 from django.contrib.auth.models import AbstractUser
-from django.core.validators import RegexValidator
 from django.db import models
 from django_extensions.db.fields import AutoSlugField
 from django_extensions.db.models import TimeStampedModel
 
-from control_panel_api import services
+from control_panel_api import services, validators
 
 
 class User(AbstractUser):
@@ -32,24 +31,10 @@ class App(TimeStampedModel):
 
 
 class S3Bucket(TimeStampedModel):
-    # See: AWS' Bucket Restrictions and Limitations
-    # http://docs.aws.amazon.com/en_gb/AmazonS3/latest/dev/BucketRestrictions.html
-    #
-    # A label starts with a letter (preventing labels starting with digits to
-    # avoid IP-like names) and ends with a letter or a digit. It has 0+
-    # letters, digits or hyphens in the middle
-    #
-    # An S3 bucket name starts with a label, it can have more than one label
-    # separated by a dot.
-    LABELS_REGEX = '^([a-z][a-z0-9-]*[a-z0-9])(.[a-z][a-z0-9-]*[a-z0-9])*$'
-    # An S3 bucket name needs to be min 3 chars, max 63 chars long.
-    LENGTH_REGEX = '^.{3,63}$'
-
     name = models.CharField(unique=True, max_length=63, validators=[
-        RegexValidator(regex=LENGTH_REGEX,
-                       message="must be between 3 and 63 characters"),
-        RegexValidator(regex=LABELS_REGEX,
-                       message="is invalid, check AWS S3 bucket names restrictions (for example, can only contains letters, digits, dots and hyphens)"),
+        validators.validate_env_prefix,
+        validators.validate_s3_bucket_length,
+        validators.validate_s3_bucket_label,
     ])
 
     class Meta:

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -9,11 +9,6 @@ READ_WRITE = 'readwrite'
 READ_ONLY = 'readonly'
 
 
-def _bucket_name(name):
-    """Prefix the bucket name with environment e.g. dev-james"""
-    return "{}-{}".format(settings.ENV, name)
-
-
 def _policy_name(bucket_name, readwrite=False):
     """Prefix the policy name with bucket name, postfix with access level e.g. dev-james-readwrite"""
     return "{}-{}".format(bucket_name, READ_WRITE if readwrite else READ_ONLY)
@@ -90,25 +85,21 @@ def get_policy_document(bucket_name, readwrite):
     }
 
 
-def create_bucket(name):
+def create_bucket(bucket_name):
     """Create an s3 bucket and add logging"""
-    bucket_name = _bucket_name(name)
     aws.create_bucket(bucket_name, region=settings.BUCKET_REGION, acl='private')
     aws.put_bucket_logging(bucket_name, target_bucket=settings.LOGS_BUCKET_NAME,
                            target_prefix="{}/".format(bucket_name))
 
 
-def create_bucket_policies(name):
+def create_bucket_policies(bucket_name):
     """Create readwrite and readonly policies for s3 bucket"""
-    bucket_name = _bucket_name(name)
     aws.create_policy(_policy_name(bucket_name, readwrite=True), get_policy_document(bucket_name, True))
     aws.create_policy(_policy_name(bucket_name, readwrite=False), get_policy_document(bucket_name, False))
 
 
-def delete_bucket_policies(name):
+def delete_bucket_policies(bucket_name):
     """Delete policy from attached entities first then delete policy, for both policy types"""
-    bucket_name = _bucket_name(name)
-
     policy_arn_readwrite = _policy_arn(bucket_name, readwrite=True)
     aws.detach_policy_from_entities(policy_arn_readwrite)
     aws.delete_policy(policy_arn_readwrite)

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.test.utils import override_settings
 from model_mommy import mommy
 from rest_framework.reverse import reverse
 from rest_framework.status import (
@@ -282,6 +283,7 @@ class AppS3BucketPermissionsTest(APITestCase):
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
+@override_settings(ENV='test')
 class S3BucketPermissionsTest(APITestCase):
     def setUp(self):
         # Create users

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -19,7 +19,7 @@ class ServicesTestCase(SimpleTestCase):
     @patch('control_panel_api.aws.put_bucket_logging')
     @patch('control_panel_api.aws.create_bucket')
     def test_create_bucket(self, mock_create_bucket, mock_put_bucket_logging):
-        services.create_bucket('bucketname')
+        services.create_bucket('test-bucketname')
 
         mock_create_bucket.assert_called_with('test-bucketname', region='eu-test-2', acl='private')
         mock_put_bucket_logging.assert_called_with('test-bucketname', target_bucket='moj-test-logs',
@@ -27,7 +27,7 @@ class ServicesTestCase(SimpleTestCase):
 
     @patch('control_panel_api.aws.create_policy')
     def test_create_bucket_policies(self, mock_create_policy):
-        services.create_bucket_policies('bucketname')
+        services.create_bucket_policies('test-bucketname')
 
         expected_calls = [
             call('test-bucketname-readwrite', POLICY_DOCUMENT_READWRITE),
@@ -38,7 +38,7 @@ class ServicesTestCase(SimpleTestCase):
     @patch('control_panel_api.aws.delete_policy')
     @patch('control_panel_api.aws.detach_policy_from_entities')
     def test_delete_bucket_policies(self, mock_detach_policy_from_entities, mock_delete_policy):
-        services.delete_bucket_policies('bucketname')
+        services.delete_bucket_policies('test-bucketname')
 
         expected_calls = [
             call('arn:aws:iam::1337:policy/test-bucketname-readwrite'),
@@ -55,23 +55,20 @@ class ServicesTestCase(SimpleTestCase):
     @patch('control_panel_api.services.create_bucket')
     @patch('control_panel_api.services.create_bucket_policies')
     def test_bucket_create(self, mock_create_bucket_policies, mock_create_bucket):
-        services.bucket_create('bucketname')
+        services.bucket_create('test-bucketname')
 
         mock_create_bucket_policies.assert_called()
         mock_create_bucket.assert_called()
 
     @patch('control_panel_api.services.delete_bucket_policies')
     def test_bucket_delete(self, mock_delete_bucket_policies):
-        services.bucket_delete('bucketname')
+        services.bucket_delete('test-bucketname')
 
         mock_delete_bucket_policies.assert_called()
 
 
 @override_settings(ENV='test', IAM_ARN_BASE='arn:aws:iam::1337')
 class NamingTestCase(SimpleTestCase):
-    def test_bucket_name_has_env(self):
-        self.assertEqual('test-bucketname', services._bucket_name('bucketname'))
-
     def test_policy_name_has_readwrite(self):
         self.assertEqual('bucketname-readonly', services._policy_name('bucketname', readwrite=False))
         self.assertEqual('bucketname-readwrite', services._policy_name('bucketname', readwrite=True))

--- a/control_panel_api/tests/test_validators.py
+++ b/control_panel_api/tests/test_validators.py
@@ -1,0 +1,14 @@
+from django.core.exceptions import ValidationError
+from django.test.testcases import SimpleTestCase
+from django.test.utils import override_settings
+
+from control_panel_api import validators
+
+
+@override_settings(ENV='test')
+class ValidatorsTestCase(SimpleTestCase):
+    def test_validate_env_prefix(self):
+        with self.assertRaises(ValidationError):
+            validators.validate_env_prefix('foo-bucketname')
+
+        validators.validate_env_prefix('test-bucketname')

--- a/control_panel_api/validators.py
+++ b/control_panel_api/validators.py
@@ -21,6 +21,6 @@ validate_s3_bucket_length = RegexValidator(regex='^.{3,63}$', message="must be b
 #
 # An S3 bucket name starts with a label, it can have more than one label
 # separated by a dot.
-validate_s3_bucket_label = RegexValidator(regex='^([a-z][a-z0-9-]*[a-z0-9])(.[a-z][a-z0-9-]*[a-z0-9])*$',
-                                          message="is invalid, check AWS S3 bucket names restrictions (for example, "
+validate_s3_bucket_labels = RegexValidator(regex='^([a-z][a-z0-9-]*[a-z0-9])(.[a-z][a-z0-9-]*[a-z0-9])*$',
+                                           message="is invalid, check AWS S3 bucket names restrictions (for example, "
                                             "can only contains letters, digits, dots and hyphens)")

--- a/control_panel_api/validators.py
+++ b/control_panel_api/validators.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
+
+
+def validate_env_prefix(value):
+    """Validate the name has env-prefix, check current set ENV value"""
+    if not value.startswith("{}-".format(settings.ENV)):
+        raise ValidationError("Name must have correct env prefix e.g. {}-bucketname".format(settings.ENV))
+
+
+# An S3 bucket name needs to be min 3 chars, max 63 chars long.
+validate_s3_bucket_length = RegexValidator(regex='^.{3,63}$', message="must be between 3 and 63 characters")
+
+# See: AWS' Bucket Restrictions and Limitations
+# http://docs.aws.amazon.com/en_gb/AmazonS3/latest/dev/BucketRestrictions.html
+#
+# A label starts with a letter (preventing labels starting with digits to
+# avoid IP-like names) and ends with a letter or a digit. It has 0+
+# letters, digits or hyphens in the middle
+#
+# An S3 bucket name starts with a label, it can have more than one label
+# separated by a dot.
+validate_s3_bucket_label = RegexValidator(regex='^([a-z][a-z0-9-]*[a-z0-9])(.[a-z][a-z0-9-]*[a-z0-9])*$',
+                                          message="is invalid, check AWS S3 bucket names restrictions (for example, "
+                                            "can only contains letters, digits, dots and hyphens)")


### PR DESCRIPTION
## What

Remove magic bucket naming and validate on bucket name create

## How to review

1. Run tests

https://trello.com/c/WWG3HLi2/386-bucket-naming-should-be-validated-on-creation-as-such-dev-bucketname-and-server-check-for-correct-env