### PR TITLE
User serializer changes

### DIFF
--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -56,8 +56,7 @@ class UserS3BucketSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class SimpleAppSerializer(serializers.ModelSerializer):
-
+class AppSimpleSerializer(serializers.ModelSerializer):
     class Meta:
         model = App
         fields = (
@@ -71,25 +70,24 @@ class SimpleAppSerializer(serializers.ModelSerializer):
         )
 
 
-class SimpleS3BucketSerializer(serializers.ModelSerializer):
-
+class S3BucketSimpleSerializer(serializers.ModelSerializer):
     class Meta:
         model = S3Bucket
         fields = ('id', 'url', 'name', 'arn', 'created_by')
 
 
-class AppAppS3BucketSerializer(serializers.ModelSerializer):
+class AppS3BucketNestedInAppSerializer(serializers.ModelSerializer):
     """Used from within with AppSerializer to not expose app"""
-    s3bucket = SimpleS3BucketSerializer()
+    s3bucket = S3BucketSimpleSerializer()
 
     class Meta:
         model = AppS3Bucket
         fields = ('id', 'url', 's3bucket', 'access_level')
 
 
-class S3BucketAppS3BucketSerializer(serializers.ModelSerializer):
+class AppS3BucketNestedInS3BucketSerializer(serializers.ModelSerializer):
     """Used from within with S3BucketSerializer to not expose s3bucket"""
-    app = SimpleAppSerializer()
+    app = AppSimpleSerializer()
 
     class Meta:
         model = AppS3Bucket
@@ -97,8 +95,7 @@ class S3BucketAppS3BucketSerializer(serializers.ModelSerializer):
 
 
 class AppSerializer(serializers.ModelSerializer):
-
-    apps3buckets = AppAppS3BucketSerializer(many=True, read_only=True)
+    apps3buckets = AppS3BucketNestedInAppSerializer(many=True, read_only=True)
 
     class Meta:
         model = App
@@ -120,7 +117,8 @@ class AppSerializer(serializers.ModelSerializer):
 
 
 class S3BucketSerializer(serializers.ModelSerializer):
-    apps3buckets = S3BucketAppS3BucketSerializer(many=True, read_only=True)
+    apps3buckets = AppS3BucketNestedInS3BucketSerializer(
+        many=True, read_only=True)
 
     class Meta:
         model = S3Bucket
@@ -147,22 +145,22 @@ class UserAppSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class UserUserAppSerializer(serializers.ModelSerializer):
+class UserAppNestedInUserSerializer(serializers.ModelSerializer):
     """Used from within with UserSerializer to explicitly expose the app
     but hide the User
     """
-    app = SimpleAppSerializer()
+    app = AppSimpleSerializer()
 
     class Meta:
         model = UserApp
         fields = ('id', 'app', 'is_admin')
 
 
-class UserUserS3BucketSerializer(serializers.ModelSerializer):
+class UserS3BucketNestedInUserSerializer(serializers.ModelSerializer):
     """Used from within with UserSerializer to explicitly expose the s3bucket
     but hide the User
     """
-    s3bucket = SimpleS3BucketSerializer()
+    s3bucket = S3BucketSimpleSerializer()
 
     class Meta:
         model = UserS3Bucket
@@ -170,8 +168,9 @@ class UserUserS3BucketSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
-    userapps = UserUserAppSerializer(many=True, read_only=True)
-    users3buckets = UserUserS3BucketSerializer(many=True, read_only=True)
+    userapps = UserAppNestedInUserSerializer(many=True, read_only=True)
+    users3buckets = UserS3BucketNestedInUserSerializer(
+        many=True, read_only=True)
 
     class Meta:
         model = User

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -144,7 +144,7 @@ class S3BucketSerializer(serializers.ModelSerializer):
         read_only_fields = ('apps3buckets', 'created_by')
 
 
-class AppUserSerializer(serializers.ModelSerializer):
+class UserAppSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UserApp

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -11,22 +11,6 @@ from control_panel_api.models import (
 )
 
 
-class UserSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = User
-        fields = (
-            'auth0_id',
-            'url',
-            'username',
-            'name',
-            'email',
-            'groups',
-            'userapps',
-            'users3buckets'
-        )
-
-
 class GroupSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -161,3 +145,43 @@ class UserAppSerializer(serializers.ModelSerializer):
             )
 
         return super().update(instance, validated_data)
+
+
+class UserUserAppSerializer(serializers.ModelSerializer):
+    """Used from within with UserSerializer to explicitly expose the app
+    but hide the User
+    """
+    app = SimpleAppSerializer()
+
+    class Meta:
+        model = UserApp
+        fields = ('id', 'app', 'is_admin')
+
+
+class UserUserS3BucketSerializer(serializers.ModelSerializer):
+    """Used from within with UserSerializer to explicitly expose the s3bucket
+    but hide the User
+    """
+    s3bucket = SimpleS3BucketSerializer()
+
+    class Meta:
+        model = UserS3Bucket
+        fields = ('id', 's3bucket', 'access_level', 'is_admin')
+
+
+class UserSerializer(serializers.ModelSerializer):
+    userapps = UserUserAppSerializer(many=True, read_only=True)
+    users3buckets = UserUserS3BucketSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = User
+        fields = (
+            'auth0_id',
+            'url',
+            'username',
+            'name',
+            'email',
+            'groups',
+            'userapps',
+            'users3buckets',
+        )

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -20,28 +20,7 @@ from control_panel_api.models import (
 )
 
 
-class AssertionsMixin(object):
-    def assert_s3bucket(self, s3bucket):
-        self.assertIn('id', s3bucket)
-        self.assertIn('url', s3bucket)
-        self.assertIn('name', s3bucket)
-        self.assertIn('arn', s3bucket)
-        self.assertIn('created_by', s3bucket)
-        self.assertEqual(5, len(s3bucket))
-
-    def assert_app(self, app):
-        self.assertIn('id', app)
-        self.assertIn('url', app)
-        self.assertIn('name', app)
-        self.assertIn('slug', app)
-        self.assertIn('repo_url', app)
-        self.assertIn('iam_role_name', app)
-        self.assertIn('created_by', app)
-        self.assertEqual(7, len(app))
-
-
 class AuthenticatedClientMixin(object):
-
     def setUp(self):
         self.superuser = mommy.make(
             'control_panel_api.User', is_superuser=True)
@@ -49,8 +28,7 @@ class AuthenticatedClientMixin(object):
 
 
 @patch('control_panel_api.helm.subprocess.run', MagicMock())
-class UserViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
-
+class UserViewTest(AuthenticatedClientMixin, APITestCase):
     def setUp(self):
         super().setUp()
         self.fixture = mommy.make('control_panel_api.User', auth0_id='github|1')
@@ -66,31 +44,52 @@ class UserViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
         response = self.client.get(
             reverse('user-detail', (self.fixture.auth0_id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
-        self.assertIn('email', response.data)
-        self.assertIn('url', response.data)
-        self.assertIn('username', response.data)
-        self.assertIn('name', response.data)
-        self.assertIn('groups', response.data)
-        self.assertIn('auth0_id', response.data)
-        self.assertIn('userapps', response.data)
-        self.assertIn('users3buckets', response.data)
-        self.assertEqual(8, len(response.data))
+
+        expected_fields = {
+            'auth0_id',
+            'url',
+            'username',
+            'name',
+            'email',
+            'groups',
+            'userapps',
+            'users3buckets',
+        }
+        self.assertEqual(expected_fields, set(response.data))
 
         userapp = response.data['userapps'][0]
-        self.assertIn('id', userapp)
-        self.assertIn('app', userapp)
-        self.assertIn('is_admin', userapp)
-        self.assertEqual(3, len(userapp))
+        expected_fields = {'id', 'app', 'is_admin'}
+        self.assertEqual(
+            expected_fields,
+            set(userapp)
+        )
 
-        self.assert_app(userapp['app'])
+        expected_fields = {
+            'id',
+            'url',
+            'name',
+            'slug',
+            'repo_url',
+            'iam_role_name',
+            'created_by',
+        }
+        self.assertEqual(
+            expected_fields,
+            set(userapp['app'])
+        )
 
         users3bucket = response.data['users3buckets'][0]
-        self.assertIn('id', users3bucket)
-        self.assertIn('s3bucket', users3bucket)
-        self.assertIn('access_level', users3bucket)
-        self.assertEqual(4, len(users3bucket))
+        expected_fields = {'id', 's3bucket', 'access_level', 'is_admin'}
+        self.assertEqual(
+            expected_fields,
+            set(users3bucket)
+        )
 
-        self.assert_s3bucket(users3bucket['s3bucket'])
+        expected_fields = {'id', 'url', 'name', 'arn', 'created_by'}
+        self.assertEqual(
+            expected_fields,
+            set(users3bucket['s3bucket'])
+        )
 
     @patch('control_panel_api.models.User.aws_delete_role')
     def test_delete(self, mock_aws_delete_role):
@@ -125,12 +124,14 @@ class UserViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
         self.assertEqual(data['auth0_id'], response.data['auth0_id'])
 
 
-class AppViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
-
+class AppViewTest(AuthenticatedClientMixin, APITestCase):
     def setUp(self):
         super().setUp()
         mommy.make('control_panel_api.App')
-        self.fixture = mommy.make('control_panel_api.App')
+        self.fixture = mommy.make(
+            'control_panel_api.App',
+            repo_url='https://foo.com'
+        )
         mommy.make('control_panel_api.AppS3Bucket', app=self.fixture)
 
     def test_list(self):
@@ -139,9 +140,6 @@ class AppViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
         self.assertEqual(len(response.data['results']), 2)
 
     def test_list_filter_by_repo_url(self):
-        self.fixture.repo_url = 'https://example.com'
-        self.fixture.save()
-
         params = {'repo_url': self.fixture.repo_url}
         response = self.client.get(reverse('app-list'), params)
 
@@ -153,28 +151,37 @@ class AppViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
     def test_detail(self):
         response = self.client.get(reverse('app-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
-        self.assertIn('id', response.data)
-        self.assertIn('url', response.data)
-        self.assertIn('name', response.data)
-        self.assertIn('slug', response.data)
-        self.assertIn('repo_url', response.data)
-        self.assertIn('apps3buckets', response.data)
-        self.assertIn('userapps', response.data)
-        self.assertIn('created_by', response.data)
+
+        expected_fields = {
+            'id',
+            'url',
+            'name',
+            'slug',
+            'repo_url',
+            'iam_role_name',
+            'created_by',
+            'apps3buckets',
+            'userapps',
+        }
+        self.assertEqual(expected_fields, set(response.data))
+
         self.assertEqual(
             response.data['iam_role_name'],
             self.fixture.iam_role_name,
         )
-        self.assertEqual(9, len(response.data))
 
         apps3bucket = response.data['apps3buckets'][0]
-        self.assertIn('id', apps3bucket)
-        self.assertIn('url', apps3bucket)
-        self.assertIn('s3bucket', apps3bucket)
-        self.assertIn('access_level', apps3bucket)
-        self.assertEqual(4, len(apps3bucket))
+        expected_fields = {'id', 'url', 's3bucket', 'access_level'}
+        self.assertEqual(
+            expected_fields,
+            set(apps3bucket)
+        )
 
-        self.assert_s3bucket(apps3bucket['s3bucket'])
+        expected_fields = {'id', 'url', 'name', 'arn', 'created_by'}
+        self.assertEqual(
+            expected_fields,
+            set(apps3bucket['s3bucket'])
+        )
 
     @patch('control_panel_api.models.App.aws_delete_role')
     def test_delete(self, mock_aws_delete_role):
@@ -189,7 +196,7 @@ class AppViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
 
     @patch('control_panel_api.models.App.aws_create_role')
     def test_create(self, mock_aws_create_role):
-        data = {'name': 'foo', 'repo_url': 'https://example.com'}
+        data = {'name': 'foo', 'repo_url': 'https://example.com.git'}
         response = self.client.post(reverse('app-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
@@ -197,29 +204,18 @@ class AppViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
 
         self.assertEqual(self.superuser.auth0_id, response.data['created_by'])
 
-    def test_create_normalises_repo_url(self):
-        data = {'name': 'foo', 'repo_url': 'https://example.com.git'}
-        response = self.client.post(reverse('app-list'), data)
-        self.assertEqual(HTTP_201_CREATED, response.status_code)
         self.assertEqual('https://example.com', response.data['repo_url'])
 
     def test_update(self):
-        data = {'name': 'foo', 'repo_url': 'http://foo.com'}
-        response = self.client.put(
-            reverse('app-detail', (self.fixture.id,)), data)
-        self.assertEqual(HTTP_200_OK, response.status_code)
-        self.assertEqual(data['name'], response.data['name'])
-
-    def test_update_normalises_repo_url(self):
         data = {'name': 'foo', 'repo_url': 'http://foo.com.git'}
         response = self.client.put(
             reverse('app-detail', (self.fixture.id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertEqual(data['name'], response.data['name'])
         self.assertEqual('http://foo.com', response.data['repo_url'])
 
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
-
     def setUp(self):
         super().setUp()
 
@@ -248,13 +244,18 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(
             reverse('apps3bucket-detail', (self.apps3bucket_1.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
-        self.assertIn('id', response.data)
-        self.assertIn('url', response.data)
-        self.assertIn('app', response.data)
-        self.assertIn('s3bucket', response.data)
-        self.assertIn('access_level', response.data)
-        self.assertEqual('readonly', response.data['access_level'])
-        self.assertEqual(5, len(response.data))
+
+        expected_fields = {
+            'id',
+            'url',
+            'app',
+            's3bucket',
+            'access_level'
+        }
+        self.assertEqual(
+            expected_fields,
+            set(response.data),
+        )
 
     @patch('control_panel_api.models.AppS3Bucket.aws_delete')
     def test_delete(self, mock_aws_delete):
@@ -342,13 +343,11 @@ class UserAppViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(
             reverse('userapp-detail', (self.userapp_1.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
-        self.assertIn('id', response.data)
-        self.assertIn('url', response.data)
-        self.assertIn('app', response.data)
-        self.assertIn('user', response.data)
-        self.assertIn('is_admin', response.data)
+
+        expected_fields = {'id', 'url', 'app', 'user', 'is_admin'}
+        self.assertEqual(expected_fields, set(response.data))
+
         self.assertEqual(True, response.data['is_admin'])
-        self.assertEqual(5, len(response.data))
 
     def test_create(self):
         data = {
@@ -399,8 +398,7 @@ class UserAppViewTest(AuthenticatedClientMixin, APITestCase):
             self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
 
 
-class S3BucketViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
-
+class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
     def setUp(self):
         super().setUp()
         mommy.make('control_panel_api.S3Bucket')
@@ -417,22 +415,37 @@ class S3BucketViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
         response = self.client.get(
             reverse('s3bucket-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
-        self.assertIn('id', response.data)
-        self.assertIn('url', response.data)
-        self.assertIn('name', response.data)
-        self.assertIn('arn', response.data)
-        self.assertIn('apps3buckets', response.data)
-        self.assertIn('created_by', response.data)
-        self.assertEqual(6, len(response.data))
+
+        expected_fields = {
+            'id',
+            'url',
+            'name',
+            'arn',
+            'apps3buckets',
+            'created_by'
+        }
+        self.assertEqual(expected_fields, set(response.data))
 
         apps3bucket = response.data['apps3buckets'][0]
-        self.assertIn('id', apps3bucket)
-        self.assertIn('url', apps3bucket)
-        self.assertIn('app', apps3bucket)
-        self.assertIn('access_level', apps3bucket)
-        self.assertEqual(4, len(apps3bucket))
+        expected_fields = {'id', 'url', 'app', 'access_level'}
+        self.assertEqual(
+            expected_fields,
+            set(apps3bucket)
+        )
 
-        self.assert_app(apps3bucket['app'])
+        expected_fields = {
+            'id',
+            'url',
+            'name',
+            'slug',
+            'repo_url',
+            'iam_role_name',
+            'created_by',
+        }
+        self.assertEqual(
+            expected_fields,
+            set(apps3bucket['app'])
+        )
 
     @patch('control_panel_api.models.S3Bucket.aws_delete')
     def test_delete(self, mock_aws_delete):
@@ -481,10 +494,10 @@ class S3BucketViewTest(AssertionsMixin, AuthenticatedClientMixin, APITestCase):
 class UserS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
     def setUp(self):
         super().setUp()
-        self.user_1 = User.objects.create(auth0_id='github|1',
-                                          username="user-1")
-        self.user_2 = User.objects.create(auth0_id='github|2',
-                                          username="user-2")
+        self.user_1 = User.objects.create(
+            auth0_id='github|1', username="user-1")
+        self.user_2 = User.objects.create(
+            auth0_id='github|2', username="user-2")
         self.s3_bucket_1 = S3Bucket.objects.create(name="test-bucket-1")
         self.s3_bucket_2 = S3Bucket.objects.create(name="test-bucket-2")
         self.users3bucket_1 = self.user_1.users3buckets.create(
@@ -501,14 +514,20 @@ class UserS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         response = self.client.get(
             reverse('users3bucket-detail', (self.users3bucket_1.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
-        self.assertIn('id', response.data)
-        self.assertIn('url', response.data)
-        self.assertIn('user', response.data)
-        self.assertIn('s3bucket', response.data)
-        self.assertIn('access_level', response.data)
-        self.assertIn('is_admin', response.data)
+
+        expected_fields = {
+            'id',
+            'url',
+            'user',
+            's3bucket',
+            'access_level',
+            'is_admin'
+        }
+        self.assertEqual(
+            expected_fields,
+            set(response.data)
+        )
         self.assertEqual('readonly', response.data['access_level'])
-        self.assertEqual(6, len(response.data))
 
     @patch('control_panel_api.models.UserS3Bucket.aws_create')
     def test_create(self, mock_aws_create):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -22,7 +22,7 @@ from control_panel_api.permissions import (
 from control_panel_api.serializers import (
     AppS3BucketSerializer,
     AppSerializer,
-    AppUserSerializer,
+    UserAppSerializer,
     GroupSerializer,
     S3BucketSerializer,
     UserS3BucketSerializer,
@@ -119,4 +119,4 @@ class S3BucketViewSet(viewsets.ModelViewSet):
 
 class UserAppViewSet(viewsets.ModelViewSet):
     queryset = UserApp.objects.all()
-    serializer_class = AppUserSerializer
+    serializer_class = UserAppSerializer


### PR DESCRIPTION
## What

Nested related data is now exposed on User for the frontend.  Create custom explicit serializers that hide the nested User field to prevent data duplication, nesting and recursion.

Refactored tests slightly for a shared assertion.

## How to review

1. ./manage.py test
2. Make a request using swagger.

https://trello.com/c/GjaFQjvn/463-user-needs-the-s3bucket-nested-data-similiar-to-app-and-s3bucket-work-1