### PR TITLE
Stricter k8s permissions

### DIFF
--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -6,6 +6,8 @@ See: http://www.django-rest-framework.org/api-guide/permissions/#custom-permissi
 
 from rest_framework.permissions import BasePermission
 
+from control_panel_api.utils import sanitize_dns_label
+
 
 def is_superuser(user):
     return user and user.is_superuser
@@ -42,9 +44,10 @@ class K8sPermissions(BasePermission):
             return False
 
         path = request.path.lower()
+        namespace = sanitize_dns_label(f'user-{username}')
 
         for api in self.ALLOWED_APIS:
-            if path.startswith(f'/k8s/{api}/namespaces/user-{username}/'):
+            if path.startswith(f'/k8s/{api}/namespaces/{namespace}/'):
                 return True
 
         return False

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -44,7 +44,7 @@ class K8sPermissions(BasePermission):
         path = request.path.lower()
 
         for api in self.ALLOWED_APIS:
-            if path.startswith(f'/k8s/{api}/namespaces/user-{username}'):
+            if path.startswith(f'/k8s/{api}/namespaces/user-{username}/'):
                 return True
 
         return False

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -417,6 +417,7 @@ class K8sPermissionsTest(APITestCase):
         )
         self.normal_user = mommy.make(
             'control_panel_api.User',
+            username='alice',
             auth0_id='github|user_2',
             is_superuser=False,
         )


### PR DESCRIPTION
### What 
K8s: Fix permissions to disallow requests to namespace with common prefix

Because of the use `startWith()` to check the k8s request path is for the
user's namespace and the lack of trailing slash `/` a user could potentially
make request to operate on someone else namespace.

This happens if the user has a username which is prefix of another user'
username, e.g.

- User `andy` has a namespace called `user-andy`
- User `andyother` has a namespace called `user-andyother`
- `andy` should only be able to operate in `user-andy`
- `andy` can operate in `user-andyother` because this namespace starts
  with `user-andy`.

**Also**: DNS-sanitise generated namespace when checking permissions.


### Ticket
https://trello.com/c/4zkAt4r3/556-1-cp-api-improve-k8s-namespace-permissions