### PR TITLE
Really create the user in the database and the cluster

### DIFF
--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -48,5 +48,8 @@ class Auth0JWTAuthentication(BaseAuthentication):
                 email=decoded.get(settings.OIDC_FIELD_EMAIL),
                 name=decoded.get(settings.OIDC_FIELD_NAME),
             )
+            user.save()
+            user.aws_create_role()
+            user.helm_create()
 
         return user, None

--- a/control_panel_api/tests/test_authentication.py
+++ b/control_panel_api/tests/test_authentication.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import jwt
 from django.test import override_settings
 from model_mommy import mommy
@@ -5,6 +7,8 @@ from rest_framework.reverse import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
 from rest_framework.test import APITestCase
 
+from control_panel_api.aws import aws
+from control_panel_api.helm import helm
 from control_panel_api.models import User
 
 
@@ -23,6 +27,9 @@ def build_jwt(user, audience, secret):
 
 
 @override_settings(OIDC_CLIENT_SECRET='secret', OIDC_CLIENT_ID='audience')
+@patch.object(aws, 'client', MagicMock())
+@patch.object(helm, 'config_user', MagicMock())
+@patch.object(helm, 'init_user', MagicMock())
 class Auth0JWTAuthenticationTestCase(APITestCase):
 
     def setUp(self):


### PR DESCRIPTION
## What

* When an unknown authenticated user makes a request, the user should be created in the database and the cluster, and have an IAM role attached. Now this actually happens.

## How to review

1. Make an API request as an unknown user
2. See that `init-user` and `config-user` helm charts are deployed for this user
3. You can now successfully deploy RStudio for this user