### PR TITLE
Delete role and policy on apps3bucket deletion

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -23,7 +23,7 @@ class User(AbstractUser):
 
 class App(TimeStampedModel):
     name = models.CharField(max_length=100, blank=False)
-    slug = AutoSlugField(populate_from='name', slugify_function=services.app_slug)
+    slug = AutoSlugField(populate_from='name', slugify_function=services.app_slugify)
     repo_url = models.URLField(max_length=512, blank=True, default='')
 
     class Meta:

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -30,7 +30,7 @@ def bucket_arn(bucket_name):
     return "arn:aws:s3:::{}".format(bucket_name)
 
 
-def app_slug(name):
+def app_slugify(name):
     """Create a valid slug for s3 using standard django slugify but we add some custom"""
     return re.sub(r'_+', '-', slugify(name))
 

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -147,11 +147,13 @@ def delete_bucket_policies(bucket_name):
 
 
 def detach_bucket_access_from_app_role(app_slug, bucket_name, access_level):
+    policy_arn = _policy_arn(
+        bucket_name=bucket_name,
+        readwrite=access_level == READWRITE
+    )
+
     aws.detach_policy_from_role(
-        policy_arn=_policy_arn(
-            bucket_name=bucket_name,
-            readwrite=access_level == READWRITE
-        ),
+        policy_arn=policy_arn,
         role_name=_app_role_name(app_slug)
     )
 

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -38,6 +38,8 @@ def app_create(app_slug):
 
 
 def _create_app_role(role_name):
+    """See: `sts:AssumeRole` required by kube2iam
+    https://github.com/jtblin/kube2iam#iam-roles"""
     assume_role_policy = {
         "Version": "2012-10-17",
         "Statement": [

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -123,7 +123,7 @@ class ServicesTestCase(TestCase):
             )
 
     @patch('control_panel_api.aws.detach_policy_from_role')
-    def test_bucket_delete(self, mock_detach_policy_from_role):
+    def test_bucket_delete_readwrite(self, mock_detach_policy_from_role):
         apps3bucket = mommy.make(
             'control_panel_api.AppS3Bucket',
             make_m2m=True,
@@ -135,6 +135,20 @@ class ServicesTestCase(TestCase):
 
         mock_detach_policy_from_role.assert_called_with(
             policy_arn=f'{settings.IAM_ARN_BASE}:policy/test-bucket-1-readwrite',
+            role_name='test_app_app-1')
+
+    @patch('control_panel_api.aws.detach_policy_from_role')
+    def test_bucket_delete_readonly(self, mock_detach_policy_from_role):
+        apps3bucket = mommy.make(
+            'control_panel_api.AppS3Bucket',
+            app=self.app_1,
+            s3bucket=self.s3_bucket_1,
+            access_level=services.READ_ONLY)
+
+        services.apps3bucket_delete(apps3bucket)
+
+        mock_detach_policy_from_role.assert_called_with(
+            policy_arn=f'{settings.IAM_ARN_BASE}:policy/test-bucket-1-readonly',
             role_name='test_app_app-1')
 
 

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -179,7 +179,7 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
     @patch('control_panel_api.services.apps3bucket_delete')
-    def test_delete_calls_api(self, mock_apps3bucket_delete):
+    def test_delete_calls_service(self, mock_apps3bucket_delete):
         response = self.client.delete(
             reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -178,6 +178,15 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
+    @patch('control_panel_api.services.apps3bucket_delete')
+    def test_delete_calls_api(self, mock_apps3bucket_delete):
+        response = self.client.delete(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+        called_args, _ = mock_apps3bucket_delete.call_args
+        self.assertIsInstance(called_args[0], AppS3Bucket)
+
     def test_create(self):
         data = {
             'app': self.app_1.id,

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -186,6 +186,7 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 
         called_args, _ = mock_apps3bucket_delete.call_args
         self.assertIsInstance(called_args[0], AppS3Bucket)
+        self.assertEqual(called_args[0].app.slug, self.apps3bucket_1.app.slug)
 
     def test_create(self):
         data = {

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -60,8 +60,11 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         apps3bucket = serializer.save()
-
         services.apps3bucket_create(apps3bucket)
+
+    def perform_destroy(self, instance):
+        instance.delete()
+        services.apps3bucket_delete(instance)
 
 
 class S3BucketViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## What

When you delete the apps3bucket relation it should also detach policy and role.

(Note: apologies on line length reformatting - I updated to 80 char after team decided on that length)

## How to review

1. Run tests.
2. Call it live and check.
