### PR TITLE
Trigger Jenkins job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - deploy:
           name: Deploy to Kubernetes
           command: |
-            curl ${JENKINS_URL}/job/control-panel/job/${CIRCLE_BRANCH}/buildWithParameters \
+            curl ${JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
               --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
-              --data BRANCH=${CIRCLE_BRANCH} \
+              --data BRANCH_NAME=${CIRCLE_BRANCH} \
               --user ${JENKINS_USER}:${JENKINS_TOKEN}


### PR DESCRIPTION
## What

* Fixed Jenkins job invocation

## How to review

1. In a CircleCI build, see the last command invokes Jenkins job remotely (eg: https://circleci.com/gh/ministryofjustice/analytics-platform-control-panel/217)