### PR TITLE
Grant app access to S3 bucket

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -78,6 +78,13 @@ def detach_policy_from_entities(policy_arn):
         detach_policy_from_user(policy_arn, user["UserName"])
 
 
+def attach_policy_to_role(policy_arn, role_name):
+    aws_api_client("iam").attach_role_policy(
+        RoleName=role_name,
+        PolicyArn=policy_arn,
+    )
+
+
 def detach_policy_from_role(policy_arn, role_name):
     aws_api_client("iam").detach_role_policy(
         RoleName=role_name,

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -5,13 +5,13 @@ from django.template.defaultfilters import slugify
 
 from . import aws
 
-READ_WRITE = 'readwrite'
-READ_ONLY = 'readonly'
+READWRITE = 'readwrite'
+READONLY = 'readonly'
 
 
 def _policy_name(bucket_name, readwrite=False):
     """Prefix the policy name with bucket name, postfix with access level e.g. dev-james-readwrite"""
-    return "{}-{}".format(bucket_name, READ_WRITE if readwrite else READ_ONLY)
+    return "{}-{}".format(bucket_name, READWRITE if readwrite else READONLY)
 
 
 def _app_role_name(app_slug):

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -153,6 +153,13 @@ def delete_bucket_policies(bucket_name):
     aws.delete_policy(policy_arn_readonly)
 
 
+def app_granted_access_to_bucket(app_slug, bucket_name, readwrite):
+    aws.attach_policy_to_role(
+        policy_arn=_policy_arn(bucket_name, readwrite),
+        role_name=_app_role_name(app_slug),
+    )
+
+
 def bucket_create(name):
     """Simple facade function for view to call on s3bucket create"""
     create_bucket(name)

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -153,7 +153,11 @@ def delete_bucket_policies(bucket_name):
     aws.delete_policy(policy_arn_readonly)
 
 
-def app_granted_access_to_bucket(app_slug, bucket_name, readwrite):
+def apps3bucket_create(apps3bucket):
+    app_slug = apps3bucket.app.slug
+    bucket_name = apps3bucket.s3bucket.name
+    readwrite = (apps3bucket.access_level == READWRITE)
+
     aws.attach_policy_to_role(
         policy_arn=_policy_arn(bucket_name, readwrite),
         role_name=_app_role_name(app_slug),

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -154,13 +154,14 @@ def delete_bucket_policies(bucket_name):
 
 
 def apps3bucket_create(apps3bucket):
-    app_slug = apps3bucket.app.slug
-    bucket_name = apps3bucket.s3bucket.name
-    readwrite = (apps3bucket.access_level == READWRITE)
+    policy_arn = _policy_arn(
+        apps3bucket.s3bucket.name,
+        apps3bucket.access_level == READWRITE,
+    )
 
     aws.attach_policy_to_role(
-        policy_arn=_policy_arn(bucket_name, readwrite),
-        role_name=_app_role_name(app_slug),
+        policy_arn=policy_arn,
+        role_name=_app_role_name(apps3bucket.app.slug),
     )
 
 

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -8,6 +8,7 @@ from control_panel_api.aws import aws_api_client
 
 
 class AwsTestCase(TestCase):
+
     def test_create_bucket(self):
         aws.create_bucket('bucketname', 'eu-west-1')
         aws_api_client.return_value.create_bucket.assert_called()
@@ -47,6 +48,13 @@ class AwsTestCase(TestCase):
         )
         aws_api_client.return_value.detach_user_policy.assert_called_with(
             UserName='baz',
+            PolicyArn='policyarn',
+        )
+
+    def test_attach_policy_to_role(self):
+        aws.attach_policy_to_role('policyarn', 'rolename')
+        aws_api_client.return_value.attach_role_policy.assert_called_with(
+            RoleName='rolename',
             PolicyArn='policyarn',
         )
 

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -99,7 +99,7 @@ class ServicesTestCase(TransactionTestCase):
 
     @patch('control_panel_api.aws.attach_policy_to_role')
     def test_apps3bucket_create(self, mock_attach_policy_to_role):
-        app = App.objects.create(slug = 'appslug')
+        app = App.objects.create(slug='appslug')
         s3bucket = S3Bucket.objects.create(name='test-bucketname')
 
         for access_level in ['readonly', 'readwrite']:

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -92,6 +92,26 @@ class ServicesTestCase(SimpleTestCase):
 
         mock_delete_role.assert_called_with(expected_role_name)
 
+    @patch('control_panel_api.aws.attach_policy_to_role')
+    def test_app_granted_access_to_bucket(self, mock_attach_policy_to_role):
+        app_slug = 'appslug'
+        bucket_name = 'test-bucketname'
+
+        for readwrite in ['readonly', 'readwrite']:
+            services.app_granted_access_to_bucket(
+                app_slug=app_slug,
+                bucket_name=bucket_name,
+                readwrite=(readwrite == 'readwrite'),
+            )
+
+            expected_policy_arn = f'{settings.IAM_ARN_BASE}:policy/test-bucketname-{readwrite}'
+            expected_role_name = f'test_app_{app_slug}'
+
+            mock_attach_policy_to_role.assert_called_with(
+                policy_arn=expected_policy_arn,
+                role_name=expected_role_name,
+            )
+
 
 class NamingTestCase(SimpleTestCase):
 

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -187,8 +187,8 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.post(reverse('apps3bucket-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    @patch('control_panel_api.services.app_granted_access_to_bucket')
-    def test_create_grant_access_readonly(self, mock_app_granted_access_to_bucket):
+    @patch('control_panel_api.services.apps3bucket_create')
+    def test_create_grants_access(self, mock_apps3bucket_create):
         data = {
             'app': self.app_1.id,
             's3bucket': self.s3_bucket_3.id,
@@ -196,26 +196,12 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         }
         self.client.post(reverse('apps3bucket-list'), data)
 
-        mock_app_granted_access_to_bucket.assert_called_with(
-            app_slug=self.app_1.slug,
-            bucket_name=self.s3_bucket_3.name,
-            readwrite=False,
+        apps3bucket = AppS3Bucket.objects.get(
+            app=self.app_1,
+            s3bucket=self.s3_bucket_3,
         )
 
-    @patch('control_panel_api.services.app_granted_access_to_bucket')
-    def test_create_grant_access_readwrite(self, mock_app_granted_access_to_bucket):
-        data = {
-            'app': self.app_1.id,
-            's3bucket': self.s3_bucket_3.id,
-            'access_level': AppS3Bucket.READWRITE,
-        }
-        self.client.post(reverse('apps3bucket-list'), data)
-
-        mock_app_granted_access_to_bucket.assert_called_with(
-            app_slug=self.app_1.slug,
-            bucket_name=self.s3_bucket_3.name,
-            readwrite=True,
-        )
+        mock_apps3bucket_create.assert_called_with(apps3bucket)
 
     def test_update(self):
         data = {

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -130,6 +130,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super().setUp()
 
@@ -185,6 +186,36 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         }
         response = self.client.post(reverse('apps3bucket-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    @patch('control_panel_api.services.app_granted_access_to_bucket')
+    def test_create_grant_access_readonly(self, mock_app_granted_access_to_bucket):
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3_bucket_3.id,
+            'access_level': AppS3Bucket.READONLY,
+        }
+        self.client.post(reverse('apps3bucket-list'), data)
+
+        mock_app_granted_access_to_bucket.assert_called_with(
+            app_slug=self.app_1.slug,
+            bucket_name=self.s3_bucket_3.name,
+            readwrite=False,
+        )
+
+    @patch('control_panel_api.services.app_granted_access_to_bucket')
+    def test_create_grant_access_readwrite(self, mock_app_granted_access_to_bucket):
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3_bucket_3.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        self.client.post(reverse('apps3bucket-list'), data)
+
+        mock_app_granted_access_to_bucket.assert_called_with(
+            app_slug=self.app_1.slug,
+            bucket_name=self.s3_bucket_3.name,
+            readwrite=True,
+        )
 
     def test_update(self):
         data = {

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -59,13 +59,9 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
     serializer_class = AppS3BucketSerializer
 
     def perform_create(self, serializer):
-        app_s3bucket = serializer.save()
+        apps3bucket = serializer.save()
 
-        services.app_granted_access_to_bucket(
-            app_slug=app_s3bucket.app.slug,
-            bucket_name=app_s3bucket.s3bucket.name,
-            readwrite=(app_s3bucket.access_level == AppS3Bucket.READWRITE),
-        )
+        services.apps3bucket_create(apps3bucket)
 
 
 class S3BucketViewSet(viewsets.ModelViewSet):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -58,6 +58,15 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
     queryset = AppS3Bucket.objects.all()
     serializer_class = AppS3BucketSerializer
 
+    def perform_create(self, serializer):
+        app_s3bucket = serializer.save()
+
+        services.app_granted_access_to_bucket(
+            app_slug=app_s3bucket.app.slug,
+            bucket_name=app_s3bucket.s3bucket.name,
+            readwrite=(app_s3bucket.access_level == AppS3Bucket.READWRITE),
+        )
+
 
 class S3BucketViewSet(viewsets.ModelViewSet):
     queryset = S3Bucket.objects.all()


### PR DESCRIPTION
## What

When a `AppS3Bucket` record is created for an app and an S3 bucket,
the right IAM policy to access the S3 bucket (depending on this record
`access_level`) is attached to the app IAM role.


### Ticket
Ticket: https://trello.com/c/oR2oS4Af/382-cp-api-when-s3-bucket-access-is-granted-to-an-app-attach-iam-policy


### Related code
This is similar to what already done by one of the lambda functions:

https://github.com/ministryofjustice/analytics-platform-ops/blob/master/infra/terraform/modules/data_access/memberships/memberships.py#L38
