### PR TITLE
Fixed DRF view error 'TemplateDoesNotExist'

### DIFF
--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     # 'django.contrib.messages',
     'django.contrib.staticfiles',  # TODO - remove this?
     'django_extensions',
+    'django_filters',
     'rest_framework',
     'rest_framework_swagger',
     'raven.contrib.django.raven_compat',


### PR DESCRIPTION
The view is provided by the `django_filters` which wasn't installed.

### Related PR
(I should have tested in the CD deployment for the branch)

https://github.com/ministryofjustice/analytics-platform-control-panel/pull/37