### PR TITLE
Create User on auth and map fields from auth0

### DIFF
--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -39,9 +39,14 @@ class Auth0JWTAuthentication(BaseAuthentication):
             raise AuthenticationFailed('JWT missing "sub" field')
 
         try:
-            user = User.objects.get(auth0_id=sub)
+            user = User.objects.get(pk=sub)
 
         except User.DoesNotExist:
-            raise AuthenticationFailed(f'No such user: {sub}')
+            user = User.objects.create(
+                pk=sub,
+                username=decoded.get(settings.OIDC_FIELD_USERNAME),
+                email=decoded.get(settings.OIDC_FIELD_EMAIL),
+                name=decoded.get(settings.OIDC_FIELD_NAME),
+            )
 
         return user, None

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -142,6 +142,9 @@ RAVEN_CONFIG = {
 OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID')
 OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET')
 OIDC_DOMAIN = os.environ.get('OIDC_DOMAIN')
+OIDC_FIELD_USERNAME = 'nickname'
+OIDC_FIELD_EMAIL = 'email'
+OIDC_FIELD_NAME = 'name'
 
 # Helm variables
 NFS_HOSTNAME = os.environ.get('NFS_HOSTNAME')


### PR DESCRIPTION
## What

When a request comes through the auth we create a User if one is not found.  User is already authenticated and filtered from auth0.

Fields are mapped from JWT and auth0 onto our User object.

Currently the request will 403 as we have permissions set to superusers only and here we do not set them as superuser.

Test shows User is created correctly.

**This will require frontend auth0 JS to request the appropriate profile fields using the scope parameter @axemonkey** 

## How to review

1. ./manage.py test

https://trello.com/c/q5R4HQob/450-2-create-user-if-does-not-exist-but-authenticated