### PR TITLE
Expose S3Bucket's users3buckets as in the other serializers

### DIFF
--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -133,8 +133,8 @@ class UserSimpleSerializer(serializers.ModelSerializer):
 
 class UserS3BucketNestedInS3BucketSerializer(serializers.ModelSerializer):
     """
-    Used from within with S3BucketSerializer to explicitly expose the
-    user but not the s3bucket
+    Serializer for `UserS3Bucket`s used within S3Bucket serializer.
+    It exposes the `user` but not the `s3bucket` (which is the parent)
     """
     user = UserSimpleSerializer()
 

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -57,6 +57,7 @@ class UserS3BucketSerializer(serializers.ModelSerializer):
 
 
 class AppSimpleSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = App
         fields = (
@@ -71,6 +72,7 @@ class AppSimpleSerializer(serializers.ModelSerializer):
 
 
 class S3BucketSimpleSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = S3Bucket
         fields = ('id', 'url', 'name', 'arn', 'created_by')
@@ -116,14 +118,42 @@ class AppSerializer(serializers.ModelSerializer):
         return value.rsplit(".git", 1)[0]
 
 
+class UserSimpleSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = User
+        fields = (
+            'auth0_id',
+            'url',
+            'username',
+            'name',
+            'email',
+        )
+
+
+class UserS3BucketNestedInS3BucketSerializer(serializers.ModelSerializer):
+    """
+    Used from within with S3BucketSerializer to explicitly expose the
+    user but not the s3bucket
+    """
+    user = UserSimpleSerializer()
+
+    class Meta:
+        model = UserS3Bucket
+        fields = ('id', 'user', 'access_level', 'is_admin')
+
+
 class S3BucketSerializer(serializers.ModelSerializer):
     apps3buckets = AppS3BucketNestedInS3BucketSerializer(
+        many=True, read_only=True)
+    users3buckets = UserS3BucketNestedInS3BucketSerializer(
         many=True, read_only=True)
 
     class Meta:
         model = S3Bucket
-        fields = ('id', 'url', 'name', 'arn', 'apps3buckets', 'created_by')
-        read_only_fields = ('apps3buckets', 'created_by')
+        fields = ('id', 'url', 'name', 'arn', 'apps3buckets',
+                  'users3buckets', 'created_by')
+        read_only_fields = ('apps3buckets', 'users3buckets', 'created_by')
 
 
 class UserAppSerializer(serializers.ModelSerializer):

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -405,6 +405,7 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         self.fixture = mommy.make(
             'control_panel_api.S3Bucket', name='test-bucket-1')
         mommy.make('control_panel_api.AppS3Bucket', s3bucket=self.fixture)
+        mommy.make('control_panel_api.UserS3Bucket', s3bucket=self.fixture)
 
     def test_list(self):
         response = self.client.get(reverse('s3bucket-list'))
@@ -416,24 +417,25 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             reverse('s3bucket-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
 
-        expected_fields = {
+        expected_s3bucket_fields = {
             'id',
             'url',
             'name',
             'arn',
             'apps3buckets',
+            'users3buckets',
             'created_by'
         }
-        self.assertEqual(expected_fields, set(response.data))
+        self.assertEqual(expected_s3bucket_fields, set(response.data))
 
         apps3bucket = response.data['apps3buckets'][0]
-        expected_fields = {'id', 'url', 'app', 'access_level'}
+        expected_apps3bucket_fields = {'id', 'url', 'app', 'access_level'}
         self.assertEqual(
-            expected_fields,
+            expected_apps3bucket_fields,
             set(apps3bucket)
         )
 
-        expected_fields = {
+        expected_app_fields = {
             'id',
             'url',
             'name',
@@ -443,8 +445,27 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             'created_by',
         }
         self.assertEqual(
-            expected_fields,
+            expected_app_fields,
             set(apps3bucket['app'])
+        )
+
+        users3bucket = response.data['users3buckets'][0]
+        expected_users3bucket_fields = {'id', 'user', 'access_level', 'is_admin'}
+        self.assertEqual(
+            expected_users3bucket_fields,
+            set(users3bucket)
+        )
+
+        expected_user_fields = {
+            'auth0_id',
+            'url',
+            'username',
+            'name',
+            'email',
+        }
+        self.assertEqual(
+            expected_user_fields,
+            set(users3bucket['user'])
         )
 
     @patch('control_panel_api.models.S3Bucket.aws_delete')


### PR DESCRIPTION
### What
This is needed by the UI to filter out (in the form) users that
already have access to this S3 bucket.

### Why
This is required by the UI:
 - UI needs to show users that already have access to S3 bucket (`users3buckets` association of the S3 bucket)
- UI displays a form with list of users who *do not* already have access to this S3 bucket. In order to generate this list we need to know which users already have access to it (again this is in the `users3buckets` association).

### Part of ticket
https://trello.com/c/hgdqE4dG/471-cp-api-present-s3bucketusers3buckets-as-in-other-endpoints-4
