### PR TITLE
Feature refactor model service

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -159,8 +159,26 @@ class AppS3Bucket(AccessToS3Bucket):
         # one record per app/s3bucket
         unique_together = ('app', 's3bucket')
 
+    def aws_create(self):
+        services.attach_bucket_access_to_app_role(
+            self.s3bucket.name,
+            self.has_readwrite_access(),
+            self.app.role_name
+        )
+
+    def aws_delete(self):
+        services.detach_bucket_access_from_app_role(
+            self.s3bucket.name,
+            self.has_readwrite_access(),
+            self.app.role_name
+        )
+
     def update_aws_permissions(self):
-        services.apps3bucket_update(self)
+        services.apps3bucket_update(
+            self.s3bucket.name,
+            self.has_readwrite_access(),
+            self.app.role_name
+        )
 
 
 class UserS3Bucket(AccessToS3Bucket):

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -50,9 +50,6 @@ class App(TimeStampedModel):
 
 
 class S3Bucket(TimeStampedModel):
-    READWRITE = 'readwrite'
-    READONLY = 'readonly'
-
     name = models.CharField(unique=True, max_length=63, validators=[
         validators.validate_env_prefix,
         validators.validate_s3_bucket_length,

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -1,5 +1,9 @@
+import re
+
+from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.template.defaultfilters import slugify
 from django_extensions.db.fields import AutoSlugField
 from django_extensions.db.models import TimeStampedModel
 
@@ -22,12 +26,27 @@ class User(AbstractUser):
 
 
 class App(TimeStampedModel):
+    def _slugify(name):
+        """Create a slug using standard django slugify but we override with
+        extra replacement so it's valid for s3"""
+        return re.sub(r'_+', '-', slugify(name))
+
     name = models.CharField(max_length=100, blank=False)
-    slug = AutoSlugField(populate_from='name', slugify_function=services.app_slugify)
+    slug = AutoSlugField(populate_from='name', slugify_function=_slugify)
     repo_url = models.URLField(max_length=512, blank=True, default='')
 
     class Meta:
         ordering = ('name',)
+
+    @property
+    def role_name(self):
+        return f"{settings.ENV}_app_{self.slug}"
+
+    def create_app_role(self):
+        services.create_app_role(self.role_name)
+
+    def delete_app_role(self):
+        services.delete_app_role(self.role_name)
 
 
 class S3Bucket(TimeStampedModel):

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -39,14 +39,14 @@ class App(TimeStampedModel):
         ordering = ('name',)
 
     @property
-    def role_name(self):
+    def aws_role_name(self):
         return f"{settings.ENV}_app_{self.slug}"
 
-    def create_app_role(self):
-        services.create_app_role(self.role_name)
+    def aws_create_role(self):
+        services.create_app_role(self.aws_role_name)
 
-    def delete_app_role(self):
-        services.delete_app_role(self.role_name)
+    def aws_delete_role(self):
+        services.delete_app_role(self.aws_role_name)
 
 
 class S3Bucket(TimeStampedModel):
@@ -163,21 +163,21 @@ class AppS3Bucket(AccessToS3Bucket):
         services.attach_bucket_access_to_app_role(
             self.s3bucket.name,
             self.has_readwrite_access(),
-            self.app.role_name
+            self.app.aws_role_name,
         )
 
     def aws_delete(self):
         services.detach_bucket_access_from_app_role(
             self.s3bucket.name,
             self.has_readwrite_access(),
-            self.app.role_name
+            self.app.aws_role_name
         )
 
-    def update_aws_permissions(self):
+    def aws_update(self):
         services.apps3bucket_update(
             self.s3bucket.name,
             self.has_readwrite_access(),
-            self.app.role_name
+            self.app.aws_role_name
         )
 
 

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -1,7 +1,4 @@
-import re
-
 from django.conf import settings
-from django.template.defaultfilters import slugify
 
 from . import aws
 
@@ -28,16 +25,7 @@ def bucket_arn(bucket_name):
     return "arn:aws:s3:::{}".format(bucket_name)
 
 
-def app_slugify(name):
-    """Create a valid slug for s3 using standard django slugify but we add some custom"""
-    return re.sub(r'_+', '-', slugify(name))
-
-
-def app_create(app_slug):
-    _create_app_role(_app_role_name(app_slug))
-
-
-def _create_app_role(role_name):
+def create_app_role(role_name):
     """See: `sts:AssumeRole` required by kube2iam
     https://github.com/jtblin/kube2iam#iam-roles"""
     assume_role_policy = {
@@ -63,8 +51,8 @@ def _create_app_role(role_name):
     aws.create_role(role_name, assume_role_policy)
 
 
-def app_delete(app_slug):
-    aws.delete_role(_app_role_name(app_slug))
+def delete_app_role(role_name):
+    aws.delete_role(role_name)
 
 
 def get_policy_document(bucket_name, readwrite):

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -134,10 +134,10 @@ def delete_bucket_policies(bucket_name):
 
 
 def detach_bucket_access_from_app_role(
-        app_slug, bucket_name, access_level, app_role_name):
+        bucket_name, readwrite, app_role_name):
     policy_arn = _policy_arn(
         bucket_name=bucket_name,
-        readwrite=access_level == READWRITE
+        readwrite=readwrite
     )
 
     aws.detach_policy_from_role(
@@ -146,10 +146,10 @@ def detach_bucket_access_from_app_role(
     )
 
 
-def apps3bucket_create(apps3bucket, app_role_name):
+def attach_bucket_access_to_app_role(bucket_name, readwrite, app_role_name):
     policy_arn = _policy_arn(
-        apps3bucket.s3bucket.name,
-        apps3bucket.has_readwrite_access(),
+        bucket_name,
+        readwrite,
     )
 
     aws.attach_policy_to_role(
@@ -158,16 +158,14 @@ def apps3bucket_create(apps3bucket, app_role_name):
     )
 
 
-def apps3bucket_update(apps3bucket):
-    app_role_name = _app_role_name(apps3bucket.app.slug)
-
+def apps3bucket_update(bucket_name, readwrite, app_role_name):
     new_policy_arn = _policy_arn(
-        apps3bucket.s3bucket.name,
-        apps3bucket.has_readwrite_access(),
+        bucket_name,
+        readwrite,
     )
     old_policy_arn = _policy_arn(
-        apps3bucket.s3bucket.name,
-        not apps3bucket.has_readwrite_access(),
+        bucket_name,
+        not readwrite,
     )
 
     aws.attach_policy_to_role(
@@ -177,13 +175,4 @@ def apps3bucket_update(apps3bucket):
     aws.detach_policy_from_role(
         policy_arn=old_policy_arn,
         role_name=app_role_name,
-    )
-
-def apps3bucket_delete(apps3bucket):
-    """:type apps3bucket: control_panel_api.models.AppS3Bucket"""
-    detach_bucket_access_from_app_role(
-        apps3bucket.app.slug,
-        apps3bucket.s3bucket.name,
-        apps3bucket.access_level,
-        apps3bucket.app.role_name
     )

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -181,6 +181,7 @@ class AppS3BucketTestCase(TestCase):
                 access_level=AppS3Bucket.READWRITE,
             )
 
+
     @patch('control_panel_api.services.apps3bucket_update')
     def test_update_aws_permissions(self, mock_apps3bucket_update):
         apps3bucket = AppS3Bucket.objects.create(
@@ -189,8 +190,27 @@ class AppS3BucketTestCase(TestCase):
             access_level=AppS3Bucket.READONLY,
         )
         apps3bucket.update_aws_permissions()
-        mock_apps3bucket_update.assert_called_with(apps3bucket)
 
+        mock_apps3bucket_update.assert_called_with(
+            self.s3_bucket_1.name,
+            apps3bucket.has_readwrite_access(),
+            self.app_1.role_name
+        )
+
+    @patch('control_panel_api.services.detach_bucket_access_from_app_role')
+    def test_aws_delete(self, mock_detach_bucket_access_from_app_role):
+        apps3bucket = self.app_1.apps3buckets.create(
+            s3bucket=self.s3_bucket_1,
+            access_level=AppS3Bucket.READONLY,
+        )
+
+        apps3bucket.aws_delete()
+
+        mock_detach_bucket_access_from_app_role.assert_called_with(
+            self.s3_bucket_1.name,
+            apps3bucket.has_readwrite_access(),
+            self.app_1.role_name
+        )
 
 
 class UserS3BucketTestCase(TestCase):

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -108,10 +108,10 @@ class AppTestCase(TestCase):
         self.assertEqual('foo-2', app2.slug)
 
     @patch('control_panel_api.aws.create_role')
-    def test_create_app_role_calls_service(self, mock_create_role):
+    def test_aws_create_role_calls_service(self, mock_create_role):
         app_name = 'appname'
         app = App.objects.create(name=app_name)
-        app.create_app_role()
+        app.aws_create_role()
 
         expected_role_name = f"test_app_{app_name}"
 
@@ -121,10 +121,10 @@ class AppTestCase(TestCase):
         )
 
     @patch('control_panel_api.aws.delete_role')
-    def test_delete_app_role_calls_service(self, mock_delete_role):
+    def test_aws_delete_role_calls_service(self, mock_delete_role):
         app_name = 'appname'
         app = App.objects.create(name=app_name)
-        app.delete_app_role()
+        app.aws_delete_role()
 
         expected_role_name = f"test_app_{app_name}"
 
@@ -189,12 +189,13 @@ class AppS3BucketTestCase(TestCase):
             s3bucket=self.s3_bucket_1,
             access_level=AppS3Bucket.READONLY,
         )
-        apps3bucket.update_aws_permissions()
+
+        apps3bucket.aws_update()
 
         mock_apps3bucket_update.assert_called_with(
             self.s3_bucket_1.name,
             apps3bucket.has_readwrite_access(),
-            self.app_1.role_name
+            self.app_1.aws_role_name
         )
 
     @patch('control_panel_api.services.detach_bucket_access_from_app_role')
@@ -209,7 +210,7 @@ class AppS3BucketTestCase(TestCase):
         mock_detach_bucket_access_from_app_role.assert_called_with(
             self.s3_bucket_1.name,
             apps3bucket.has_readwrite_access(),
-            self.app_1.role_name
+            self.app_1.aws_role_name
         )
 
 

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -132,20 +132,34 @@ class AppTestCase(TestCase):
 
 
 class S3BucketTestCase(TestCase):
-
     @classmethod
     def setUpTestData(cls):
         # Create an S3 bucket
         cls.s3_bucket_1 = S3Bucket.objects.create(name="test-bucket-1")
 
     def test_arn(self):
-        expected_arn = "arn:aws:s3:::{}".format(self.s3_bucket_1.name)
+        self.assertEqual(
+            'arn:aws:s3:::test-bucket-1',
+            self.s3_bucket_1.arn
+        )
 
-        self.assertEqual(self.s3_bucket_1.arn, expected_arn)
+    @patch('control_panel_api.services.create_bucket')
+    @patch('control_panel_api.services.create_bucket_policies')
+    def test_bucket_create(self, mock_create_bucket_policies,
+                           mock_create_bucket):
+        self.s3_bucket_1.aws_create()
+
+        mock_create_bucket_policies.assert_called()
+        mock_create_bucket.assert_called()
+
+    @patch('control_panel_api.services.delete_bucket_policies')
+    def test_bucket_delete(self, mock_delete_bucket_policies):
+        self.s3_bucket_1.aws_delete()
+
+        mock_delete_bucket_policies.assert_called()
 
 
 class AppS3BucketTestCase(TestCase):
-
     @classmethod
     def setUpTestData(cls):
         # Apps

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -86,25 +86,6 @@ class ServicesTestCase(TestCase):
 
         mock_delete_bucket_policies.assert_called()
 
-    @patch('control_panel_api.aws.create_role')
-    def test_app_create(self, mock_create_role):
-        app_slug = 'appname'
-        services.app_create(app_slug)
-
-        expected_role_name = "test_app_{}".format(app_slug)
-
-        mock_create_role.assert_called_with(
-            expected_role_name, APP_IAM_ROLE_ASSUME_POLICY)
-
-    @patch('control_panel_api.aws.delete_role')
-    def test_app_delete(self, mock_delete_role):
-        app_slug = 'appname'
-        services.app_delete(app_slug)
-
-        expected_role_name = "test_app_{}".format(app_slug)
-
-        mock_delete_role.assert_called_with(expected_role_name)
-
     @patch('control_panel_api.aws.attach_policy_to_role')
     def test_apps3bucket_create(self, mock_attach_policy_to_role):
         app = App.objects.create(slug='appslug')

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -85,7 +85,7 @@ class ServicesTestCase(TestCase):
                 defaults={'access_level': access_level},
             )
 
-            services.apps3bucket_create(apps3bucket)
+            services.apps3bucket_create(apps3bucket, apps3bucket.app.role_name)
 
             expected_policy_arn = f'{settings.IAM_ARN_BASE}:policy/test-bucketname-{access_level}'
             expected_role_name = f'test_app_{app.slug}'
@@ -143,15 +143,20 @@ class ServicesTestCase(TestCase):
         mock_detach_bucket_access_from_app_role.assert_called_with(
             app_name,
             s3_bucket_name,
-            services.READWRITE)
+            services.READWRITE,
+            apps3bucket.app.role_name
+        )
 
     @patch('control_panel_api.aws.detach_policy_from_role')
     def test_detach_bucket_access_from_app_role_readwrite(
             self,
             mock_detach_policy_from_role):
-        services.detach_bucket_access_from_app_role(self.app_1.slug,
-                                                    self.s3_bucket_1.name,
-                                                    services.READWRITE)
+        services.detach_bucket_access_from_app_role(
+            self.app_1.slug,
+            self.s3_bucket_1.name,
+            services.READWRITE,
+            self.app_1.role_name
+        )
 
         mock_detach_policy_from_role.assert_called_with(
             policy_arn=f'{settings.IAM_ARN_BASE}:policy/test-bucket-1-readwrite',
@@ -161,9 +166,12 @@ class ServicesTestCase(TestCase):
     def test_detach_bucket_access_from_app_role_readonly(
             self,
             mock_detach_policy_from_role):
-        services.detach_bucket_access_from_app_role(self.app_1.slug,
-                                                    self.s3_bucket_1.name,
-                                                    services.READONLY)
+        services.detach_bucket_access_from_app_role(
+            self.app_1.slug,
+            self.s3_bucket_1.name,
+            services.READONLY,
+            self.app_1.role_name
+        )
 
         mock_detach_policy_from_role.assert_called_with(
             policy_arn=f'{settings.IAM_ARN_BASE}:policy/test-bucket-1-readonly',

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -88,7 +88,7 @@ class ServicesTestCase(TestCase):
             services.attach_bucket_access_to_app_role(
                 apps3bucket.s3bucket.name,
                 apps3bucket.has_readwrite_access(),
-                apps3bucket.app.role_name
+                apps3bucket.app.aws_role_name
             )
 
             expected_policy_arn = f'{settings.IAM_ARN_BASE}:policy/test-bucketname-{access_level}'
@@ -119,7 +119,7 @@ class ServicesTestCase(TestCase):
             services.apps3bucket_update(
                 s3bucket.name,
                 apps3bucket.has_readwrite_access(),
-                app.role_name
+                app.aws_role_name
             )
 
             old_access_level = 'readwrite' if access_level == 'readonly' else 'readonly'
@@ -143,7 +143,7 @@ class ServicesTestCase(TestCase):
         services.detach_bucket_access_from_app_role(
             self.s3_bucket_1.name,
             services.READWRITE,
-            self.app_1.role_name
+            self.app_1.aws_role_name,
         )
 
         mock_detach_policy_from_role.assert_called_with(
@@ -159,7 +159,7 @@ class ServicesTestCase(TestCase):
         services.detach_bucket_access_from_app_role(
             self.s3_bucket_1.name,
             False,
-            self.app_1.role_name,
+            self.app_1.aws_role_name,
         )
 
         mock_detach_policy_from_role.assert_called_with(

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -101,11 +101,11 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    @patch('control_panel_api.services.app_delete')
-    def test_delete_deletes_app_iam_role(self, app_delete):
+    @patch('control_panel_api.models.App.delete_app_role')
+    def test_delete_deletes_app_iam_role(self, delete_app_role):
         self.client.delete(reverse('app-detail', (self.fixture.id,)))
 
-        app_delete.assert_called_with(self.fixture.slug)
+        delete_app_role.assert_called()
 
     @patch('boto3.client')
     def test_create(self, mock_client):
@@ -113,13 +113,12 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    @patch('control_panel_api.services.app_create')
-    def test_create_creates_app_iam_role(self, app_create):
+    @patch('control_panel_api.models.App.create_app_role')
+    def test_create_creates_app_iam_role(self, create_app_role):
         data = {'name': 'foo'}
-        response = self.client.post(reverse('app-list'), data)
+        self.client.post(reverse('app-list'), data)
 
-        app = App.objects.get(id=response.data["id"])
-        app_create.assert_called_with(app.slug)
+        create_app_role.assert_called()
 
     def test_update(self):
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -101,23 +101,23 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    @patch('control_panel_api.models.App.delete_app_role')
-    def test_delete_deletes_app_iam_role(self, delete_app_role):
+    @patch('control_panel_api.models.App.aws_delete_role')
+    def test_delete_deletes_app_iam_role(self, mock_aws_delete_role):
         self.client.delete(reverse('app-detail', (self.fixture.id,)))
 
-        delete_app_role.assert_called()
+        mock_aws_delete_role.assert_called()
 
     def test_create(self):
         data = {'name': 'foo'}
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    @patch('control_panel_api.models.App.create_app_role')
-    def test_create_creates_app_iam_role(self, create_app_role):
+    @patch('control_panel_api.models.App.aws_create_role')
+    def test_create_creates_app_iam_role(self, mock_aws_create_role):
         data = {'name': 'foo'}
         self.client.post(reverse('app-list'), data)
 
-        create_app_role.assert_called()
+        mock_aws_create_role.assert_called()
 
     def test_update(self):
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}
@@ -204,8 +204,8 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 
         mock_aws_create.assert_called()
 
-    @patch('control_panel_api.models.AppS3Bucket.update_aws_permissions')
-    def test_update(self, mock_update_aws_permissions):
+    @patch('control_panel_api.models.AppS3Bucket.aws_update')
+    def test_update(self, mock_aws_update):
         data = {
             'app': self.app_1.id,
             's3bucket': self.s3_bucket_1.id,
@@ -216,8 +216,8 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['access_level'], response.data['access_level'])
 
-    @patch('control_panel_api.models.AppS3Bucket.update_aws_permissions')
-    def test_update_updates_aws(self, mock_update_aws_permissions):
+    @patch('control_panel_api.models.AppS3Bucket.aws_update')
+    def test_update_updates_aws(self, mock_aws_update):
         data = {
             'app': self.app_1.id,
             's3bucket': self.s3_bucket_1.id,
@@ -225,7 +225,7 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         }
         self.client.put(
             reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
-        mock_update_aws_permissions.assert_called()
+        mock_aws_update.assert_called()
 
     def test_update_when_app_changed(self):
         data = {

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -107,8 +107,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
         delete_app_role.assert_called()
 
-    @patch('boto3.client')
-    def test_create(self, mock_client):
+    def test_create(self):
         data = {'name': 'foo'}
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
@@ -289,10 +288,10 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('s3bucket-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    @patch('control_panel_api.services.bucket_delete')
-    def test_delete_calls_apis(self, mock_bucket_delete):
+    @patch('control_panel_api.models.S3Bucket.aws_delete')
+    def test_delete_calls_aws_delete(self, mock_aws_delete):
         self.client.delete(reverse('s3bucket-detail', (self.fixture.id,)))
-        mock_bucket_delete.assert_called_with('test-bucket-1')
+        mock_aws_delete.assert_called()
 
     def test_create_when_valid_data(self):
         data = {'name': 'test-bucket-123'}
@@ -329,11 +328,11 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.post(reverse('s3bucket-list'), data)
         self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
 
-    @patch('control_panel_api.services.bucket_create')
-    def test_create_calls_apis(self, mock_bucket_create):
+    @patch('control_panel_api.models.S3Bucket.aws_create')
+    def test_create_calls_aws_create(self, mock_aws_create):
         data = {'name': 'test-bucket-123'}
         self.client.post(reverse('s3bucket-list'), data)
-        mock_bucket_create.assert_called_with('test-bucket-123')
+        mock_aws_create.assert_called()
 
     def test_update_when_valid_data(self):
         data = {'name': 'test-bucket-updated'}

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -209,7 +209,10 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             s3bucket=self.s3_bucket_3,
         )
 
-        mock_apps3bucket_create.assert_called_with(apps3bucket)
+        mock_apps3bucket_create.assert_called_with(
+            apps3bucket,
+            apps3bucket.app.role_name
+        )
 
     @patch('control_panel_api.models.AppS3Bucket.update_aws_permissions')
     def test_update(self, mock_update_aws_permissions):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -61,7 +61,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         apps3bucket = serializer.save()
-        services.apps3bucket_create(apps3bucket, apps3bucket.app.role_name)
+        apps3bucket.aws_create()
 
     def perform_update(self, serializer):
         apps3bucket = serializer.save()
@@ -69,7 +69,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
 
     def perform_destroy(self, instance):
         instance.delete()
-        services.apps3bucket_delete(instance)
+        instance.aws_delete()
 
 
 class S3BucketViewSet(viewsets.ModelViewSet):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -48,11 +48,11 @@ class AppViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         app = serializer.save()
-        services.app_create(app.slug)
+        app.create_app_role()
 
     def perform_destroy(self, instance):
         instance.delete()
-        services.app_delete(instance.slug)
+        instance.delete_app_role()
 
 
 class AppS3BucketViewSet(viewsets.ModelViewSet):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -80,8 +80,8 @@ class S3BucketViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         instance = serializer.save()
-        services.bucket_create(instance.name)
+        instance.aws_create()
 
     def perform_destroy(self, instance):
         instance.delete()
-        services.bucket_delete(instance.name)
+        instance.aws_delete()

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -61,7 +61,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         apps3bucket = serializer.save()
-        services.apps3bucket_create(apps3bucket)
+        services.apps3bucket_create(apps3bucket, apps3bucket.app.role_name)
 
     def perform_update(self, serializer):
         apps3bucket = serializer.save()

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -48,11 +48,11 @@ class AppViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         app = serializer.save()
-        app.create_app_role()
+        app.aws_create_role()
 
     def perform_destroy(self, instance):
         instance.delete()
-        instance.delete_app_role()
+        instance.aws_delete_role()
 
 
 class AppS3BucketViewSet(viewsets.ModelViewSet):
@@ -65,7 +65,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
 
     def perform_update(self, serializer):
         apps3bucket = serializer.save()
-        apps3bucket.update_aws_permissions()
+        apps3bucket.aws_update()
 
     def perform_destroy(self, instance):
         instance.delete()


### PR DESCRIPTION
## What

Goal of this PR was to extract some of the ORM code from the service layer to reduce coupling.

Views are clean and call a method on model.

Model is clean and calls `service` functions passing its instance attributes as params.  Service does not need to know about django model.  Service function could be called by a command by just passing params.

Service layer does a bit of orchestrating and calls lower level aws wrapper functions.

Each layer is tested with each other.

## Issues

- Naming of model methods.
- Refactor out policy name and arn etc.
- Now we have django models with methods hitting aws, is this ok? Do we want to further pull out this to different classes to clean up and make clearer?

## How to review

1. Check design.
2. Run tests.

