### PR TITLE
Users3bucket access level based on is_admin

### DIFF
--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -39,9 +39,14 @@ class Auth0JWTAuthentication(BaseAuthentication):
             raise AuthenticationFailed('JWT missing "sub" field')
 
         try:
-            user = User.objects.get(auth0_id=sub)
+            user = User.objects.get(pk=sub)
 
         except User.DoesNotExist:
-            raise AuthenticationFailed(f'No such user: {sub}')
+            user = User.objects.create(
+                pk=sub,
+                username=decoded.get(settings.OIDC_FIELD_USERNAME),
+                email=decoded.get(settings.OIDC_FIELD_EMAIL),
+                name=decoded.get(settings.OIDC_FIELD_NAME),
+            )
 
         return user, None

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -58,6 +58,7 @@ class UserS3BucketSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserS3Bucket
         fields = ('id', 'url', 'user', 's3bucket', 'access_level', 'is_admin')
+        read_only_fields = ('access_level',)
 
     def update(self, instance, validated_data):
         if instance.user != validated_data['user']:

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -142,6 +142,9 @@ RAVEN_CONFIG = {
 OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID')
 OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET')
 OIDC_DOMAIN = os.environ.get('OIDC_DOMAIN')
+OIDC_FIELD_USERNAME = 'nickname'
+OIDC_FIELD_EMAIL = 'email'
+OIDC_FIELD_NAME = 'name'
 
 # Helm variables
 NFS_HOSTNAME = os.environ.get('NFS_HOSTNAME')

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -276,14 +276,14 @@ class UserS3BucketTestCase(TestCase):
 
         cls.users3bucket_1 = cls.user_1.users3buckets.create(
             s3bucket=cls.s3_bucket_1,
-            access_level=AppS3Bucket.READONLY,
+            is_admin=False,
         )
 
     def test_one_record_per_user_per_s3bucket(self):
         with self.assertRaises(IntegrityError):
             self.user_1.users3buckets.create(
                 s3bucket=self.s3_bucket_1,
-                access_level=UserS3Bucket.READWRITE,
+                is_admin=False,
             )
 
     @patch('control_panel_api.services.attach_bucket_access_to_role')
@@ -304,4 +304,14 @@ class UserS3BucketTestCase(TestCase):
             self.s3_bucket_1.name,
             self.users3bucket_1.has_readwrite_access(),
             self.user_1.iam_role_name
+        )
+
+    @patch('control_panel_api.services.update_bucket_access')
+    def test_update(self, mock_update_bucket_access):
+        self.users3bucket_1.aws_update()
+
+        mock_update_bucket_access.assert_called_with(
+            self.s3_bucket_1.name,
+            self.users3bucket_1.has_readwrite_access(),
+            self.user_1.iam_role_name,
         )


### PR DESCRIPTION
## What

UserS3Bucket access_level should not be editable and should be based on the is_admin flag.

## How to review

1. ./manage.py test
2. Use api to create UserS3Bucket

https://trello.com/c/WuFheSAR/447-confirm-users-assigned-s3-bucket-policy-is-read-only-2