### PR TITLE
Disable per-branch deployments to dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,13 @@ jobs:
       - deploy:
           name: Deploy to dev
           command: |
-            curl ${JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
-              --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
-              --data COMMIT_HASH=${CIRCLE_SHA1} \
-              --data BRANCH_NAME=${CIRCLE_BRANCH} \
-              --user ${JENKINS_USER}:${JENKINS_TOKEN}
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              curl ${JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
+                --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
+                --data COMMIT_HASH=${CIRCLE_SHA1} \
+                --data BRANCH_NAME=${CIRCLE_BRANCH} \
+                --user ${JENKINS_USER}:${JENKINS_TOKEN}
+            fi
 
       - deploy:
           name: Deploy to alpha


### PR DESCRIPTION
## What

Automatic per-branch deployments to the dev cluster are consuming resources unnecessarily. It is simple enough to manually deploy a branch, so this PR will disable the automatic deployment, except for the `master` branch.

See [Trello #473](https://trello.com/c/KZ5KsfyW)