### PR TITLE
Normalise App.repo_url to not have the trailing '.git'

### DIFF
--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -12,6 +12,7 @@ from control_panel_api.models import (
 
 
 class UserSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = User
         fields = (
@@ -28,6 +29,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class GroupSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = Group
         fields = ('id', 'url', 'name')
@@ -48,6 +50,10 @@ class AppSerializer(serializers.ModelSerializer):
             'apps3buckets',
             'userapps',
         )
+
+    def validate_repo_url(self, value):
+        """Normalise repo URLs by removing trailing .git"""
+        return value.rsplit(".git", 1)[0]
 
 
 class AppS3BucketSerializer(serializers.ModelSerializer):
@@ -89,12 +95,14 @@ class UserS3BucketSerializer(serializers.ModelSerializer):
 
 
 class S3BucketSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = S3Bucket
         fields = ('id', 'url', 'name', 'arn', 'apps3buckets', 'created_by')
 
 
 class AppUserSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = UserApp
         fields = ('id', 'url', 'app', 'user', 'is_admin')

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -143,6 +143,13 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
         self.assertEqual(self.superuser.auth0_id, response.data['created_by'])
 
+    @patch('control_panel_api.models.App.aws_create_role')
+    def test_create_normalises_repo_url(self, mock_aws_create_role):
+        data = {'name': 'foo', 'repo_url': 'https://example.com.git'}
+        response = self.client.post(reverse('app-list'), data)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+        self.assertEqual('https://example.com', response.data['repo_url'])
+
     def test_update(self):
         data = {'name': 'foo', 'repo_url': 'http://foo.com'}
         response = self.client.put(
@@ -150,6 +157,12 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(data['name'], response.data['name'])
 
+    def test_update_normalises_repo_url(self):
+        data = {'name': 'foo', 'repo_url': 'http://foo.com.git'}
+        response = self.client.put(
+            reverse('app-detail', (self.fixture.id,)), data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertEqual('http://foo.com', response.data['repo_url'])
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 


### PR DESCRIPTION
### What
To avoid ambiguity we're ensuring that the App repo URL will always have
the same format. This will enable us to simplify the Jenkins job to deploy
a webapp.

This gets the app details by filtering apps by repo_url but currently has
to perform two separate HTTP requests (in the worst-case scenario) to
try both versions of the repo URL.

This will mean we can just filter by the `repo_url` without the trailing
".git".

### Part of ticket
https://trello.com/c/yfUlKPdb/428-cp-api-jenkins-normalise-repourl-and-avoid-possible-second-request
