### PR TITLE
On S3Bucket POST create a UserS3Bucket

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -121,6 +121,14 @@ class S3Bucket(TimeStampedModel):
         """Note we do not destroy the actual data, just the policies"""
         services.delete_bucket_policies(self.name)
 
+    def create_users3bucket(self, user):
+        UserS3Bucket.objects.create(
+            user=user,
+            s3bucket=self,
+            is_admin=True,
+            access_level=UserS3Bucket.READWRITE,
+        )
+
 
 class Role(TimeStampedModel):
     name = models.CharField(max_length=256, blank=False, unique=True)

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -432,6 +432,19 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 
         mock_aws_create.assert_called()
 
+        users3bucket = UserS3Bucket.objects.get(
+            user_id=self.superuser.auth0_id,
+            s3bucket_id=response.data['id'],
+        )
+
+        self.assertEqual(
+            self.superuser.auth0_id, users3bucket.user.auth0_id)
+        self.assertEqual(
+            response.data['id'], users3bucket.s3bucket.id)
+        self.assertEqual(
+            UserS3Bucket.READWRITE, users3bucket.access_level)
+        self.assertTrue(users3bucket.is_admin)
+
     def test_create_bad_requests(self):
         fixtures = (
             {'name': self.fixture.name},  # name exists

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -111,6 +111,7 @@ class S3BucketViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         instance = serializer.save(created_by=self.request.user)
         instance.aws_create()
+        instance.create_users3bucket(user=self.request.user)
 
     def perform_destroy(self, instance):
         instance.delete()


### PR DESCRIPTION
## What

An associated UserS3Bucket shuold be created when an S3Bucket is created with `is_admin=True` and `access_level="readwrite"`.

## How to review

1. ./manage.py test

https://trello.com/c/WuFheSAR/447-confirm-users-assigned-s3-bucket-policy-is-read-only-2