### PR TITLE
Update attached app policies when `AppS3Bucket` access level changes

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -112,3 +112,9 @@ class AppS3Bucket(TimeStampedModel):
     class Meta:
         # one record per app/s3bucket
         unique_together = ('app', 's3bucket')
+
+    def has_readwrite_access(self):
+        return self.access_level == self.READWRITE
+
+    def update_aws_permissions(self):
+        services.apps3bucket_update(self)

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -36,6 +36,18 @@ class AppS3BucketSerializer(serializers.ModelSerializer):
         model = AppS3Bucket
         fields = ('id', 'url', 'app', 's3bucket', 'access_level')
 
+    def update(self, instance, validated_data):
+        if instance.app != validated_data['app']:
+            raise serializers.ValidationError(
+                "app can't change, create a new record"
+            )
+        if instance.s3bucket != validated_data['s3bucket']:
+            raise serializers.ValidationError(
+                "s3bucket can't change, create a new record"
+            )
+
+        return super().update(instance, validated_data)
+
 
 class S3BucketSerializer(serializers.ModelSerializer):
 

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -173,7 +173,7 @@ def bucket_delete(name):
 def apps3bucket_create(apps3bucket):
     policy_arn = _policy_arn(
         apps3bucket.s3bucket.name,
-        apps3bucket.access_level == READWRITE,
+        apps3bucket.has_readwrite_access(),
     )
 
     aws.attach_policy_to_role(
@@ -181,6 +181,27 @@ def apps3bucket_create(apps3bucket):
         role_name=_app_role_name(apps3bucket.app.slug),
     )
 
+
+def apps3bucket_update(apps3bucket):
+    app_role_name = _app_role_name(apps3bucket.app.slug)
+
+    new_policy_arn = _policy_arn(
+        apps3bucket.s3bucket.name,
+        apps3bucket.has_readwrite_access(),
+    )
+    old_policy_arn = _policy_arn(
+        apps3bucket.s3bucket.name,
+        not apps3bucket.has_readwrite_access(),
+    )
+
+    aws.attach_policy_to_role(
+        policy_arn=new_policy_arn,
+        role_name=app_role_name,
+    )
+    aws.detach_policy_from_role(
+        policy_arn=old_policy_arn,
+        role_name=app_role_name,
+    )
 
 def apps3bucket_delete(apps3bucket):
     """:type apps3bucket: control_panel_api.models.AppS3Bucket"""

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.db.utils import IntegrityError
 from django.test import TestCase, TransactionTestCase
 
@@ -139,3 +141,13 @@ class AppS3BucketTestCase(TestCase):
                 s3bucket=self.s3_bucket_1,
                 access_level=AppS3Bucket.READWRITE,
             )
+
+    @patch('control_panel_api.services.apps3bucket_update')
+    def test_update_aws_permissions(self, mock_apps3bucket_update):
+        apps3bucket = AppS3Bucket.objects.create(
+            app=self.app_1,
+            s3bucket=self.s3_bucket_1,
+            access_level=AppS3Bucket.READONLY,
+        )
+        apps3bucket.update_aws_permissions()
+        mock_apps3bucket_update.assert_called_with(apps3bucket)

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -213,7 +213,8 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 
         mock_apps3bucket_create.assert_called_with(apps3bucket)
 
-    def test_update(self):
+    @patch('control_panel_api.models.AppS3Bucket.update_aws_permissions')
+    def test_update(self, mock_update_aws_permissions):
         data = {
             'app': self.app_1.id,
             's3bucket': self.s3_bucket_1.id,
@@ -223,6 +224,17 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['access_level'], response.data['access_level'])
+
+    @patch('control_panel_api.models.AppS3Bucket.update_aws_permissions')
+    def test_update_updates_aws(self, mock_update_aws_permissions):
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3_bucket_1.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        self.client.put(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
+        mock_update_aws_permissions.assert_called()
 
     def test_update_when_app_changed(self):
         data = {

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -224,6 +224,26 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['access_level'], response.data['access_level'])
 
+    def test_update_when_app_changed(self):
+        data = {
+            'app': self.app_2.id,
+            's3bucket': self.s3_bucket_1.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        response = self.client.put(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
+        self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
+
+    def test_update_when_s3bucket_changed(self):
+        data = {
+            'app': self.app_1.id,
+            's3bucket': self.s3_bucket_2.id,
+            'access_level': AppS3Bucket.READWRITE,
+        }
+        response = self.client.put(
+            reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
+        self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
+
 
 class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Group
 from rest_framework import viewsets
+from rest_framework.exceptions import ValidationError
 
 from control_panel_api import services
 from control_panel_api.filters import (

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -63,6 +63,10 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
         apps3bucket = serializer.save()
         services.apps3bucket_create(apps3bucket)
 
+    def perform_update(self, serializer):
+        apps3bucket = serializer.save()
+        apps3bucket.update_aws_permissions()
+
     def perform_destroy(self, instance):
         instance.delete()
         services.apps3bucket_delete(instance)


### PR DESCRIPTION
## What

When the AppS3Bucket record is updated the policies attached to the
policies changes accordingly:
* If new `access_level` is `readwrite`, old one would be `readonly` (`readonly` => `readwrite`):
  * so the readonly policy would be detached from the app role and the readwrite policy would be attached 
* Conversely, when new `access_level` is `readonly` (`readwrite` => `readonly`):
  * the readonly policy would be attached and the readwrite policy detached 

**NOTE**: When talking about policy here I mean IAM policy to access the S3 bucket in the `AppS3Bucket` record.

## Ticket
https://trello.com/c/D3y3Mzre/388-cp-api-when-app-access-level-to-s3-bucket-changes-iam-policies-attached-to-its-role-should-change-too