### PR TITLE
Handle aws and helm errors and add transaction support

### DIFF
--- a/control_panel_api/exceptions.py
+++ b/control_panel_api/exceptions.py
@@ -1,0 +1,13 @@
+from rest_framework.exceptions import APIException
+
+
+class AWSException(APIException):
+    status_code = 500
+    default_detail = 'There was an error with AWS'
+    default_code = 'aws_error'
+
+
+class HelmException(APIException):
+    status_code = 500
+    default_detail = 'There was an error with Helm'
+    default_code = 'helm_error'

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -15,13 +15,16 @@ def ignore_existing(func):
     """Decorates a function to catch and allow exceptions that are thrown for
     existing entities or already created buckets etc, and reraise all others
     """
-    e_names = 'BucketAlreadyOwnedByYou', 'EntityAlreadyExistsException'
+    exception_names = (
+        'BucketAlreadyOwnedByYou',
+        'EntityAlreadyExistsException'
+    )
 
     def inner(*args, **kwargs):
         try:
             func(*args, **kwargs)
         except ClientError as e:
-            if e.__class__.__name__ not in e_names:
+            if e.__class__.__name__ not in exception_names:
                 raise e
 
             logger.error(f"Caught aws exception and ignored: {e}")

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -134,11 +134,10 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(data['username'], response.data['username'])
         self.assertEqual(data['auth0_id'], response.data['auth0_id'])
 
-    @patch('control_panel_api.models.User.aws_delete_role')
     @patch('control_panel_api.models.User.helm_create')
     @patch('control_panel_api.models.User.aws_create_role')
     def test_aws_error_and_transaction(self, mock_aws_create_role,
-                                       mock_helm_create, mock_aws_delete_role):
+                                       mock_helm_create):
         mock_helm_create.side_effect = CalledProcessError(1, 'foo error')
 
         data = {'auth0_id': 'github|3', 'username': 'foo'}
@@ -146,7 +145,6 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(HTTP_500_INTERNAL_SERVER_ERROR, response.status_code)
 
         mock_aws_create_role.assert_called()
-        mock_aws_delete_role.assert_called()
 
         with self.assertRaises(User.DoesNotExist):
             User.objects.get(name=data['auth0_id'])

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -56,7 +56,6 @@ class UserViewSet(viewsets.ModelViewSet):
             raise AWSException
         except CalledProcessError as e:
             logger.error(e)
-            instance.aws_delete_role()
             raise HelmException
 
     @transaction.atomic

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -53,10 +53,10 @@ class UserViewSet(viewsets.ModelViewSet):
             instance.helm_create()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
         except CalledProcessError as e:
             logger.error(e)
-            raise HelmException
+            raise HelmException from e
 
     @transaction.atomic
     def perform_destroy(self, instance):
@@ -66,7 +66,7 @@ class UserViewSet(viewsets.ModelViewSet):
             instance.aws_delete_role()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
 
 class GroupViewSet(viewsets.ModelViewSet):
@@ -90,7 +90,8 @@ class AppViewSet(viewsets.ModelViewSet):
             app.aws_create_role()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+
+            raise AWSException(e) from e
 
     @transaction.atomic
     def perform_destroy(self, instance):
@@ -100,7 +101,7 @@ class AppViewSet(viewsets.ModelViewSet):
             instance.aws_delete_role()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
 
 class AppS3BucketViewSet(viewsets.ModelViewSet):
@@ -115,7 +116,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             apps3bucket.aws_create()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
     @transaction.atomic
     def perform_update(self, serializer):
@@ -125,7 +126,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             apps3bucket.aws_update()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
     @transaction.atomic
     def perform_destroy(self, instance):
@@ -135,7 +136,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_delete()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
 
 class UserS3BucketViewSet(viewsets.ModelViewSet):
@@ -150,7 +151,7 @@ class UserS3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_create()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
     @transaction.atomic
     def perform_update(self, serializer):
@@ -160,7 +161,7 @@ class UserS3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_update()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
     @transaction.atomic
     def perform_destroy(self, instance):
@@ -170,7 +171,7 @@ class UserS3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_delete()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
 
 class S3BucketViewSet(viewsets.ModelViewSet):
@@ -187,7 +188,7 @@ class S3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_create()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
         instance.create_users3bucket(user=self.request.user)
 
@@ -199,7 +200,7 @@ class S3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_delete()
         except ClientError as e:
             logger.error(e)
-            raise AWSException
+            raise AWSException from e
 
 
 class UserAppViewSet(viewsets.ModelViewSet):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -6,7 +6,10 @@ from django.contrib.auth.models import Group
 from django.db import transaction
 from rest_framework import viewsets
 
-from control_panel_api.exceptions import AWSException, HelmException
+from control_panel_api.exceptions import (
+    AWSException,
+    HelmException,
+)
 from control_panel_api.filters import (
     AppFilter,
     S3BucketFilter,
@@ -53,10 +56,10 @@ class UserViewSet(viewsets.ModelViewSet):
             instance.helm_create()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
         except CalledProcessError as e:
             logger.error(e)
-            raise HelmException from e
+            raise HelmException(e) from e
 
     @transaction.atomic
     def perform_destroy(self, instance):
@@ -66,7 +69,7 @@ class UserViewSet(viewsets.ModelViewSet):
             instance.aws_delete_role()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
 
 class GroupViewSet(viewsets.ModelViewSet):
@@ -90,7 +93,6 @@ class AppViewSet(viewsets.ModelViewSet):
             app.aws_create_role()
         except ClientError as e:
             logger.error(e)
-
             raise AWSException(e) from e
 
     @transaction.atomic
@@ -101,7 +103,7 @@ class AppViewSet(viewsets.ModelViewSet):
             instance.aws_delete_role()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
 
 class AppS3BucketViewSet(viewsets.ModelViewSet):
@@ -116,7 +118,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             apps3bucket.aws_create()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
     @transaction.atomic
     def perform_update(self, serializer):
@@ -126,7 +128,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             apps3bucket.aws_update()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
     @transaction.atomic
     def perform_destroy(self, instance):
@@ -136,7 +138,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_delete()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
 
 class UserS3BucketViewSet(viewsets.ModelViewSet):
@@ -161,7 +163,7 @@ class UserS3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_update()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
     @transaction.atomic
     def perform_destroy(self, instance):
@@ -171,7 +173,7 @@ class UserS3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_delete()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
 
 class S3BucketViewSet(viewsets.ModelViewSet):
@@ -188,7 +190,7 @@ class S3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_create()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
         instance.create_users3bucket(user=self.request.user)
 
@@ -200,7 +202,7 @@ class S3BucketViewSet(viewsets.ModelViewSet):
             instance.aws_delete()
         except ClientError as e:
             logger.error(e)
-            raise AWSException from e
+            raise AWSException(e) from e
 
 
 class UserAppViewSet(viewsets.ModelViewSet):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -108,6 +108,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
     queryset = AppS3Bucket.objects.all()
     serializer_class = AppS3BucketSerializer
 
+    @transaction.atomic
     def perform_create(self, serializer):
         apps3bucket = serializer.save()
 
@@ -117,6 +118,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             logger.error(e)
             raise AWSException
 
+    @transaction.atomic
     def perform_update(self, serializer):
         apps3bucket = serializer.save()
 
@@ -126,6 +128,7 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
             logger.error(e)
             raise AWSException
 
+    @transaction.atomic
     def perform_destroy(self, instance):
         instance.delete()
 


### PR DESCRIPTION
## What

- Add explicit transaction support on view functions.
- AWS and helm explicit error handling - let the lower level exceptions bubble up to the view, log, then throw a subclassed APIView exception.
- For 2 stage view operations e.g. aws call then helm call, if it fails on the 2nd helm call, we can revert the aws call.

## How to review

1. Run the tests.
2. Rename the helm command for an obvious error on User create and check that the aws call is rolled back and no db item is saved.

https://trello.com/c/GZphN2qR/479-db-transactions-aws-helm-error-handling-3