### PR TITLE
Fix repo name and add test to cover bug

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -78,11 +78,15 @@ class App(TimeStampedModel):
         "https://github.com/org/a_repo_name" => "a_repo_name"
         "git@github.com:org/repo_2.git" => "repo_2"
         """
-        last_after_slash = self.repo_url \
-            .rstrip('/') \
-            .replace('.git', '') \
-            .rsplit('/', 1)[1]
-        return last_after_slash
+        repo_name = self.repo_url
+
+        if repo_name.endswith('/'):
+            repo_name = repo_name[:-1]
+
+        if repo_name.endswith('.git'):
+            repo_name = repo_name[:-4]
+
+        return repo_name.rsplit('/', 1)[1]
 
 
 class UserApp(TimeStampedModel):

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -68,8 +68,7 @@ class App(TimeStampedModel):
 
     @property
     def _repo_name(self):
-        '''
-        Returns the repo name
+        """Returns the repo name
 
         The name is the part after the last slash in the URL, without
         the '.git' (if present).
@@ -78,10 +77,12 @@ class App(TimeStampedModel):
 
         "https://github.com/org/a_repo_name" => "a_repo_name"
         "git@github.com:org/repo_2.git" => "repo_2"
-        '''
-
-        last_after_slash = self.repo_url.split('/')[-1]
-        return last_after_slash.replace('.git', '')
+        """
+        last_after_slash = self.repo_url \
+            .rstrip('/') \
+            .replace('.git', '') \
+            .rsplit('/', 1)[1]
+        return last_after_slash
 
 
 class UserApp(TimeStampedModel):

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -197,11 +197,9 @@ class S3BucketTestCase(TestCase):
 class AppS3BucketTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        # Apps
-        cls.app_1 = App.objects.create(name="app_1")
-
-        # S3 buckets
-        cls.s3_bucket_1 = S3Bucket.objects.create(name="test-bucket-1")
+        cls.app_1 = mommy.make('control_panel_api.App', name="app_1")
+        cls.s3_bucket_1 = mommy.make(
+            'control_panel_api.S3Bucket', name="test-bucket-1")
 
     def test_one_record_per_app_per_s3bucket(self):
         # Give app_1 access to bucket_1 (read-only)
@@ -261,6 +259,25 @@ class AppS3BucketTestCase(TestCase):
             apps3bucket.has_readwrite_access(),
             self.app_1.iam_role_name
         )
+
+    def test_repo_name(self):
+        app = mommy.prepare(
+            'control_panel_api.App',
+            repo_url='https://github.com/org/a_repo_name'
+        )
+        self.assertEqual('a_repo_name', app._repo_name)
+
+        app.repo_url = 'git@github.com:org/repo_2.git'
+        self.assertEqual('repo_2', app._repo_name)
+
+        app.repo_url = 'https://github.com/org/a_repo_name/'
+        self.assertEqual('a_repo_name', app._repo_name)
+
+        app.repo_url = 'http://foo.com'
+        self.assertEqual('foo.com', app._repo_name)
+
+        app.repo_url = 'http://foo.com/'
+        self.assertEqual('foo.com', app._repo_name)
 
 
 class UserS3BucketTestCase(TestCase):

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -266,6 +266,7 @@ class AppS3BucketTestCase(TestCase):
         url_test_cases = (
             ('https://github.com/org/a_repo_name', 'a_repo_name'),
             ('git@github.com:org/repo_2.git', 'repo_2'),
+            ('https://github.com/org/a_repo_name.git/', 'a_repo_name'),
             ('https://github.com/org/a_repo_name/', 'a_repo_name'),
             ('http://foo.com', 'foo.com'),
             ('http://foo.com/', 'foo.com'),

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -261,23 +261,19 @@ class AppS3BucketTestCase(TestCase):
         )
 
     def test_repo_name(self):
-        app = mommy.prepare(
-            'control_panel_api.App',
-            repo_url='https://github.com/org/a_repo_name'
+        app = mommy.prepare('control_panel_api.App')
+
+        url_test_cases = (
+            ('https://github.com/org/a_repo_name', 'a_repo_name'),
+            ('git@github.com:org/repo_2.git', 'repo_2'),
+            ('https://github.com/org/a_repo_name/', 'a_repo_name'),
+            ('http://foo.com', 'foo.com'),
+            ('http://foo.com/', 'foo.com'),
         )
-        self.assertEqual('a_repo_name', app._repo_name)
 
-        app.repo_url = 'git@github.com:org/repo_2.git'
-        self.assertEqual('repo_2', app._repo_name)
-
-        app.repo_url = 'https://github.com/org/a_repo_name/'
-        self.assertEqual('a_repo_name', app._repo_name)
-
-        app.repo_url = 'http://foo.com'
-        self.assertEqual('foo.com', app._repo_name)
-
-        app.repo_url = 'http://foo.com/'
-        self.assertEqual('foo.com', app._repo_name)
+        for url, expected in url_test_cases:
+            app.repo_url = url
+            self.assertEqual(expected, app._repo_name)
 
 
 class UserS3BucketTestCase(TestCase):

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -78,8 +78,9 @@ class ServicesTestCase(TestCase):
 
     @patch('control_panel_api.aws.attach_policy_to_role')
     def test_apps3bucket_create(self, mock_attach_policy_to_role):
-        app = App.objects.create(slug='appslug')
-        s3bucket = S3Bucket.objects.create(name='test-bucketname')
+        app = mommy.make('control_panel_api.App', slug='appslug')
+        s3bucket = mommy.make(
+            'control_panel_api.S3Bucket', name='test-bucketname')
 
         for access_level in ['readonly', 'readwrite']:
             apps3bucket, _ = AppS3Bucket.objects.update_or_create(
@@ -108,8 +109,9 @@ class ServicesTestCase(TestCase):
     def test_apps3bucket_update(self,
             mock_detach_policy_from_role,
             mock_attach_policy_to_role):
-        app = App.objects.create(slug='appslug')
-        s3bucket = S3Bucket.objects.create(name='test-bucketname')
+        app = mommy.make('control_panel_api.App', slug='appslug')
+        s3bucket = mommy.make(
+            'control_panel_api.S3Bucket', name='test-bucketname')
 
         app_role_name = f'test_app_{app.slug}'
 


### PR DESCRIPTION
## What

Fixes bug with empty string being returned when url has trailing slash.

Fix tests to use mommy so valid repo urls are created during test

## How to review

1. Run tests

https://trello.com/c/aQbbFCqu/464-cp-api-handle-trailing-slash-in-apprepourl-1