### PR TITLE
Refactor settings structure and use mock aws client 

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -2,6 +2,7 @@ import json
 
 from django.conf import settings
 
+
 aws_api_client = settings.AWS_API_CLIENT_HANDLER
 
 
@@ -37,8 +38,7 @@ def delete_policy(policy_arn):
 
 
 def detach_policy_from_entities(policy_arn):
-    """Get all entities to which policy is attached
-    See: http://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.list_entities_for_policy"""
+    """Get all entities to which policy is attached first then call separate detach operations"""
     entities = aws_api_client("iam").list_entities_for_policy(PolicyArn=policy_arn)
 
     for role in entities["PolicyRoles"]:

--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -1,10 +1,12 @@
 import json
 
-import boto3
+from django.conf import settings
+
+aws_api_client = settings.AWS_API_CLIENT_HANDLER
 
 
 def create_bucket(name, region, acl='private'):
-    boto3.client('s3').create_bucket(
+    aws_api_client('s3').create_bucket(
         Bucket=name,
         ACL=acl,
         CreateBucketConfiguration={'LocationConstraint': region},
@@ -12,7 +14,7 @@ def create_bucket(name, region, acl='private'):
 
 
 def put_bucket_logging(name, target_bucket, target_prefix):
-    boto3.client('s3').put_bucket_logging(
+    aws_api_client('s3').put_bucket_logging(
         Bucket=name,
         BucketLoggingStatus={
             'LoggingEnabled': {
@@ -24,20 +26,20 @@ def put_bucket_logging(name, target_bucket, target_prefix):
 
 
 def create_policy(name, policy_document):
-    boto3.client("iam").create_policy(
+    aws_api_client("iam").create_policy(
         PolicyName=name,
         PolicyDocument=json.dumps(policy_document)
     )
 
 
 def delete_policy(policy_arn):
-    boto3.client("iam").delete_policy(PolicyArn=policy_arn)
+    aws_api_client("iam").delete_policy(PolicyArn=policy_arn)
 
 
 def detach_policy_from_entities(policy_arn):
     """Get all entities to which policy is attached
-    See: http://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_entities_for_policy"""
-    entities = boto3.client("iam").list_entities_for_policy(PolicyArn=policy_arn)
+    See: http://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.list_entities_for_policy"""
+    entities = aws_api_client("iam").list_entities_for_policy(PolicyArn=policy_arn)
 
     for role in entities["PolicyRoles"]:
         detach_policy_from_role(policy_arn, role["RoleName"])
@@ -50,21 +52,21 @@ def detach_policy_from_entities(policy_arn):
 
 
 def detach_policy_from_role(policy_arn, role_name):
-    boto3.client("iam").detach_role_policy(
+    aws_api_client("iam").detach_role_policy(
         RoleName=role_name,
         PolicyArn=policy_arn,
     )
 
 
 def detach_policy_from_group(policy_arn, group_name):
-    boto3.client("iam").detach_group_policy(
+    aws_api_client("iam").detach_group_policy(
         GroupName=group_name,
         PolicyArn=policy_arn,
     )
 
 
 def detach_policy_from_user(policy_arn, user_name):
-    boto3.client("iam").detach_user_policy(
+    aws_api_client("iam").detach_user_policy(
         UserName=user_name,
         PolicyArn=policy_arn,
     )

--- a/control_panel_api/settings/__init__.py
+++ b/control_panel_api/settings/__init__.py
@@ -1,0 +1,1 @@
+from .base import *

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -1,7 +1,9 @@
 import os
 
+import boto3
 
 # SECURITY WARNING: keep the secret key used in production secret!
+
 SECRET_KEY = os.environ.get(
     'SECRET_KEY',
     '(2gbfi1uc1llww251t00s7$^luuzvivf7l+(snj=sbt#s8h!wu')
@@ -15,10 +17,8 @@ DEBUG = os.environ.get('DEBUG', 'False').lower() == 'true'
 ALLOWED_HOSTS = list(
     filter(None, os.environ.get('ALLOWED_HOSTS', '').split(' ')))
 
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
 
 # Application definition
 
@@ -68,7 +68,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'control_panel_api.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
@@ -82,7 +81,6 @@ DATABASES = {
         'PORT': os.environ.get('DB_PORT', '5432'),
     }
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
@@ -103,7 +101,6 @@ USE_I18N = False
 USE_L10N = False
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
@@ -128,3 +125,5 @@ BUCKET_REGION = os.environ.get('BUCKET_REGION', 'eu-west-1')
 ENV = os.environ.get('ENV', 'dev')
 LOGS_BUCKET_NAME = os.environ.get('LOGS_BUCKET_NAME', 'moj-analytics-s3-logs')
 IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', 'arn:aws:iam::593291632749')
+
+AWS_API_CLIENT_HANDLER = boto3.client

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -2,8 +2,6 @@ import os
 
 import boto3
 
-# SECURITY WARNING: keep the secret key used in production secret!
-
 SECRET_KEY = os.environ.get(
     'SECRET_KEY',
     '(2gbfi1uc1llww251t00s7$^luuzvivf7l+(snj=sbt#s8h!wu')

--- a/control_panel_api/settings/test.py
+++ b/control_panel_api/settings/test.py
@@ -1,0 +1,9 @@
+from .base import *
+from unittest.mock import MagicMock
+
+
+ENV = 'test'
+AWS_API_CLIENT_HANDLER = MagicMock()
+BUCKET_REGION = 'eu-test-2'
+LOGS_BUCKET_NAME = 'moj-test-logs'
+IAM_ARN_BASE = 'arn:aws:iam::1337'

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from control_panel_api import aws
 
 
-@patch('boto3.client')
+@patch('control_panel_api.aws.aws_api_client')
 class AwsTestCase(TestCase):
     def test_create_bucket(self, mock_client):
         aws.create_bucket('bucketname', 'eu-west-1')

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -1,32 +1,31 @@
 from unittest.case import TestCase
-from unittest.mock import patch
 
 from control_panel_api import aws
+from control_panel_api.aws import aws_api_client
 
 
-@patch('control_panel_api.aws.aws_api_client')
 class AwsTestCase(TestCase):
-    def test_create_bucket(self, mock_client):
+    def test_create_bucket(self):
         aws.create_bucket('bucketname', 'eu-west-1')
-        mock_client.return_value.create_bucket.assert_called()
+        aws_api_client.return_value.create_bucket.assert_called()
 
-    def test_put_bucket_logging(self, mock_client):
+    def test_put_bucket_logging(self):
         aws.put_bucket_logging('bucketname', 'target_bucket', 'target_prefix')
-        mock_client.return_value.put_bucket_logging.assert_called()
+        aws_api_client.return_value.put_bucket_logging.assert_called()
 
-    def test_create_policy_json_encoded(self, mock_client):
+    def test_create_policy_json_encoded(self):
         aws.create_policy('bucketname', {'foo': 'bar'})
-        mock_client.return_value.create_policy.assert_called_with(
+        aws_api_client.return_value.create_policy.assert_called_with(
             PolicyName='bucketname',
             PolicyDocument='{"foo": "bar"}'
         )
 
-    def test_delete_policy(self, mock_client):
+    def test_delete_policy(self):
         aws.delete_policy('policyarn')
-        mock_client.return_value.delete_policy.assert_called()
+        aws_api_client.return_value.delete_policy.assert_called()
 
-    def test_detach_policy_from_entities(self, mock_client):
-        mock_client.return_value.list_entities_for_policy.return_value = {
+    def test_detach_policy_from_entities(self):
+        aws_api_client.return_value.list_entities_for_policy.return_value = {
             'PolicyRoles': [{'RoleName': 'foo'}],
             'PolicyGroups': [{'GroupName': 'bar'}],
             'PolicyUsers': [{'UserName': 'baz'}],
@@ -34,28 +33,28 @@ class AwsTestCase(TestCase):
 
         aws.detach_policy_from_entities('policyarn')
 
-        mock_client.return_value.list_entities_for_policy.assert_called()
-        mock_client.return_value.detach_role_policy.assert_called_with(
+        aws_api_client.return_value.list_entities_for_policy.assert_called()
+        aws_api_client.return_value.detach_role_policy.assert_called_with(
             RoleName='foo',
             PolicyArn='policyarn',
         )
-        mock_client.return_value.detach_group_policy.assert_called_with(
+        aws_api_client.return_value.detach_group_policy.assert_called_with(
             GroupName='bar',
             PolicyArn='policyarn',
         )
-        mock_client.return_value.detach_user_policy.assert_called_with(
+        aws_api_client.return_value.detach_user_policy.assert_called_with(
             UserName='baz',
             PolicyArn='policyarn',
         )
 
-    def test_detach_policy_from_role(self, mock_client):
+    def test_detach_policy_from_role(self):
         aws.detach_policy_from_role('policyarn', 'foo')
-        mock_client.return_value.detach_role_policy.assert_called()
+        aws_api_client.return_value.detach_role_policy.assert_called()
 
-    def test_detach_policy_from_group(self, mock_client):
+    def test_detach_policy_from_group(self):
         aws.detach_policy_from_group('policyarn', 'foo')
-        mock_client.return_value.detach_group_policy.assert_called()
+        aws_api_client.return_value.detach_group_policy.assert_called()
 
-    def test_detach_policy_from_user(self, mock_client):
+    def test_detach_policy_from_user(self):
         aws.detach_policy_from_user('policyarn', 'foo')
-        mock_client.return_value.detach_user_policy.assert_called()
+        aws_api_client.return_value.detach_user_policy.assert_called()

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -283,7 +283,6 @@ class AppS3BucketPermissionsTest(APITestCase):
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
-@override_settings(ENV='test')
 class S3BucketPermissionsTest(APITestCase):
     def setUp(self):
         # Create users
@@ -323,8 +322,7 @@ class S3BucketPermissionsTest(APITestCase):
             reverse('s3bucket-detail', (self.s3bucket_1.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    @patch('boto3.client')
-    def test_delete_as_superuser_responds_OK(self, mock_client):
+    def test_delete_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.delete(
@@ -338,8 +336,7 @@ class S3BucketPermissionsTest(APITestCase):
             reverse('s3bucket-detail', (self.s3bucket_1.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    @patch('boto3.client')
-    def test_create_as_superuser_responds_OK(self, mock_client):
+    def test_create_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         data = {'name': 'test-bucket'}

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -1,13 +1,11 @@
 from unittest.mock import patch, call
 
-from django.test.testcases import SimpleTestCase, override_settings
+from django.test.testcases import SimpleTestCase
 
 from control_panel_api import services
 from control_panel_api.tests import POLICY_DOCUMENT_READWRITE, POLICY_DOCUMENT_READONLY
 
 
-@override_settings(ENV='test', BUCKET_REGION='eu-test-2', LOGS_BUCKET_NAME='moj-test-logs',
-                   IAM_ARN_BASE='arn:aws:iam::1337')
 class ServicesTestCase(SimpleTestCase):
     def test_policy_document_readwrite(self):
         document = services.get_policy_document('test-bucketname', readwrite=True)
@@ -67,11 +65,12 @@ class ServicesTestCase(SimpleTestCase):
         mock_delete_bucket_policies.assert_called()
 
 
-@override_settings(ENV='test', IAM_ARN_BASE='arn:aws:iam::1337')
 class NamingTestCase(SimpleTestCase):
     def test_policy_name_has_readwrite(self):
-        self.assertEqual('bucketname-readonly', services._policy_name('bucketname', readwrite=False))
-        self.assertEqual('bucketname-readwrite', services._policy_name('bucketname', readwrite=True))
+        self.assertEqual('bucketname-readonly',
+                         services._policy_name('bucketname', readwrite=False))
+        self.assertEqual('bucketname-readwrite',
+                         services._policy_name('bucketname', readwrite=True))
 
     def test_policy_arn(self):
         self.assertEqual('arn:aws:iam::1337:policy/bucketname-readonly',

--- a/control_panel_api/tests/test_validators.py
+++ b/control_panel_api/tests/test_validators.py
@@ -1,11 +1,9 @@
 from django.core.exceptions import ValidationError
 from django.test.testcases import SimpleTestCase
-from django.test.utils import override_settings
 
 from control_panel_api import validators
 
 
-@override_settings(ENV='test')
 class ValidatorsTestCase(SimpleTestCase):
     def test_validate_env_prefix(self):
         with self.assertRaises(ValidationError):

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-from django.test.utils import override_settings
 from model_mommy import mommy
 from rest_framework.reverse import reverse
 from rest_framework.status import (
@@ -112,7 +111,6 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
-
     def setUp(self):
         super().setUp()
 
@@ -181,7 +179,6 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(data['access_level'], response.data['access_level'])
 
 
-@override_settings(ENV='test')
 class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
     def setUp(self):
         super().setUp()
@@ -205,8 +202,7 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('apps3buckets', response.data)
         self.assertEqual(5, len(response.data))
 
-    @patch('boto3.client')
-    def test_delete(self, mock_client):
+    def test_delete(self):
         response = self.client.delete(
             reverse('s3bucket-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
@@ -220,8 +216,7 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.client.delete(reverse('s3bucket-detail', (self.fixture.id,)))
         mock_bucket_delete.assert_called()
 
-    @patch('boto3.client')
-    def test_create_when_valid_data(self, mock_client):
+    def test_create_when_valid_data(self):
         data = {'name': 'test-bucket-123'}
         response = self.client.post(reverse('s3bucket-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
@@ -241,8 +236,7 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.post(reverse('s3bucket-list'), data)
         self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
 
-    @patch('boto3.client')
-    def test_create_name_valid_env_prefix(self, mock_client):
+    def test_create_name_valid_env_prefix(self):
         data = {'name': 'test-bucketname-foo-bar'}
         response = self.client.post(reverse('s3bucket-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
       DB_NAME: "controlpanel"
       DB_USER: "postgres"
       DEBUG: "True"
-      DJANGO_SETTINGS_MODULE: "control_panel_api.settings"
+      DJANGO_SETTINGS_MODULE: "control_panel_api.settings.test"
     command: ["./run_tests"]
   db:
     image: "postgres:9.6.2"

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,10 @@ import os
 import sys
 
 if __name__ == "__main__":
-    settings = 'control_panel_api.settings.test' if 'test' in sys.argv else 'control_panel_api.settings'
+    if 'test' in sys.argv:
+        settings = 'control_panel_api.settings.test'
+    else:
+        settings = 'control_panel_api.settings'
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings)
     try:

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,9 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "control_panel_api.settings")
+    settings = 'control_panel_api.settings.test' if 'test' in sys.argv else 'control_panel_api.settings'
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings)
     try:
         from django.core.management import execute_from_command_line
     except ImportError:


### PR DESCRIPTION
## What

Allow the switching of the boto3 client to a magicmock during test so no live calls are made (which has happened whilst developing).

- This refactors into a conventional multi settings file layout.
- Regular running of ./manage.py tasks will continue to work as settings package imports the base.py.
- No longer need to patch boto3 in view tests etc to prevent a live call.
- No longer need to override settings in tests to add test values.
- **Now, tests must be run as `./manage.py test --settings=control_panel_api.settings.test`**