### PR TITLE
Allow authentication with Auth0 ID token JWT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apk add --no-cache \
 # install python3 and 'ca-certificates' so that HTTPS works consistently
 RUN apk add --no-cache \
         ca-certificates \
+        libffi-dev \
+        libressl-dev \
         postgresql-dev \
         python3-dev
 

--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -1,0 +1,35 @@
+import jwt
+from django.conf import settings
+from jwt.exceptions import InvalidTokenError
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+from control_panel_api.models import User
+
+
+class Auth0JWTAuthentication(BaseAuthentication):
+    def authenticate(self, request):
+        try:
+            prefix, token = request.META.get('HTTP_AUTHORIZATION', '').split()
+        except (ValueError, TypeError):
+            return None
+
+        if prefix != 'JWT':
+            raise AuthenticationFailed('JWT prefix missing')
+
+        try:
+            decoded = jwt.decode(token, key=settings.AUTH0_SECRET, audience=settings.AUTH0_AUDIENCE)
+        except InvalidTokenError:
+            raise AuthenticationFailed('JWT decode error')
+
+        try:
+            username = decoded['sub']
+        except KeyError:
+            raise AuthenticationFailed('JWT missing sub username field')
+
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise AuthenticationFailed('No such user')
+
+        return (user, None)

--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -1,35 +1,47 @@
-import jwt
 from django.conf import settings
+import jwt
 from jwt.exceptions import InvalidTokenError
-from rest_framework.authentication import BaseAuthentication, get_authorization_header
+from rest_framework.authentication import (
+    BaseAuthentication,
+    get_authorization_header
+)
 from rest_framework.exceptions import AuthenticationFailed
 
 from control_panel_api.models import User
 
 
 class Auth0JWTAuthentication(BaseAuthentication):
+
     def authenticate(self, request):
+
         try:
             prefix, token = get_authorization_header(request).split()
+
         except (ValueError, TypeError):
             return None
 
-        if prefix != settings.AUTH0_JWT_PREFIX.encode():
+        if prefix != 'JWT'.encode():
             raise AuthenticationFailed('JWT prefix missing')
 
         try:
-            decoded = jwt.decode(token, key=settings.AUTH0_SECRET, audience=settings.AUTH0_AUDIENCE)
+            decoded = jwt.decode(
+                token,
+                key=settings.AUTH0_CLIENT_SECRET,
+                audience=settings.AUTH0_CLIENT_ID
+            )
+
         except InvalidTokenError:
             raise AuthenticationFailed('JWT decode error')
 
-        try:
-            username = decoded.get(settings.AUTH0_USERNAME_FIELD)
-        except KeyError:
-            raise AuthenticationFailed('JWT missing {} username field'.format(settings.AUTH0_USERNAME_FIELD))
+        sub = decoded.get('sub')
+
+        if sub is None:
+            raise AuthenticationFailed('JWT missing "sub" field')
 
         try:
-            user = User.objects.get(username=username)
+            user = User.objects.get(auth0_id=sub)
+
         except User.DoesNotExist:
-            raise AuthenticationFailed('No such user')
+            raise AuthenticationFailed(f'No such user: {sub}')
 
         return user, None

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -111,6 +111,11 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 STATIC_URL = '/static/'
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'control_panel_api.authentication.Auth0JWTAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication'
+    ],
     'DEFAULT_FILTER_BACKENDS': ('control_panel_api.filters.SuperusersOnlyFilter',),
     'DEFAULT_PERMISSION_CLASSES': [
         'control_panel_api.permissions.IsSuperuser',

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -134,3 +134,6 @@ RAVEN_CONFIG = {
     'dsn': os.environ.get('SENTRY_DSN', ''),
     'environment': ENV,
 }
+
+AUTH0_CLIENT_ID = os.environ.get('AUTH0_CLIENT_ID')
+AUTH0_CLIENT_SECRET = os.environ.get('AUTH0_CLIENT_SECRET')

--- a/control_panel_api/tests/test_authentication.py
+++ b/control_panel_api/tests/test_authentication.py
@@ -1,33 +1,52 @@
 from django.test import override_settings
+import jwt
 from model_mommy import mommy
 from rest_framework.reverse import reverse
 from rest_framework.status import HTTP_403_FORBIDDEN, HTTP_200_OK
 from rest_framework.test import APITestCase
 
+from control_panel_api.authentication import Auth0JWTAuthentication
+
+
 # Decode token at https://jwt.io/
-GOOD_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImphbWVzQGptb3ouY28udWsiLCJuYW1lIjoiSmFtZXMgTW9ycmlzIiwiYXVkIjoiYXVkaWVuY2UiLCJzdWIiOiJqYW1lcyJ9.MF9RW-o6g0RFK-G0z1ss07Ru7H4XUz8ZSqeBYHgUWjg'
+GOOD_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImphbWVzQGptb3ouY28udWsiLCJuYW1lIjoiSmFtZXMgTW9ycmlzIiwiYXVkIjoiYXVkaWVuY2UiLCJzdWIiOiJnaXRodWJ8MTIzNDUifQ.Vfvhtm_TXbtOBKcIWed0YzVH7gIKlSdzg36bbIK6UZ4'  # noqa
 
 
 class Auth0JWTAuthenticationTestCase(APITestCase):
+
     def setUp(self):
-        self.user = mommy.make('control_panel_api.User', username='james')
+        self.user = mommy.make(
+            'control_panel_api.User',
+            username='james',
+            auth0_id='github|12345',
+            is_superuser=True
+        )
+
+    def get_user(self):
+        return self.client.get(
+            reverse('user-detail', args=[self.user.auth0_id]))
+
+    def assert_access_denied(self):
+        self.assertEqual(HTTP_403_FORBIDDEN, self.get_user().status_code)
+
+    def assert_authenticated(self):
+        self.assertEqual(HTTP_200_OK, self.get_user().status_code)
 
     def test_user_can_not_view(self):
-        response = self.client.get(reverse('user-detail', (self.user.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assert_access_denied()
 
     def test_bad_header(self):
         self.client.credentials(HTTP_AUTHORIZATION='FOO bar')
-        response = self.client.get(reverse('user-detail', (self.user.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assert_access_denied()
 
     def test_bad_token(self):
         self.client.credentials(HTTP_AUTHORIZATION='JWT bar')
-        response = self.client.get(reverse('user-detail', (self.user.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assert_access_denied()
 
-    @override_settings(AUTH0_SECRET='secret', AUTH0_AUDIENCE='audience')
+    @override_settings(AUTH0_CLIENT_SECRET='secret', AUTH0_CLIENT_ID='audience')
     def test_good_token(self):
-        self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(GOOD_TOKEN))
-        response = self.client.get(reverse('user-detail', (self.user.id,)))
-        self.assertEqual(HTTP_200_OK, response.status_code)
+        # assert the token is good
+        decoded = jwt.decode(GOOD_TOKEN, key='secret', audience='audience')
+        self.assertEqual(decoded['sub'], 'github|12345')
+        self.client.credentials(HTTP_AUTHORIZATION=f'JWT {GOOD_TOKEN}')
+        self.assert_authenticated()

--- a/control_panel_api/tests/test_authentication.py
+++ b/control_panel_api/tests/test_authentication.py
@@ -1,0 +1,33 @@
+from django.test import override_settings
+from model_mommy import mommy
+from rest_framework.reverse import reverse
+from rest_framework.status import HTTP_403_FORBIDDEN, HTTP_200_OK
+from rest_framework.test import APITestCase
+
+# Decode token at https://jwt.io/
+GOOD_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImphbWVzQGptb3ouY28udWsiLCJuYW1lIjoiSmFtZXMgTW9ycmlzIiwiYXVkIjoiYXVkaWVuY2UiLCJzdWIiOiJqYW1lcyJ9.MF9RW-o6g0RFK-G0z1ss07Ru7H4XUz8ZSqeBYHgUWjg'
+
+
+class Auth0JWTAuthenticationTestCase(APITestCase):
+    def setUp(self):
+        self.user = mommy.make('control_panel_api.User', username='james')
+
+    def test_user_can_not_view(self):
+        response = self.client.get(reverse('user-detail', (self.user.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_bad_header(self):
+        self.client.credentials(HTTP_AUTHORIZATION='FOO bar')
+        response = self.client.get(reverse('user-detail', (self.user.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_bad_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION='JWT bar')
+        response = self.client.get(reverse('user-detail', (self.user.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    @override_settings(AUTH0_SECRET='secret', AUTH0_AUDIENCE='audience')
+    def test_good_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(GOOD_TOKEN))
+        response = self.client.get(reverse('user-detail', (self.user.id,)))
+        self.assertEqual(HTTP_200_OK, response.status_code)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - db
     links:
       - db
+    env_file:
+      - .env
     environment:
       DB_HOST: "db"
       DB_NAME: "controlpanel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ certifi==2017.7.27.1
 chardet==3.0.4
 coreapi==2.3.1
 coreschema==0.0.4
+cryptography==2.1.1
 Django==1.11.4
 django-extensions==1.8.1
 django-filter==1.0.4
@@ -24,6 +25,7 @@ openapi-codec==1.3.2
 psycopg2==2.7.3
 pyasn1==0.3.2
 pyasn1-modules==0.0.11
+PyJWT==1.5.3
 python-dateutil==2.6.1
 pytz==2017.2
 PyYAML==3.12


### PR DESCRIPTION
## What

* Rebased @jmoz's work
* Accept `Authorization: JWT <token>` header and verify JWT to authenticate user

## How to review

1. Use `docker-compose up` to run an instance of the API
2. `docker-compose run app python3 manage.py createsuperuser` to create a user with an `auth0_id`
3. Run the [frontend](https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/tree/api-client-auth) and login with Auth0
4. See your user data retrieved from the API
