### PR TITLE
Send exceptions to sentry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+Jenkinsfile
+venv
+.cache
+.circleci
+.env
+.github
+.gitignore
+.python-version
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM alpine:3.6
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
 # install build dependencies (they'll be uninstalled after pip install)
-RUN apk add --update --no-cache \
+RUN apk add --no-cache \
         --virtual build-deps \
         gcc \
         musl-dev
 
 # install python3 and 'ca-certificates' so that HTTPS works consistently
-RUN apk add \
+RUN apk add --no-cache \
         ca-certificates \
         postgresql-dev \
         python3-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM alpine:3.6
 
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
-RUN apk update && \
-    apk add \
+# install build dependencies (they'll be uninstalled after pip install)
+RUN apk add --update --no-cache \
         --virtual build-deps \
         gcc \
-        musl-dev \
+        musl-dev
+
+# install python3 and 'ca-certificates' so that HTTPS works consistently
+RUN apk add \
+        ca-certificates \
         postgresql-dev \
         python3-dev
 
@@ -15,6 +19,9 @@ WORKDIR /home/control-panel
 # install python dependencies
 ADD requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
+
+# uninstall build dependencies
+RUN apk del build-deps
 
 ADD manage.py manage.py
 ADD run_api run_api

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -2,6 +2,7 @@ import os
 
 import boto3
 
+
 SECRET_KEY = os.environ.get(
     'SECRET_KEY',
     '(2gbfi1uc1llww251t00s7$^luuzvivf7l+(snj=sbt#s8h!wu')
@@ -30,6 +31,7 @@ INSTALLED_APPS = [
     'django_extensions',
     'rest_framework',
     'rest_framework_swagger',
+    'raven.contrib.django.raven_compat',
     'control_panel_api',
 ]
 
@@ -126,3 +128,8 @@ IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', '')
 K8S_WORKER_ROLE_NAME = os.environ.get('K8S_WORKER_ROLE_NAME', '')
 SAML_PROVIDER_ARN = os.environ.get('SAML_PROVIDER_ARN', '')
 AWS_API_CLIENT_HANDLER = boto3.client
+
+RAVEN_CONFIG = {
+    'dsn': os.environ.get('SENTRY_DSN', ''),
+    'environment': ENV,
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ pyasn1-modules==0.0.11
 python-dateutil==2.6.1
 pytz==2017.2
 PyYAML==3.12
+raven==6.2.1
 requests==2.18.4
 rsa==3.4.2
 s3transfer==0.1.11


### PR DESCRIPTION
### What

When exceptions happen, details are sent to Sentry (that's the theory).


### `Dockerfile` changes

The main changes to the `Dockerfile` are:
* Use apk's [`--virtual`](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#virtual-packages) to uninstall build dependencies (`gcc` and `musl-dev`) after `pip install` of requirements. This is done by `apk del build-deps`. This is not only good as reduces the size of the image/container but it's also good from a security perspective (as `gcc` could be potentially used by an attacker)
* Use apk's [`--no-cache` (`--update` is implicit when using this)](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache)
* Install `ca-certificates` to avoid problems with HTTPS
* also added `.dockerignore` file to slightly reduce build time (by reducing context sent to docker when building the image)

### Ticket

https://trello.com/c/G8qny9WN/400-cp-api-set-up-sentry-for-exceptions


### Other resources

[Django/Sentry integration documentation](https://docs.sentry.io/clients/python/integrations/django/)


### TODO

- [x] [Support for `SENTRY_DSN` environment variable in `cpanel` help chart](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/32)
- [X] [Add `SENTRY_DSN` config](https://github.com/ministryofjustice/analytics-platform-config/pull/13)