### PR TITLE
Add custom pagination where ?page_size=0 returns all items

### DIFF
--- a/control_panel_api/pagination.py
+++ b/control_panel_api/pagination.py
@@ -13,7 +13,8 @@ class CustomPageNumberPagination(PageNumberPagination):
         execute original parent functionality
         """
         page_size = self.get_page_size(request)
-        if page_size != 0:
+
+        if not self._page_size_is_all(page_size):
             return super().paginate_queryset(queryset, request, view)
 
         paginator = self.django_paginator_class(queryset, queryset.count())
@@ -35,3 +36,8 @@ class CustomPageNumberPagination(PageNumberPagination):
                 pass
 
         return self.page_size
+
+    def _page_size_is_all(self, page_size):
+        """If page_size is specified as 0 we use that to mean return all
+        """
+        return page_size == 0

--- a/control_panel_api/pagination.py
+++ b/control_panel_api/pagination.py
@@ -1,5 +1,37 @@
-from rest_framework.pagination import PageNumberPagination
+from rest_framework.pagination import PageNumberPagination, _positive_int
 
 
 class CustomPageNumberPagination(PageNumberPagination):
+    """This Pagination class allows a request to pass the page_size query param
+    for usual pagination functionality but adds custom whereby a value of
+    page_size=0 will return all items
+    """
     page_size_query_param = 'page_size'
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """Override to check for page_size=0 if so then return all items else
+        execute original parent functionality
+        """
+        page_size = self.get_page_size(request)
+        if page_size != 0:
+            return super().paginate_queryset(queryset, request, view)
+
+        paginator = self.django_paginator_class(queryset, queryset.count())
+        self.page = paginator.page(1)
+
+        return list(self.page)
+
+    def get_page_size(self, request):
+        """Override to set strict=False to allow a 0 value
+        """
+        if self.page_size_query_param:
+            try:
+                return _positive_int(
+                    request.query_params[self.page_size_query_param],
+                    strict=False,
+                    cutoff=self.max_page_size
+                )
+            except (KeyError, ValueError):
+                pass
+
+        return self.page_size

--- a/control_panel_api/tests/test_pagination.py
+++ b/control_panel_api/tests/test_pagination.py
@@ -1,0 +1,29 @@
+from model_mommy import mommy
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from control_panel_api.tests.test_views import AuthenticatedClientMixin
+
+
+class TestPagination(AuthenticatedClientMixin, APITestCase):
+    def test_pagination(self):
+        mommy.make('control_panel_api.App', 120)  # 120 exceeds the 100 default
+
+        app_list_url = reverse('app-list')
+
+        fixtures = (
+            (app_list_url, 100, True),  # default paging no query param
+            (app_list_url + '?page_size=50', 50, True),  # less than default
+            (app_list_url + '?page_size=130', 120, False),  # more than default
+            (app_list_url + '?page_size=0', 120, False),  # return all
+        )
+
+        for url, expected_page_size, has_next in fixtures:
+            response = self.client.get(url)
+            self.assertEqual(120, response.data['count'])
+            self.assertEqual(expected_page_size, len(response.data['results']))
+            self.assertIsNone(response.data['previous'])
+            if has_next:
+                self.assertIsNotNone(response.data['next'])
+            else:
+                self.assertIsNone(response.data['next'])

--- a/control_panel_api/tests/test_pagination.py
+++ b/control_panel_api/tests/test_pagination.py
@@ -7,23 +7,31 @@ from control_panel_api.tests.test_views import AuthenticatedClientMixin
 
 class TestPagination(AuthenticatedClientMixin, APITestCase):
     def test_pagination(self):
-        mommy.make('control_panel_api.App', 120)  # 120 exceeds the 100 default
+        default_page_size = 100
+
+        mommy.make('control_panel_api.App', default_page_size + 20)
 
         app_list_url = reverse('app-list')
 
         fixtures = (
-            (app_list_url, 100, True),  # default paging no query param
-            (app_list_url + '?page_size=50', 50, True),  # less than default
-            (app_list_url + '?page_size=130', 120, False),  # more than default
-            (app_list_url + '?page_size=0', 120, False),  # return all
+            (app_list_url, default_page_size, True, False),
+            (f'{app_list_url}?page_size={default_page_size - 50}', 50, True, False),
+            (f'{app_list_url}?page_size={default_page_size - 50}&page=3', 20, False, True),
+            (f'{app_list_url}?page_size={default_page_size + 30}', 120, False, False),
+            (f'{app_list_url}?page_size=0', 120, False, False),
         )
 
-        for url, expected_page_size, has_next in fixtures:
+        for url, expected_page_size, has_next, has_prev in fixtures:
             response = self.client.get(url)
             self.assertEqual(120, response.data['count'])
             self.assertEqual(expected_page_size, len(response.data['results']))
-            self.assertIsNone(response.data['previous'])
+
             if has_next:
                 self.assertIsNotNone(response.data['next'])
             else:
                 self.assertIsNone(response.data['next'])
+
+            if has_prev:
+                self.assertIsNotNone(response.data['previous'])
+            else:
+                self.assertIsNone(response.data['previous'])

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -783,27 +783,3 @@ class K8sAPIHandlerTest(AuthenticatedClientMixin, APITestCase):
             headers={'authorization': self.K8S_AUTH_TOKEN},
             verify=self.K8S_SSL_CERT_PATH,
         )
-
-
-class TestPagination(AuthenticatedClientMixin, APITestCase):
-    def test_pagination(self):
-        mommy.make('control_panel_api.App', 120)  # 120 exceeds the 100 default
-
-        app_list_url = reverse('app-list')
-
-        fixtures = (
-            (app_list_url, 100, True),  # default paging no query param
-            (app_list_url + '?page_size=50', 50, True),  # less than default
-            (app_list_url + '?page_size=130', 120, False),  # more than default
-            (app_list_url + '?page_size=0', 120, False),  # return all
-        )
-
-        for url, expected_page_size, has_next in fixtures:
-            response = self.client.get(url)
-            self.assertEqual(120, response.data['count'])
-            self.assertEqual(expected_page_size, len(response.data['results']))
-            self.assertIsNone(response.data['previous'])
-            if has_next:
-                self.assertIsNotNone(response.data['next'])
-            else:
-                self.assertIsNone(response.data['next'])

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -783,3 +783,27 @@ class K8sAPIHandlerTest(AuthenticatedClientMixin, APITestCase):
             headers={'authorization': self.K8S_AUTH_TOKEN},
             verify=self.K8S_SSL_CERT_PATH,
         )
+
+
+class TestPagination(AuthenticatedClientMixin, APITestCase):
+    def test_pagination(self):
+        mommy.make('control_panel_api.App', 120)  # 120 exceeds the 100 default
+
+        app_list_url = reverse('app-list')
+
+        fixtures = (
+            (app_list_url, 100, True),  # default paging no query param
+            (app_list_url + '?page_size=50', 50, True),  # less than default
+            (app_list_url + '?page_size=130', 120, False),  # more than default
+            (app_list_url + '?page_size=0', 120, False),  # return all
+        )
+
+        for url, expected_page_size, has_next in fixtures:
+            response = self.client.get(url)
+            self.assertEqual(120, response.data['count'])
+            self.assertEqual(expected_page_size, len(response.data['results']))
+            self.assertIsNone(response.data['previous'])
+            if has_next:
+                self.assertIsNotNone(response.data['next'])
+            else:
+                self.assertIsNone(response.data['next'])


### PR DESCRIPTION
## What

Add custom pagination where ?page_size=0 returns all items

Keeps existing pagination but overrides and adds the functionality.

## How to review

1. Make a request and add ?page_size=0

https://trello.com/c/amqhVpb5/528-2-paginate-app-bucket-user-lists