### PR TITLE
Add kubernetes/helm to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,30 @@ RUN apk add --no-cache \
 
 # install python3 and 'ca-certificates' so that HTTPS works consistently
 RUN apk add --no-cache \
+        openssl \
         ca-certificates \
         libffi-dev \
         libressl-dev \
         postgresql-dev \
         python3-dev
+
+# Install kubernetes
+ENV K8S_VERSION 1.7.7
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v$K8S_VERSION/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+# Install helm
+ENV HELM_VERSION 2.6.1
+RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v$HELM_VERSION-linux-amd64.tar.gz \
+    && tar xzf helm-v$HELM_VERSION-linux-amd64.tar.gz \
+    && mv linux-amd64/helm /usr/local/bin \
+    && rm -rf helm-v$HELM_VERSION-linux-amd64.tar.gz linux-amd64
+
+# Configure helm
+ENV HELM_HOME /tmp/helm
+RUN helm init --client-only
+COPY helm-repositories.yaml /tmp/helm/repository/repositories.yaml
+RUN helm repo update
 
 WORKDIR /home/control-panel
 

--- a/helm-repositories.yaml
+++ b/helm-repositories.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+generated: 2017-07-18T12:08:14.812467603Z
+repositories:
+- caFile: ""
+  cache: /tmp/helm/repository/cache/stable-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: stable
+  url: https://kubernetes-charts.storage.googleapis.com
+- caFile: ""
+  cache: /tmp/helm/repository/cache/local-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: local
+  url: http://127.0.0.1:8879/charts
+- caFile: ""
+  cache: /tmp/helm/repository/cache/mojanalytics-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: mojanalytics
+  url: https://ministryofjustice.github.io/analytics-platform-helm-charts/charts/


### PR DESCRIPTION
### What
Added k8s (kubernetes `v1.7.7`) and helm (`v2.6.1`) to the docker image.

Also added the moj-analytics helm repository

**NOTE**: I had to install `openssl` to solve a weird SSL certificate problem when getting the tarballs via `wget`.

### Why
Set up a user within the platform involves the installation of a couple of our helm charts.

### Ticket
https://trello.com/c/8dwIeL6w/455-ensure-helm-client-is-present-in-cp-api-docker-container-3

This is similar to what [we already do in the jenkins-agent image](https://github.com/ministryofjustice/analytics-platform-jenkins-agent/blob/master/Dockerfile#L13).
