### PR TITLE
k8s proxy: Allow requests to Deployments endpoints (v1beta2)

### DIFF
--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -25,6 +25,11 @@ class K8sPermissions(BasePermission):
     User can operate only in his namespace (unless superuser)
     """
 
+    ALLOWED_APIS = [
+        'api/v1',
+        'apis/apps/v1beta2',
+    ]
+
     def has_permission(self, request, view):
         if not request.user:
             return False
@@ -37,7 +42,12 @@ class K8sPermissions(BasePermission):
             return False
 
         path = request.path.lower()
-        return path.startswith(f'/k8s/api/v1/namespaces/user-{username}')
+
+        for api in self.ALLOWED_APIS:
+            if path.startswith(f'/k8s/{api}/namespaces/user-{username}'):
+                return True
+
+        return False
 
 
 class AppPermissions(IsSuperuser):

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -451,5 +451,12 @@ class K8sPermissionsTest(APITestCase):
         mock_request.return_value.status_code = 200
 
         username = self.normal_user.username.lower()
-        response = self.client.get(f'/k8s/api/v1/namespaces/user-{username}')
-        self.assertEqual(HTTP_200_OK, response.status_code)
+
+        api_groups = [
+            'api/v1',
+            'apis/apps/v1beta2',
+        ]
+
+        for api in api_groups:
+            response = self.client.get(f'/k8s/{api}/namespaces/user-{username}')
+            self.assertEqual(HTTP_200_OK, response.status_code)

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -436,7 +436,7 @@ class K8sPermissionsTest(APITestCase):
         response = self.client.get('/k8s/something')
         self.assertEqual(HTTP_200_OK, response.status_code)
 
-    def test_user_cant_operate_outside_their_namespace(self):
+    def test_normal_user_cant_operate_outside_their_namespace(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get('/k8s/api/v1/namespaces/user-other')
@@ -445,7 +445,7 @@ class K8sPermissionsTest(APITestCase):
     @patch('kubernetes.client.configuration')
     @patch('kubernetes.config.load_incluster_config')
     @patch('requests.request')
-    def test_user_can_operate_in_their_namespace(self, mock_request, mock_load_config, mock_config):
+    def test_normal_user_can_operate_in_their_namespace(self, mock_request, mock_load_config, mock_config):
         self.client.force_login(self.normal_user)
 
         mock_request.return_value.status_code = 200
@@ -460,3 +460,12 @@ class K8sPermissionsTest(APITestCase):
         for api in api_groups:
             response = self.client.get(f'/k8s/{api}/namespaces/user-{username}')
             self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_normal_user_cant_make_requests_to_disallowed_apis(self):
+        self.client.force_login(self.normal_user)
+
+        username = self.normal_user.username.lower()
+
+        disallowed_api = 'apis/disallowed/v1alpha0'
+        response = self.client.get(f'/k8s/{disallowed_api}/namespaces/user-{username}')
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)


### PR DESCRIPTION
### What
Kubernetes Deployment endpoints are not part of v1 core API - [they're part of `v1beta2`](https://kubernetes.io/docs/api-reference/v1.8/#deployment-v1beta2-apps).

UI could make requests to get list of deployment or create them at some point.

### How
I tweaked the `K8sPermissions` class to:
1) Allow normale user requests to this endpoints (as long as they're
   operating in their personal namespace)
2) Make it easy to support other API groups if/when will need to for
  whatever reason
