### PR TITLE
App and S3Bucket return nested data

### DIFF
--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -35,27 +35,6 @@ class GroupSerializer(serializers.ModelSerializer):
         fields = ('id', 'url', 'name')
 
 
-class AppSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = App
-        fields = (
-            'id',
-            'url',
-            'name',
-            'slug',
-            'repo_url',
-            'iam_role_name',
-            'created_by',
-            'apps3buckets',
-            'userapps',
-        )
-
-    def validate_repo_url(self, value):
-        """Normalise repo URLs by removing trailing .git"""
-        return value.rsplit(".git", 1)[0]
-
-
 class AppS3BucketSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -94,11 +73,76 @@ class UserS3BucketSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
+class SimpleAppSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = App
+        fields = (
+            'id',
+            'url',
+            'name',
+            'slug',
+            'repo_url',
+            'iam_role_name',
+            'created_by',
+        )
+
+
+class SimpleS3BucketSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = S3Bucket
+        fields = ('id', 'url', 'name', 'arn', 'created_by')
+
+
+class AppAppS3BucketSerializer(serializers.ModelSerializer):
+    """Used from within with AppSerializer to not expose app"""
+    s3bucket = SimpleS3BucketSerializer()
+
+    class Meta:
+        model = AppS3Bucket
+        fields = ('id', 'url', 's3bucket', 'access_level')
+
+
+class S3BucketAppS3BucketSerializer(serializers.ModelSerializer):
+    """Used from within with S3BucketSerializer to not expose s3bucket"""
+    app = SimpleAppSerializer()
+
+    class Meta:
+        model = AppS3Bucket
+        fields = ('id', 'url', 'app', 'access_level')
+
+
+class AppSerializer(serializers.ModelSerializer):
+
+    apps3buckets = AppAppS3BucketSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = App
+        fields = (
+            'id',
+            'url',
+            'name',
+            'slug',
+            'repo_url',
+            'iam_role_name',
+            'created_by',
+            'apps3buckets',
+            'userapps',
+        )
+
+    def validate_repo_url(self, value):
+        """Normalise repo URLs by removing trailing .git"""
+        return value.rsplit(".git", 1)[0]
+
+
 class S3BucketSerializer(serializers.ModelSerializer):
+    apps3buckets = S3BucketAppS3BucketSerializer(many=True, read_only=True)
 
     class Meta:
         model = S3Bucket
         fields = ('id', 'url', 'name', 'arn', 'apps3buckets', 'created_by')
+        read_only_fields = ('apps3buckets', 'created_by')
 
 
 class AppUserSerializer(serializers.ModelSerializer):

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -87,6 +87,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         super().setUp()
         mommy.make('control_panel_api.App')
         self.fixture = mommy.make('control_panel_api.App')
+        mommy.make('control_panel_api.AppS3Bucket', app=self.fixture)
 
     def test_list(self):
         response = self.client.get(reverse('app-list'))
@@ -121,6 +122,21 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
             self.fixture.iam_role_name,
         )
         self.assertEqual(9, len(response.data))
+
+        apps3bucket = response.data['apps3buckets'][0]
+        self.assertIn('id', apps3bucket)
+        self.assertIn('url', apps3bucket)
+        self.assertIn('s3bucket', apps3bucket)
+        self.assertIn('access_level', apps3bucket)
+        self.assertEqual(4, len(apps3bucket))
+
+        s3bucket = apps3bucket['s3bucket']
+        self.assertIn('id', s3bucket)
+        self.assertIn('url', s3bucket)
+        self.assertIn('name', s3bucket)
+        self.assertIn('arn', s3bucket)
+        self.assertIn('created_by', s3bucket)
+        self.assertEqual(5, len(s3bucket))
 
     @patch('control_panel_api.models.App.aws_delete_role')
     def test_delete(self, mock_aws_delete_role):
@@ -351,6 +367,7 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         mommy.make('control_panel_api.S3Bucket')
         self.fixture = mommy.make(
             'control_panel_api.S3Bucket', name='test-bucket-1')
+        mommy.make('control_panel_api.AppS3Bucket', s3bucket=self.fixture)
 
     def test_list(self):
         response = self.client.get(reverse('s3bucket-list'))
@@ -368,6 +385,23 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertIn('apps3buckets', response.data)
         self.assertIn('created_by', response.data)
         self.assertEqual(6, len(response.data))
+
+        apps3bucket = response.data['apps3buckets'][0]
+        self.assertIn('id', apps3bucket)
+        self.assertIn('url', apps3bucket)
+        self.assertIn('app', apps3bucket)
+        self.assertIn('access_level', apps3bucket)
+        self.assertEqual(4, len(apps3bucket))
+
+        app = apps3bucket['app']
+        self.assertIn('id', app)
+        self.assertIn('url', app)
+        self.assertIn('name', app)
+        self.assertIn('slug', app)
+        self.assertIn('repo_url', app)
+        self.assertIn('iam_role_name', app)
+        self.assertIn('created_by', app)
+        self.assertEqual(7, len(app))
 
     @patch('control_panel_api.models.S3Bucket.aws_delete')
     def test_delete(self, mock_aws_delete):


### PR DESCRIPTION
## What

This returns some of the nested data when on app or s3bucket to prevent multiple calls for data we already have available.

Use different serializers which exclude the parent data.

Create simple serializer for app and s3bucket which does not return relations.

## App output

```
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 1,
      "url": "http://127.0.0.1:8003/apps/1/",
      "name": "jamesapp",
      "slug": "foocom",
      "repo_url": "http://foo.com",
      "iam_role_name": "dev_app_foocom",
      "created_by": "foo",
      "apps3buckets": [
        {
          "id": 1,
          "url": "http://127.0.0.1:8003/apps3buckets/1/",
          "s3bucket": {
            "id": 2,
            "url": "http://127.0.0.1:8003/s3buckets/2/",
            "name": "dev-james2",
            "arn": "arn:aws:s3:::dev-james2",
            "created_by": "foo"
          },
          "access_level": "readwrite"
        }
      ],
      "userapps": []
    }
  ]
}
```

## S3Bucket output

```
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 2,
      "url": "http://127.0.0.1:8003/s3buckets/2/",
      "name": "dev-james2",
      "arn": "arn:aws:s3:::dev-james2",
      "apps3buckets": [
        {
          "id": 1,
          "url": "http://127.0.0.1:8003/apps3buckets/1/",
          "app": {
            "id": 1,
            "url": "http://127.0.0.1:8003/apps/1/",
            "name": "jamesapp",
            "slug": "foocom",
            "repo_url": "http://foo.com",
            "iam_role_name": "dev_app_foocom",
            "created_by": "foo"
          },
          "access_level": "readwrite"
        }
      ],
      "created_by": "foo"
    }
  ]
}
```

## How to review

1. ./manage.py test
2. Check the endpoints for app and s3bucket
