### PR TITLE
Add endpoint to deploy tool

### DIFF
--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -9,6 +9,7 @@ from django_extensions.db.models import TimeStampedModel
 
 from control_panel_api import services, validators
 from control_panel_api.helm import helm
+from control_panel_api.utils import sanitize_dns_label
 
 
 class User(AbstractUser):
@@ -32,6 +33,10 @@ class User(AbstractUser):
     @property
     def iam_role_name(self):
         return f"{settings.ENV}_user_{self.username.lower()}"
+
+    @property
+    def k8s_namespace(self):
+        return sanitize_dns_label(f'user-{self.username}')
 
     def aws_create_role(self):
         services.create_role(self.iam_role_name, add_saml_statement=True)

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -75,3 +75,9 @@ class UserPermissions(BasePermission):
             return True
 
         return request.user == obj
+
+
+class ToolDeploymentPermissions(BasePermission):
+
+    def has_permission(self, request, view):
+        return not request.user.is_anonymous()

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -33,21 +33,15 @@ class K8sPermissions(BasePermission):
     ]
 
     def has_permission(self, request, view):
-        if not request.user:
+        if not request.user or request.user.is_anonymous():
             return False
 
         if is_superuser(request.user):
             return True
 
-        username = request.user.username.lower()
-        if not username:
-            return False
-
         path = request.path.lower()
-        namespace = sanitize_dns_label(f'user-{username}')
-
         for api in self.ALLOWED_APIS:
-            if path.startswith(f'/k8s/{api}/namespaces/{namespace}/'):
+            if path.startswith(f'/k8s/{api}/namespaces/{request.user.k8s_namespace}/'):
                 return True
 
         return False

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -157,6 +157,11 @@ OIDC_FIELD_NAME = 'name'
 
 # Helm variables
 NFS_HOSTNAME = os.environ.get('NFS_HOSTNAME')
+TOOLS_DOMAIN = os.environ.get('TOOLS_DOMAIN')
+# RStudio tool - Auth client config
+RSTUDIO_AUTH_CLIENT_DOMAIN = os.environ.get('RSTUDIO_AUTH_CLIENT_DOMAIN', OIDC_DOMAIN)
+RSTUDIO_AUTH_CLIENT_ID = os.environ.get('RSTUDIO_AUTH_CLIENT_ID')
+RSTUDIO_AUTH_CLIENT_SECRET = os.environ.get('RSTUDIO_AUTH_CLIENT_SECRET')
 
 LOGGING = {
     'version': 1,

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -60,6 +60,12 @@ class UserTestCase(TestCase):
         aws.client.return_value.delete_role.assert_called_with(
             RoleName=expected_role_name)
 
+    def test_k8s_namespace(self):
+        user = User(username='AlicE')
+        expected_ns = f'user-alice'
+
+        self.assertEqual(user.k8s_namespace, expected_ns)
+
 
 class MembershipsTestCase(TestCase):
     @classmethod

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -481,8 +481,6 @@ class K8sPermissionsTest(APITestCase):
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
-
-
 class ToolDeploymentPermissionsTest(APITestCase):
 
     def setUp(self):

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -479,3 +479,52 @@ class K8sPermissionsTest(APITestCase):
 
         response = self.client.get(f'/k8s/api/v1/namespaces/user-{other_username}/do/something')
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+
+
+
+class ToolDeploymentPermissionsTest(APITestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.superuser = mommy.make(
+            'control_panel_api.User',
+            auth0_id='github|user_1',
+            is_superuser=True,
+        )
+        self.normal_user = mommy.make(
+            'control_panel_api.User',
+            username='alice',
+            auth0_id='github|user_2',
+            is_superuser=False,
+        )
+
+    def test_not_logged_user_cant_deploy(self):
+        response = self.client.post(
+            reverse('tool-deployments-list', ('rstudio',)),
+            None,
+            content_type='application/json',
+        )
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    @patch('control_panel_api.views.Tool')
+    def test_normal_user_can_deploy_tool(self, mock_tool):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.post(
+            reverse('tool-deployments-list', ('rstudio',)),
+            None,
+            content_type='application/json',
+        )
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    @patch('control_panel_api.views.Tool')
+    def test_superuser_can_deploy_tool(self, mock_tool):
+        self.client.force_login(self.superuser)
+
+        response = self.client.post(
+            reverse('tool-deployments-list', ('rstudio',)),
+            None,
+            content_type='application/json',
+        )
+        self.assertEqual(HTTP_201_CREATED, response.status_code)

--- a/control_panel_api/tests/test_tools.py
+++ b/control_panel_api/tests/test_tools.py
@@ -45,7 +45,7 @@ class ToolsTestCase(TestCase):
             f'{username}-{tool_name}',
             f'mojanalytics/{tool_name}',
             '--namespace', user.k8s_namespace,
-            '--set', f'Username={username}',
+            '--set', f'username={username}',
             '--set', f'aws.iamRole={user.iam_role_name}',
             '--set', f'toolsDomain={self.TOOLS_DOMAIN}',
             '--set', f'authProxy.cookieSecret={cookie_secret_proxy}',

--- a/control_panel_api/tests/test_tools.py
+++ b/control_panel_api/tests/test_tools.py
@@ -1,7 +1,7 @@
 from unittest.case import TestCase
+from unittest.mock import patch
 
 from django.test import override_settings
-from unittest.mock import patch
 
 from control_panel_api.models import User
 from control_panel_api.tools import Tool, UnsupportedToolException

--- a/control_panel_api/tests/test_tools.py
+++ b/control_panel_api/tests/test_tools.py
@@ -1,0 +1,56 @@
+from unittest.case import TestCase
+
+from django.test import override_settings
+from unittest.mock import patch
+
+from control_panel_api.models import User
+from control_panel_api.tools import Tool, UnsupportedToolException
+
+
+class ToolsTestCase(TestCase):
+
+    TOOLS_DOMAIN = 'example.com'
+    TOOL_AUTH_CLIENT_DOMAIN = 'auth.example.com'
+    TOOL_AUTH_CLIENT_ID = '42'
+    TOOL_AUTH_CLIENT_SECRET = 'secret'
+
+    def test_when_unsupported_tool_raises_error(self):
+        with self.assertRaises(UnsupportedToolException):
+            Tool('unsupported_tool')
+
+    @override_settings(
+        TOOLS_DOMAIN=TOOLS_DOMAIN,
+        RSTUDIO_AUTH_CLIENT_DOMAIN=TOOL_AUTH_CLIENT_DOMAIN,
+        RSTUDIO_AUTH_CLIENT_ID=TOOL_AUTH_CLIENT_ID,
+        RSTUDIO_AUTH_CLIENT_SECRET=TOOL_AUTH_CLIENT_SECRET,
+    )
+    @patch('secrets.token_hex')
+    @patch('control_panel_api.tools.Helm.upgrade_release')
+    def test_deploy_for(self, mock_helm_upgrade_release, mock_token_hex):
+        tool_name = 'rstudio'
+        user = User(username='AlIcE')
+        username = user.username.lower()
+
+        cookie_secret_proxy = 'cookie secret proxy'
+        cookie_secret_tool = 'cookie secret tool'
+        mock_token_hex.side_effect = [
+            cookie_secret_proxy,
+            cookie_secret_tool
+        ]
+
+        tool = Tool(tool_name)
+        tool.deploy_for(user)
+
+        mock_helm_upgrade_release.assert_called_with(
+            f'{username}-{tool_name}',
+            f'mojanalytics/{tool_name}',
+            '--namespace', user.k8s_namespace,
+            '--set', f'Username={username}',
+            '--set', f'aws.iamRole={user.iam_role_name}',
+            '--set', f'toolsDomain={self.TOOLS_DOMAIN}',
+            '--set', f'authProxy.cookieSecret={cookie_secret_proxy}',
+            '--set', f'{tool_name}.secureCookieKey={cookie_secret_tool}',
+            '--set', f'authProxy.auth0.domain={self.TOOL_AUTH_CLIENT_DOMAIN}',
+            '--set', f'authProxy.auth0.clientId={self.TOOL_AUTH_CLIENT_ID}',
+            '--set', f'authProxy.auth0.clientSecret={self.TOOL_AUTH_CLIENT_SECRET}',
+        )

--- a/control_panel_api/tools.py
+++ b/control_panel_api/tools.py
@@ -46,7 +46,7 @@ class Tool():
             f'{username}-{self.name}',
             f'mojanalytics/{self.name}',
             '--namespace', user.k8s_namespace,
-            '--set', f'Username={username}',
+            '--set', f'username={username}',
             '--set', f'aws.iamRole={user.iam_role_name}',
             '--set', f'toolsDomain={settings.TOOLS_DOMAIN}',
             '--set', f'authProxy.cookieSecret={auth_proxy_cookie_secret}',

--- a/control_panel_api/tools.py
+++ b/control_panel_api/tools.py
@@ -25,9 +25,9 @@ class Tool():
             '--namespace', user.k8s_namespace,
             '--set', f'Username={user.username.lower()}',
             '--set', f'aws.iamRole={user.iam_role_name}',
-            '--set', 'authProxy.auth.domain=' + self.auth_client["domain"],
-            '--set', 'authProxy.auth.clientId=' + self.auth_client["id"],
-            '--set', 'authProxy.auth.clientSecret=' + self.auth_client["secret"],
+            '--set', 'authProxy.auth.domain=' + self.auth_client['domain'],
+            '--set', 'authProxy.auth.clientId=' + self.auth_client['id'],
+            '--set', 'authProxy.auth.clientSecret=' + self.auth_client['secret'],
         )
 
     def load_auth_client_config(self):

--- a/control_panel_api/tools.py
+++ b/control_panel_api/tools.py
@@ -2,19 +2,33 @@ import os
 import secrets
 
 from django.conf import settings
+from rest_framework.exceptions import APIException
 
 from control_panel_api.helm import Helm
+
+
+SUPPORTED_TOOL_NAMES = [
+    'rstudio',
+]
+
+
+class UnsupportedToolException(APIException):
+    tools_list = ", ".join(SUPPORTED_TOOL_NAMES)
+
+    status_code = 400
+    default_detail = f'Unsupported tool, tool_name must be one of: {tools_list}'
+    default_code = 'unsupported_tool'
 
 
 class Tool():
 
     def __init__(self, name):
-        self.name = name
+        self.name = self._validate_name(name)
         self.helm = Helm()
 
-        self.auth_client_domain = _get_auth_client_config('domain')
-        self.auth_client_id = _get_auth_client_config('id')
-        self.auth_client_secret = _get_auth_client_config('secret')
+        self.auth_client_domain = self._get_auth_client_config('domain')
+        self.auth_client_id = self._get_auth_client_config('id')
+        self.auth_client_secret = self._get_auth_client_config('secret')
 
     def deploy_for(self, user):
         """
@@ -29,8 +43,8 @@ class Tool():
         tool_cookie_secret = secrets.token_hex(32)
 
         self.helm.upgrade_release(
-            chart=f'mojanalytics/{self.name}',
-            release=f'{username}-{self.name}',
+            f'{username}-{self.name}',
+            f'mojanalytics/{self.name}',
             '--namespace', user.k8s_namespace,
             '--set', f'Username={username}',
             '--set', f'aws.iamRole={user.iam_role_name}',
@@ -45,3 +59,9 @@ class Tool():
     def _get_auth_client_config(self, key):
         setting_key = f'{self.name}_AUTH_CLIENT_{key}'
         return getattr(settings, setting_key.upper())
+
+    def _validate_name(self, name):
+        if not name in SUPPORTED_TOOL_NAMES:
+            raise UnsupportedToolException
+
+        return name

--- a/control_panel_api/tools.py
+++ b/control_panel_api/tools.py
@@ -19,7 +19,7 @@ class UnsupportedToolException(APIException):
     default_code = 'unsupported_tool'
 
 
-class Tool():
+class Tool(object):
 
     def __init__(self, name):
         if not name in SUPPORTED_TOOL_NAMES:

--- a/control_panel_api/tools.py
+++ b/control_panel_api/tools.py
@@ -1,4 +1,3 @@
-import os
 import secrets
 
 from django.conf import settings

--- a/control_panel_api/tools.py
+++ b/control_panel_api/tools.py
@@ -1,0 +1,58 @@
+import os
+
+from django.conf import settings
+
+from control_panel_api.helm import Helm
+from control_panel_api.utils import sanitize_dns_label
+
+
+class Tool():
+
+    def __init__(self, name):
+        self.name = name
+        self.helm = Helm()
+        self.load_auth_client_config()
+
+    def deploy_for(self, username):
+        """
+        Deploy the given tool in the user namespace.
+
+        >>> rstudio = Tool('rstudio')
+        >>> rstudio.deploy_for('alice')
+        """
+        env = settings.ENV
+        username_slug = sanitize_dns_label(username)
+
+        self.helm.upgrade_release(
+            f'{username}-{self.name}',
+            f'mojanalytics/{self.name}',
+            '--namespace', f'user-{username_slug}',
+            '--set', f'Username={username_slug}',
+            '--set', f'aws.iamRole={env}_user_{username_slug}',
+            '--set', 'authProxy.auth.domain=' + self.auth_client["domain"],
+            '--set', 'authProxy.auth.clientId=' + self.auth_client["id"],
+            '--set', 'authProxy.auth.clientSecret=' +
+            self.auth_client["secret"],
+        )
+
+    def load_auth_client_config(self):
+        """
+        Read Auth client config into `self.auth_client`
+
+        This dictionary has 3 keys:
+          - `domain` with value `settings.OIDC_DOMAIN`
+          - `id` with value from `${TOOL}_AUTH_CLIENT_ID`
+          - `secret` with value from `${TOOL}_AUTH_CLIENT_SECRET`
+
+        e.g. if the tool name is `rstudio`:
+          - `domain` will be read from `settings.OIDC_DOMAIN`
+          - `id` will be read from `RSTUDIO_AUTH_CLIENT_ID`
+          - `secret` will be read from `RSTUDIO_AUTH_CLIENT_SECRET`
+        """
+        tool_auth_prefix = f'{self.name.upper()}_AUTH_CLIENT'
+
+        self.auth_client = {
+            'domain': settings.OIDC_DOMAIN,
+            'id': os.environ[f'{tool_auth_prefix}_ID'],
+            'secret': os.environ[f'{tool_auth_prefix}_SECRET'],
+        }

--- a/control_panel_api/tools.py
+++ b/control_panel_api/tools.py
@@ -22,7 +22,10 @@ class UnsupportedToolException(APIException):
 class Tool():
 
     def __init__(self, name):
-        self.name = self._validate_name(name)
+        if not name in SUPPORTED_TOOL_NAMES:
+            raise UnsupportedToolException
+
+        self.name = name
         self.helm = Helm()
 
         self.auth_client_domain = self._get_auth_client_config('domain')
@@ -58,9 +61,3 @@ class Tool():
     def _get_auth_client_config(self, key):
         setting_key = f'{self.name}_AUTH_CLIENT_{key}'
         return getattr(settings, setting_key.upper())
-
-    def _validate_name(self, name):
-        if not name in SUPPORTED_TOOL_NAMES:
-            raise UnsupportedToolException
-
-        return name

--- a/control_panel_api/urls.py
+++ b/control_panel_api/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     url(r'^$', schema_view),
     url(r'^', include(router.urls)),
     url(r'^k8s/.+', views.k8s_api_handler),
-    url(r'^tools/(?P<tool_name>[-a-zA-Z]+)/deployments/$', views.tool_deployments_list, name='tool-deployments-list'),
+    url(r'^tools/(?P<tool_name>[-a-z]+)/deployments/$', views.tool_deployments_list, name='tool-deployments-list'),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]
 

--- a/control_panel_api/urls.py
+++ b/control_panel_api/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     url(r'^$', schema_view),
     url(r'^', include(router.urls)),
     url(r'^k8s/.+', views.k8s_api_handler),
+    url(r'^tools/(?P<tool_name>[-a-zA-Z]+)/deployments/$', views.tool_deployments_list, name='tool-deployments-list'),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]
 


### PR DESCRIPTION
### What

This adds the `POST /tools/{tool_name}/deployments/` endpoint which allow a user to deploy a tool in their namespace.

### Why
We want our user to potentially deploy their own tools (RStudio only for now).

### How
Deployment of a tool involves the installation/upgrade of the corresponding helm chart.

### Permissions
At this stage this endpoint is relatively simple and will only allow a user to deploy a tool in their namespace. Therefore the authorisation logic is only checking if user is logged in.

### Settings
This needs these new settings in order to work:

 - `TOOLS_DOMAIN` is the domain in which the tool will be available, e.g. `tools.example.com`
 - `RSTUDIO_AUTH_CLIENT_DOMAIN` is the OAuth client domain. It will default to the same domain as in `OIDC_DOMAIN` if not set
 - `RSTUDIO_AUTH_CLIENT_ID` is the OAuth client ID
 - `RSTUDIO_AUTH_CLIENT_SECRET` is the OAuth client secret

**NOTE**: When we'll add more and more tools this approach of having the tool settings in the environment variables *may not* work, we'll cross that bridge when we'll get there.

### How to review

1. Add these environment variables for `dev` in your `.dev` file
2. start the server by `$ python3 manage.py runserver`
3. Go to [http://localhost:8000](http://localhost:8000) and log in
4. User the `POST /tools/{tool_name}/deployments/` endpoint
5. Try to enter an invalid tool name => will return a `400 BAD REQUEST`
6. Try to enter `rstudio` as tool name => you should get a `201 CREATED`
7. Visit `{your_username}-rstudio.{TOOLS_DOMAIN}

### Ticket
https://trello.com/c/77FMKVLE/536-3-cp-api-add-endpoint-to-deploy-rstudio

### Related PR
The following things needs be in place before merging/deploying this:
- [ ] [Add config for cpanel](https://github.com/ministryofjustice/analytics-platform-config/pull/21)
- [ ] [Update `cpanel` helm chart](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/61)
