### PR TITLE
Add filtering apps by repo_url field

### DIFF
--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -3,17 +3,20 @@ Custom filters
 
 See: http://www.django-rest-framework.org/api-guide/filtering/#custom-generic-filtering
 """
-from rest_framework.filters import BaseFilterBackend
+
+from django_filters.rest_framework import DjangoFilterBackend
 
 from control_panel_api.permissions import is_superuser
 
 
-class SuperusersOnlyFilter(BaseFilterBackend):
+class SuperusersOnlyFilter(DjangoFilterBackend):
     """
     Superusers can see everything. Other users can't see anything
     """
 
     def filter_queryset(self, request, queryset, view):
+        queryset = super().filter_queryset(request, queryset, view)
+
         if is_superuser(request.user):
             return queryset
         else:

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -91,6 +91,18 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(response.data['results']), 2)
 
+    def test_list_filter_by_repo_url(self):
+        self.fixture.repo_url = 'https://example.com'
+        self.fixture.save()
+
+        params = {'repo_url': 'https%3A%2F%2Fexample.com'}
+        response = self.client.get(reverse('app-list'), params)
+
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertEqual(len(response.data['results']), 1)
+        app = response.data['results'][0]
+        self.assertEqual(app['id'], self.fixture.id)
+
     def test_detail(self):
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -95,7 +95,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.fixture.repo_url = 'https://example.com'
         self.fixture.save()
 
-        params = {'repo_url': 'https%3A%2F%2Fexample.com'}
+        params = {'repo_url': self.fixture.repo_url}
         response = self.client.get(reverse('app-list'), params)
 
         self.assertEqual(HTTP_200_OK, response.status_code)

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -1,5 +1,3 @@
-from urllib.parse import unquote
-
 from django.contrib.auth.models import Group
 from rest_framework import viewsets
 
@@ -56,16 +54,9 @@ class AppViewSet(viewsets.ModelViewSet):
     queryset = App.objects.all()
     serializer_class = AppSerializer
     filter_backends = (AppFilter,)
+
+    filter_fields = ('name', 'repo_url', 'slug')
     permission_classes = (AppPermissions,)
-
-    def get_queryset(self):
-        queryset = self.queryset
-
-        repo_url = self.request.query_params.get('repo_url')
-        if repo_url:
-            queryset = queryset.filter(repo_url=unquote(repo_url))
-
-        return queryset
 
     def perform_create(self, serializer):
         app = serializer.save(created_by=self.request.user)

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 from django.contrib.auth.models import Group
 from rest_framework import viewsets
 
@@ -55,6 +57,15 @@ class AppViewSet(viewsets.ModelViewSet):
     serializer_class = AppSerializer
     filter_backends = (AppFilter,)
     permission_classes = (AppPermissions,)
+
+    def get_queryset(self):
+        queryset = self.queryset
+
+        repo_url = self.request.query_params.get('repo_url')
+        if repo_url:
+            queryset = queryset.filter(repo_url=unquote(repo_url))
+
+        return queryset
 
     def perform_create(self, serializer):
         app = serializer.save(created_by=self.request.user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ coreapi==2.3.1
 coreschema==0.0.4
 Django==1.11.4
 django-extensions==1.8.1
+django-filter==1.0.4
 django-rest-swagger==2.1.2
 djangorestframework==3.6.3
 google-auth==1.0.2


### PR DESCRIPTION
### What

Ability to filter apps by `repo_url` field.

This is part of the work to avoid asking the user for the app IAM role name when deploying.

I updated the `SuperusersOnlyFilter` class to inherit from `django_filters.rest_framework.DjangoFilterBackend`, this is the class currently used by all the views (will change once we give access to non-superuser users and we need more granular permissions).


### Relevant DRF / django_filters documentation
* [DRF's filtering](http://www.django-rest-framework.org/api-guide/filtering/#djangofilterbackend)
* [django-filter](https://django-filter.readthedocs.io/en/latest/guide/rest_framework.html)

### Ticket
https://trello.com/c/vtPRBZfa/418-cp-api-investigate-implement-app-filtering-by-repourl