### PR TITLE
Port helm code from master branch

### DIFF
--- a/control_panel_api/helm.py
+++ b/control_panel_api/helm.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+
+
+def _get_subprocess():
+    """Allow the subprocess module to be switched out at runtime for a
+    magicmock to prevent real calls during testing
+    """
+    return settings.SUBPROCESS_MODULE
+
+
+def init_user(username, email, fullname):
+    helm_upgrade(
+        f'init-user-{username}',
+        'mojanalytics/init-user',
+        '--set', f'NFSHostname={settings.NFS_HOSTNAME}',
+        '--set', f'Username={username}',
+        '--set', f'Email={email}',
+        '--set', f'Fullname={fullname}',
+    )
+
+
+def config_user(username):
+    helm_upgrade(
+        f'config-user-{username}',
+        'mojanalytics/config-user',
+        '--namespace', f'user-{username}',
+        '--set', f'Username={username}',
+    )
+
+
+def helm_upgrade(release, chart, *flags):
+    default_flags = ['--install', '--wait']
+    flags = list(flags) + default_flags
+    _get_subprocess().run(
+        ['helm', 'upgrade', release, chart] + flags, check=True)

--- a/control_panel_api/helm.py
+++ b/control_panel_api/helm.py
@@ -1,11 +1,6 @@
+import subprocess
+
 from django.conf import settings
-
-
-def _get_subprocess():
-    """Allow the subprocess module to be switched out at runtime for a
-    magicmock to prevent real calls during testing
-    """
-    return settings.SUBPROCESS_MODULE
 
 
 def init_user(username, email, fullname):
@@ -31,5 +26,5 @@ def config_user(username):
 def helm_upgrade(release, chart, *flags):
     default_flags = ['--install', '--wait']
     flags = list(flags) + default_flags
-    _get_subprocess().run(
+    subprocess.run(
         ['helm', 'upgrade', release, chart] + flags, check=True)

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -7,7 +7,7 @@ from django.template.defaultfilters import slugify
 from django_extensions.db.fields import AutoSlugField
 from django_extensions.db.models import TimeStampedModel
 
-from control_panel_api import services, validators
+from control_panel_api import helm, services, validators
 
 
 class User(AbstractUser):
@@ -36,6 +36,10 @@ class User(AbstractUser):
 
     def aws_delete_role(self):
         services.delete_role(self.iam_role_name)
+
+    def helm_create_user(self):
+        helm.init_user(self.username, self.email, self.get_full_name())
+        helm.config_user(self.username)
 
 
 class App(TimeStampedModel):

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -37,7 +37,7 @@ class User(AbstractUser):
     def aws_delete_role(self):
         services.delete_role(self.iam_role_name)
 
-    def helm_create_user(self):
+    def helm_create(self):
         helm.init_user(self.username, self.email, self.get_full_name())
         helm.config_user(self.username)
 

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -1,8 +1,6 @@
 import os
-import subprocess
 
 import boto3
-
 
 SECRET_KEY = os.environ.get(
     'SECRET_KEY',
@@ -147,4 +145,3 @@ OIDC_DOMAIN = os.environ.get('OIDC_DOMAIN')
 
 # Helm variables
 NFS_HOSTNAME = os.environ.get('NFS_HOSTNAME')
-SUBPROCESS_MODULE = subprocess

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 import boto3
 
@@ -143,3 +144,7 @@ RAVEN_CONFIG = {
 OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID')
 OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET')
 OIDC_DOMAIN = os.environ.get('OIDC_DOMAIN')
+
+# Helm variables
+NFS_HOSTNAME = os.environ.get('NFS_HOSTNAME')
+SUBPROCESS_MODULE = subprocess

--- a/control_panel_api/settings/test.py
+++ b/control_panel_api/settings/test.py
@@ -9,3 +9,4 @@ LOGS_BUCKET_NAME = 'moj-test-logs'
 IAM_ARN_BASE = 'arn:aws:iam::123'
 K8S_WORKER_ROLE_NAME = 'test-k8s-worker-role'
 SAML_PROVIDER = 'test'
+SUBPROCESS_MODULE = MagicMock()

--- a/control_panel_api/settings/test.py
+++ b/control_panel_api/settings/test.py
@@ -9,4 +9,3 @@ LOGS_BUCKET_NAME = 'moj-test-logs'
 IAM_ARN_BASE = 'arn:aws:iam::123'
 K8S_WORKER_ROLE_NAME = 'test-k8s-worker-role'
 SAML_PROVIDER = 'test'
-SUBPROCESS_MODULE = MagicMock()

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -16,6 +16,22 @@ from control_panel_api.tests import APP_IAM_ROLE_ASSUME_POLICY
 
 
 class UserTestCase(TestCase):
+    @patch('control_panel_api.helm.init_user')
+    @patch('control_panel_api.helm.config_user')
+    def test_helm_create_user(self, mock_config_user, mock_init_user):
+        username = 'foo'
+        email = 'bar@baz.com'
+        name = 'bat'
+        user = User.objects.create(
+            username=username,
+            email=email,
+            name=name,
+        )
+        user.helm_create_user()
+
+        mock_config_user.assert_called_with(username)
+        mock_init_user.assert_called_with(username, email, name)
+
     @patch('control_panel_api.services.create_role')
     def test_aws_create_role_calls_service(self, mock_create_role):
         username = 'james'

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -28,7 +28,7 @@ class UserTestCase(TestCase):
             email=email,
             name=name,
         )
-        user.helm_create_user()
+        user.helm_create()
 
         mock_config_user.assert_called_with(username)
         mock_init_user.assert_called_with(username, email, name)

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.db.utils import IntegrityError
 from django.test import TestCase
@@ -15,6 +15,7 @@ from control_panel_api.models import (
 from control_panel_api.tests import APP_IAM_ROLE_ASSUME_POLICY
 
 
+@patch('control_panel_api.helm.subprocess.run', MagicMock())
 class UserTestCase(TestCase):
     @patch('control_panel_api.helm.init_user')
     @patch('control_panel_api.helm.config_user')

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from model_mommy import mommy
 from rest_framework.reverse import reverse
@@ -13,6 +13,7 @@ from rest_framework.test import APITestCase
 from control_panel_api.models import AppS3Bucket
 
 
+@patch('control_panel_api.helm.subprocess.run', MagicMock())
 class UserPermissionsTest(APITestCase):
 
     def setUp(self):

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -65,8 +65,9 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('user-detail', (self.fixture.auth0_id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
+    @patch('control_panel_api.models.User.helm_create_user')
     @patch('control_panel_api.models.User.aws_create_role')
-    def test_create(self, mock_aws_create_role):
+    def test_create(self, mock_aws_create_role, mock_helm_create_user):
         data = {'auth0_id': 'github|2', 'username': 'foo'}
         response = self.client.post(reverse('user-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
@@ -74,6 +75,7 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(data['auth0_id'], response.data['auth0_id'])
 
         mock_aws_create_role.assert_called()
+        mock_helm_create_user.assert_called()
 
     def test_update(self):
         data = {'username': 'foo', 'auth0_id': 'github|888'}

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -66,7 +66,7 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('user-detail', (self.fixture.auth0_id,)))
         self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
 
-    @patch('control_panel_api.models.User.helm_create_user')
+    @patch('control_panel_api.models.User.helm_create')
     @patch('control_panel_api.models.User.aws_create_role')
     def test_create(self, mock_aws_create_role, mock_helm_create_user):
         data = {'auth0_id': 'github|2', 'username': 'foo'}

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from model_mommy import mommy
 from rest_framework.reverse import reverse
@@ -28,6 +28,7 @@ class AuthenticatedClientMixin(object):
         self.client.force_login(self.superuser)
 
 
+@patch('control_panel_api.helm.subprocess.run', MagicMock())
 class UserViewTest(AuthenticatedClientMixin, APITestCase):
 
     def setUp(self):
@@ -183,6 +184,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('app-detail', (self.fixture.id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual('http://foo.com', response.data['repo_url'])
+
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -39,7 +39,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         instance = serializer.save()
         instance.aws_create_role()
-        instance.helm_create_user()
+        instance.helm_create()
 
     def perform_destroy(self, instance):
         instance.delete()

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -39,6 +39,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         instance = serializer.save()
         instance.aws_create_role()
+        instance.helm_create_user()
 
     def perform_destroy(self, instance):
         instance.delete()


### PR DESCRIPTION
## What

User create now also calls helm init and config.

Unit test switches out subprocess for magicmock to prevent accidental running of helm commands when developing and testing.

Other PRs with env var.

The request time for User create is now around 8 seconds.

_Latest commit shows a different method of patching out live api/process calls.  We will have to patch at class level test cases that interact with apis or system libraries, but by passing `MagicMock()` as the second parameter this stops the behaviour of having to add a parameter to all test functions._

## How to review

1. ./manage.py test
2. Create a User via api and check stdout for helm commands.

https://trello.com/c/QiDTzyob/454-when-a-user-is-created-via-api-we-run-helm-commands-3