### PR TITLE
Allow disabling writes to cluster with an environment variable

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -1,106 +1,109 @@
 import json
 
+import boto3
+
 from django.conf import settings
 
 
-aws_api_client = settings.AWS_API_CLIENT_HANDLER
+class AWSClient(object):
+
+    def __init__(self):
+        self.enabled = settings.ENABLED['write_to_cluster']
+        self.client = boto3.client
+
+    def _do(self, service, method, **kwargs):
+        if self.enabled:
+            client = self.client(service)
+            return getattr(client, method)(**kwargs)
+
+    def create_bucket(self, name, region, acl='private'):
+        self._do('s3', 'create_bucket',
+            Bucket=name,
+            ACL=acl,
+            CreateBucketConfiguration={'LocationConstraint': region})
+
+    def put_bucket_logging(self, name, target_bucket, target_prefix):
+        self._do('s3', 'put_bucket_logging',
+            Bucket=name,
+            BucketLoggingStatus={
+                'LoggingEnabled': {
+                    'TargetBucket': target_bucket,
+                    'TargetPrefix': target_prefix
+                }
+            })
+
+    def create_policy(self, name, policy_document):
+        self._do('iam', 'create_policy',
+            PolicyName=name,
+            PolicyDocument=json.dumps(policy_document))
+
+    def delete_policy(self, policy_arn):
+        self._do('iam', 'delete_policy', PolicyArn=policy_arn)
+
+    def create_role(self, role_name, assume_role_policy):
+        """Creates IAM role with the given name"""
+
+        self._do('iam', 'create_role',
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(assume_role_policy))
+
+    def delete_role(self, role_name):
+        """Delete the given IAM role."""
+
+        self._detach_role_policies(role_name)
+        self._do('iam', 'delete_role', RoleName=role_name)
+
+    def _detach_role_policies(self, role_name):
+        """Detaches all the policies from the given role"""
+
+        policies = self._do(
+            'iam', 'list_attached_role_policies', RoleName=role_name)
+
+        if policies:
+            for policy in policies["AttachedPolicies"]:
+                self.detach_policy_from_role(
+                    role_name=role_name,
+                    policy_arn=policy["PolicyArn"]
+                )
+
+    def detach_policy_from_entities(self, policy_arn):
+        """
+        Get all entities to which policy is attached first then call separate
+        detach operations
+        """
+        entities = self._do(
+            'iam', 'list_entities_for_policy', PolicyArn=policy_arn)
+
+        if entities:
+
+            for role in entities["PolicyRoles"]:
+                self.detach_policy_from_role(policy_arn, role["RoleName"])
+
+            for group in entities["PolicyGroups"]:
+                self.detach_policy_from_group(policy_arn, group["GroupName"])
+
+            for user in entities["PolicyUsers"]:
+                self.detach_policy_from_user(policy_arn, user["UserName"])
+
+    def attach_policy_to_role(self, policy_arn, role_name):
+        self._do('iam', 'attach_role_policy',
+            RoleName=role_name,
+            PolicyArn=policy_arn)
+
+    def detach_policy_from_role(self, policy_arn, role_name):
+        self._do('iam', 'detach_role_policy',
+            RoleName=role_name,
+            PolicyArn=policy_arn)
+
+    def detach_policy_from_group(self, policy_arn, group_name):
+        self._do('iam', 'detach_group_policy',
+            GroupName=group_name,
+            PolicyArn=policy_arn)
+
+    def detach_policy_from_user(self, policy_arn, user_name):
+        self._do('iam', 'detach_user_policy',
+            UserName=user_name,
+            PolicyArn=policy_arn)
 
 
-def create_bucket(name, region, acl='private'):
-    aws_api_client('s3').create_bucket(
-        Bucket=name,
-        ACL=acl,
-        CreateBucketConfiguration={'LocationConstraint': region},
-    )
-
-
-def put_bucket_logging(name, target_bucket, target_prefix):
-    aws_api_client('s3').put_bucket_logging(
-        Bucket=name,
-        BucketLoggingStatus={
-            'LoggingEnabled': {
-                'TargetBucket': target_bucket,
-                'TargetPrefix': target_prefix
-            }
-        }
-    )
-
-
-def create_policy(name, policy_document):
-    aws_api_client("iam").create_policy(
-        PolicyName=name,
-        PolicyDocument=json.dumps(policy_document)
-    )
-
-
-def delete_policy(policy_arn):
-    aws_api_client("iam").delete_policy(PolicyArn=policy_arn)
-
-
-def create_role(role_name, assume_role_policy):
-    """Creates IAM role with the given name"""
-
-    aws_api_client("iam").create_role(
-        RoleName=role_name,
-        AssumeRolePolicyDocument=json.dumps(assume_role_policy)
-    )
-
-
-def delete_role(role_name):
-    """Delete the given IAM role."""
-
-    _detach_role_policies(role_name)
-    aws_api_client("iam").delete_role(RoleName=role_name)
-
-
-def _detach_role_policies(role_name):
-    """Detaches all the policies from the given role"""
-
-    policies = aws_api_client("iam").list_attached_role_policies(RoleName=role_name)
-    for policy in policies["AttachedPolicies"]:
-        detach_policy_from_role(
-            role_name=role_name,
-            policy_arn=policy["PolicyArn"],
-        )
-
-
-def detach_policy_from_entities(policy_arn):
-    """Get all entities to which policy is attached first then call separate detach operations"""
-    entities = aws_api_client("iam").list_entities_for_policy(PolicyArn=policy_arn)
-
-    for role in entities["PolicyRoles"]:
-        detach_policy_from_role(policy_arn, role["RoleName"])
-
-    for group in entities["PolicyGroups"]:
-        detach_policy_from_group(policy_arn, group["GroupName"])
-
-    for user in entities["PolicyUsers"]:
-        detach_policy_from_user(policy_arn, user["UserName"])
-
-
-def attach_policy_to_role(policy_arn, role_name):
-    aws_api_client("iam").attach_role_policy(
-        RoleName=role_name,
-        PolicyArn=policy_arn,
-    )
-
-
-def detach_policy_from_role(policy_arn, role_name):
-    aws_api_client("iam").detach_role_policy(
-        RoleName=role_name,
-        PolicyArn=policy_arn,
-    )
-
-
-def detach_policy_from_group(policy_arn, group_name):
-    aws_api_client("iam").detach_group_policy(
-        GroupName=group_name,
-        PolicyArn=policy_arn,
-    )
-
-
-def detach_policy_from_user(policy_arn, user_name):
-    aws_api_client("iam").detach_user_policy(
-        UserName=user_name,
-        PolicyArn=policy_arn,
-    )
+aws = AWSClient()

--- a/control_panel_api/helm.py
+++ b/control_panel_api/helm.py
@@ -3,28 +3,37 @@ import subprocess
 from django.conf import settings
 
 
-def init_user(username, email, fullname):
-    helm_upgrade(
-        f'init-user-{username}',
-        'mojanalytics/init-user',
-        '--set', f'NFSHostname={settings.NFS_HOSTNAME}',
-        '--set', f'Username={username}',
-        '--set', f'Email={email}',
-        '--set', f'Fullname={fullname}',
-    )
+class Helm(object):
+
+    def __init__(self):
+        self.enabled = settings.ENABLED['write_to_cluster']
+
+    def _helm_command(self, command, *args):
+        if self.enabled:
+            subprocess.run(['helm', command] + list(args), check=True)
+
+    def upgrade_release(self, release, chart, *args):
+        default_flags = ['--install', '--wait']
+        flags = list(args) + default_flags
+        self._helm_command('upgrade', release, chart, *flags)
+
+    def init_user(self, username, email, fullname):
+        self.upgrade_release(
+            f'init-user-{username}',
+            'mojanalytics/init-user',
+            '--set', f'NFSHostname={settings.NFS_HOSTNAME}',
+            '--set', f'Username={username}',
+            '--set', f'Email={email}',
+            '--set', f'Fullname={fullname}',
+        )
+
+    def config_user(self, username):
+        self.upgrade_release(
+            f'config-user-{username}',
+            'mojanalytics/config-user',
+            '--namespace', f'user-{username}',
+            '--set', f'Username={username}',
+        )
 
 
-def config_user(username):
-    helm_upgrade(
-        f'config-user-{username}',
-        'mojanalytics/config-user',
-        '--namespace', f'user-{username}',
-        '--set', f'Username={username}',
-    )
-
-
-def helm_upgrade(release, chart, *flags):
-    default_flags = ['--install', '--wait']
-    flags = list(flags) + default_flags
-    subprocess.run(
-        ['helm', 'upgrade', release, chart] + flags, check=True)
+helm = Helm()

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -7,7 +7,8 @@ from django.template.defaultfilters import slugify
 from django_extensions.db.fields import AutoSlugField
 from django_extensions.db.models import TimeStampedModel
 
-from control_panel_api import helm, services, validators
+from control_panel_api import services, validators
+from control_panel_api.helm import helm
 
 
 class User(AbstractUser):

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from . import aws
+from .aws import aws
 
 READWRITE = 'readwrite'
 READONLY = 'readonly'

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -1,6 +1,15 @@
 import os
 
-import boto3
+
+def is_enabled(value):
+    return str(value).lower() not in ('n', 'no', 'off', 'false', '0')
+
+
+# These are boolean flags to enable/disable features in the API
+ENABLED = {
+    'write_to_cluster':
+        is_enabled(os.environ.get('ENABLE_WRITE_TO_CLUSTER', True)),
+}
 
 SECRET_KEY = os.environ.get(
     'SECRET_KEY',
@@ -132,7 +141,6 @@ LOGS_BUCKET_NAME = os.environ.get('LOGS_BUCKET_NAME', 'moj-analytics-s3-logs')
 IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', '')
 K8S_WORKER_ROLE_NAME = os.environ.get('K8S_WORKER_ROLE_NAME', '')
 SAML_PROVIDER = os.environ.get('SAML_PROVIDER', '')
-AWS_API_CLIENT_HANDLER = boto3.client
 
 RAVEN_CONFIG = {
     'dsn': os.environ.get('SENTRY_DSN', ''),

--- a/control_panel_api/settings/test.py
+++ b/control_panel_api/settings/test.py
@@ -1,9 +1,7 @@
 from .base import *
-from unittest.mock import MagicMock
 
 
 ENV = 'test'
-AWS_API_CLIENT_HANDLER = MagicMock()
 BUCKET_REGION = 'eu-test-2'
 LOGS_BUCKET_NAME = 'moj-test-logs'
 IAM_ARN_BASE = 'arn:aws:iam::123'

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -1,35 +1,35 @@
 import json
 
 from unittest.case import TestCase
-from unittest.mock import call
+from unittest.mock import MagicMock, call, patch
 
-from control_panel_api import aws
-from control_panel_api.aws import aws_api_client
+from control_panel_api.aws import aws
 
 
+@patch.object(aws, 'client', MagicMock())
 class AwsTestCase(TestCase):
 
     def test_create_bucket(self):
         aws.create_bucket('bucketname', 'eu-west-1')
-        aws_api_client.return_value.create_bucket.assert_called()
+        aws.client.return_value.create_bucket.assert_called()
 
     def test_put_bucket_logging(self):
         aws.put_bucket_logging('bucketname', 'target_bucket', 'target_prefix')
-        aws_api_client.return_value.put_bucket_logging.assert_called()
+        aws.client.return_value.put_bucket_logging.assert_called()
 
     def test_create_policy_json_encoded(self):
         aws.create_policy('bucketname', {'foo': 'bar'})
-        aws_api_client.return_value.create_policy.assert_called_with(
+        aws.client.return_value.create_policy.assert_called_with(
             PolicyName='bucketname',
             PolicyDocument='{"foo": "bar"}'
         )
 
     def test_delete_policy(self):
         aws.delete_policy('policyarn')
-        aws_api_client.return_value.delete_policy.assert_called()
+        aws.client.return_value.delete_policy.assert_called()
 
     def test_detach_policy_from_entities(self):
-        aws_api_client.return_value.list_entities_for_policy.return_value = {
+        aws.client.return_value.list_entities_for_policy.return_value = {
             'PolicyRoles': [{'RoleName': 'foo'}],
             'PolicyGroups': [{'GroupName': 'bar'}],
             'PolicyUsers': [{'UserName': 'baz'}],
@@ -37,38 +37,38 @@ class AwsTestCase(TestCase):
 
         aws.detach_policy_from_entities('policyarn')
 
-        aws_api_client.return_value.list_entities_for_policy.assert_called()
-        aws_api_client.return_value.detach_role_policy.assert_called_with(
+        aws.client.return_value.list_entities_for_policy.assert_called()
+        aws.client.return_value.detach_role_policy.assert_called_with(
             RoleName='foo',
             PolicyArn='policyarn',
         )
-        aws_api_client.return_value.detach_group_policy.assert_called_with(
+        aws.client.return_value.detach_group_policy.assert_called_with(
             GroupName='bar',
             PolicyArn='policyarn',
         )
-        aws_api_client.return_value.detach_user_policy.assert_called_with(
+        aws.client.return_value.detach_user_policy.assert_called_with(
             UserName='baz',
             PolicyArn='policyarn',
         )
 
     def test_attach_policy_to_role(self):
         aws.attach_policy_to_role('policyarn', 'rolename')
-        aws_api_client.return_value.attach_role_policy.assert_called_with(
+        aws.client.return_value.attach_role_policy.assert_called_with(
             RoleName='rolename',
             PolicyArn='policyarn',
         )
 
     def test_detach_policy_from_role(self):
         aws.detach_policy_from_role('policyarn', 'foo')
-        aws_api_client.return_value.detach_role_policy.assert_called()
+        aws.client.return_value.detach_role_policy.assert_called()
 
     def test_detach_policy_from_group(self):
         aws.detach_policy_from_group('policyarn', 'foo')
-        aws_api_client.return_value.detach_group_policy.assert_called()
+        aws.client.return_value.detach_group_policy.assert_called()
 
     def test_detach_policy_from_user(self):
         aws.detach_policy_from_user('policyarn', 'foo')
-        aws_api_client.return_value.detach_user_policy.assert_called()
+        aws.client.return_value.detach_user_policy.assert_called()
 
     def test_create_role(self):
         role_name = "a_role"
@@ -76,13 +76,13 @@ class AwsTestCase(TestCase):
 
         aws.create_role(role_name, assume_role_policy)
 
-        aws_api_client.return_value.create_role.assert_called_with(
+        aws.client.return_value.create_role.assert_called_with(
             RoleName=role_name,
             AssumeRolePolicyDocument=json.dumps(assume_role_policy),
         )
 
     def test_delete_role(self):
-        aws_api_client.return_value.list_attached_role_policies.return_value = {
+        aws.client.return_value.list_attached_role_policies.return_value = {
             "AttachedPolicies": [
                 {"PolicyArn": "arn_1"},
                 {"PolicyArn": "arn_2"},
@@ -98,10 +98,10 @@ class AwsTestCase(TestCase):
         ]
 
         # Check policies are detached from role
-        aws_api_client.return_value.detach_role_policy.assert_has_calls(
+        aws.client.return_value.detach_role_policy.assert_has_calls(
             expected_detach_calls)
 
         # Check role is deleted
-        aws_api_client.return_value.delete_role.assert_called_with(
+        aws.client.return_value.delete_role.assert_called_with(
             RoleName=role_name,
         )

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -10,13 +10,17 @@ from rest_framework.status import (
 )
 from rest_framework.test import APITestCase
 
+from control_panel_api.aws import aws
+from control_panel_api.helm import helm
 from control_panel_api.models import AppS3Bucket
 
 
-@patch('control_panel_api.helm.subprocess.run', MagicMock())
+@patch.object(aws, 'client', MagicMock())
+@patch.object(helm, '_helm_command', MagicMock())
 class UserPermissionsTest(APITestCase):
 
     def setUp(self):
+        super().setUp()
         self.superuser = mommy.make(
             'control_panel_api.User',
             auth0_id='github|user_1',
@@ -99,9 +103,11 @@ class UserPermissionsTest(APITestCase):
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
+@patch.object(aws, 'client', MagicMock())
 class AppPermissionsTest(APITestCase):
 
     def setUp(self):
+        super().setUp()
         # Create users
         self.superuser = mommy.make(
             'control_panel_api.User', is_superuser=True)
@@ -184,9 +190,11 @@ class AppPermissionsTest(APITestCase):
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
+@patch.object(aws, 'client', MagicMock())
 class AppS3BucketPermissionsTest(APITestCase):
 
     def setUp(self):
+        super().setUp()
         # Create users
         self.superuser = mommy.make(
             "control_panel_api.User", is_superuser=True)
@@ -293,9 +301,11 @@ class AppS3BucketPermissionsTest(APITestCase):
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
+@patch.object(aws, 'client', MagicMock())
 class S3BucketPermissionsTest(APITestCase):
 
     def setUp(self):
+        super().setUp()
         # Create users
         self.superuser = mommy.make(
             'control_panel_api.User', is_superuser=True)

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -11,6 +11,7 @@ from rest_framework.status import (
 )
 from rest_framework.test import APITestCase
 
+from control_panel_api.aws import aws
 from control_panel_api.models import (
     AppS3Bucket,
     S3Bucket,
@@ -21,14 +22,16 @@ from control_panel_api.models import (
 
 
 class AuthenticatedClientMixin(object):
+
     def setUp(self):
         self.superuser = mommy.make(
             'control_panel_api.User', is_superuser=True)
         self.client.force_login(self.superuser)
+        super().setUp()
 
 
-@patch('control_panel_api.helm.subprocess.run', MagicMock())
 class UserViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super().setUp()
         self.fixture = mommy.make('control_panel_api.User', auth0_id='github|1')
@@ -106,7 +109,8 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
     @patch('control_panel_api.models.User.helm_create')
     @patch('control_panel_api.models.User.aws_create_role')
     def test_create(self, mock_aws_create_role, mock_helm_create_user):
-        data = {'auth0_id': 'github|2', 'username': 'foo'}
+        username = 'foo'
+        data = {'auth0_id': 'github|2', 'username': username}
         response = self.client.post(reverse('user-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
@@ -125,6 +129,7 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
 
 
 class AppViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super().setUp()
         mommy.make('control_panel_api.App')
@@ -216,6 +221,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super().setUp()
 
@@ -316,6 +322,7 @@ class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 
 
 class UserAppViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super().setUp()
 
@@ -398,7 +405,9 @@ class UserAppViewTest(AuthenticatedClientMixin, APITestCase):
             self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
 
 
+@patch.object(aws, 'client', MagicMock())
 class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super().setUp()
         mommy.make('control_panel_api.S3Bucket')
@@ -450,7 +459,8 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         )
 
         users3bucket = response.data['users3buckets'][0]
-        expected_users3bucket_fields = {'id', 'user', 'access_level', 'is_admin'}
+        expected_users3bucket_fields = {
+            'id', 'user', 'access_level', 'is_admin'}
         self.assertEqual(
             expected_users3bucket_fields,
             set(users3bucket)
@@ -526,6 +536,7 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
 
 
 class UserS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
+
     def setUp(self):
         super().setUp()
         self.user_1 = User.objects.create(


### PR DESCRIPTION
## What

* Added setting dictionary `ENABLED` for feature flags
* Added `write_to_cluster` feature flag, taking value from `ENABLE_WRITE_TO_CLUSTER` environment variable (default `True`), to allow disabling AWS calls and Helm commands in development (or for other reasons)
* Refactored AWS and Helm client modules and calling code to honour feature flag
* Refactored tests to mock AWS and Helm clients

## How to review

1. Set `ENABLE_WRITE_TO_CLUSTER` to a falsey value (eg: `False` or `0`)
2. `docker-compose up`
3. Create a user:
    ```shell
    docker-compose exec app python3 manage.py shell
    ```
    then
    ```python
    from control_panel_api.models import User
    user = User.objects.create(username='test-user', auth0_id='github|12345')
    user.save()
    ```
4. See that the user is not created in the cluster and no AWS API calls are made

See [Trello #476](https://trello.com/c/ECksDteJ)