### PR TITLE
Add COMMIT_HASH as docker image tag and parameter to jenkins job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,9 @@ jobs:
           name: Push application Docker image
           command: |
             docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} quay.io
+            docker tag app "quay.io/mojanalytics/control-panel:${CIRCLE_SHA1}"
             docker tag app "quay.io/mojanalytics/control-panel:${CIRCLE_BRANCH}"
+            docker push "quay.io/mojanalytics/control-panel:${CIRCLE_SHA1}"
             docker push "quay.io/mojanalytics/control-panel:${CIRCLE_BRANCH}"
 
       - deploy:
@@ -64,5 +66,6 @@ jobs:
           command: |
             curl ${JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
               --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
+              --data COMMIT_HASH=${CIRCLE_SHA1} \
               --data BRANCH_NAME=${CIRCLE_BRANCH} \
               --user ${JENKINS_USER}:${JENKINS_TOKEN}


### PR DESCRIPTION
## What

* Tag the docker image with the commit hash to avoid kubernetes caching the image by branch name and failing to redeploy the api branch on merge (among other cases)
* Pass the commit hash to Jenkins (which is updated to pass it to helm) to install the latest version of the image and not a cached version