### PR TITLE
Auth RS256

### DIFF
--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -17,8 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_jwks():
-    response = requests.get(
-        f'https://{settings.OIDC_DOMAIN}/.well-known/jwks.json')
+    response = requests.get(settings.OIDC_WELL_KNOWN_URL)
     return response.json()
 
 

--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -35,15 +35,15 @@ def get_jwk(kid):
     return get_key(jwks, kid)
 
 
-def get_or_create_user(payload):
+def get_or_create_user(decoded_payload):
     try:
-        user = User.objects.get(pk=payload.get('sub'))
+        user = User.objects.get(pk=decoded_payload.get('sub'))
     except User.DoesNotExist:
         user = User.objects.create(
-            pk=payload.get('sub'),
-            username=payload.get(settings.OIDC_FIELD_USERNAME),
-            email=payload.get(settings.OIDC_FIELD_EMAIL),
-            name=payload.get(settings.OIDC_FIELD_NAME),
+            pk=decoded_payload.get('sub'),
+            username=decoded_payload.get(settings.OIDC_FIELD_USERNAME),
+            email=decoded_payload.get(settings.OIDC_FIELD_EMAIL),
+            name=decoded_payload.get(settings.OIDC_FIELD_NAME),
         )
         user.save()
         user.helm_create()

--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -1,22 +1,39 @@
+import logging
+
+import requests
 from django.conf import settings
-import jwt
-from jwt.exceptions import InvalidTokenError
+from jose import jwt
+from jose.exceptions import JWTError
+from requests.exceptions import RequestException
 from rest_framework.authentication import (
     BaseAuthentication,
-    get_authorization_header
+    get_authorization_header,
 )
 from rest_framework.exceptions import AuthenticationFailed
 
 from control_panel_api.models import User
 
+logger = logging.getLogger(__name__)
+
+
+def get_jwks():
+    response = requests.get(
+        f'https://{settings.OIDC_DOMAIN}/.well-known/jwks.json')
+    return response.json()
+
+
+def get_key(jwks, unverified_header):
+    for jwk in jwks.get('keys'):
+        if jwk['kid'] == unverified_header['kid']:
+            return jwk
+
+    return None
+
 
 class Auth0JWTAuthentication(BaseAuthentication):
-
     def authenticate(self, request):
-
         try:
             prefix, token = get_authorization_header(request).split()
-
         except (ValueError, TypeError):
             return None
 
@@ -24,14 +41,30 @@ class Auth0JWTAuthentication(BaseAuthentication):
             return None
 
         try:
+            unverified_header = jwt.get_unverified_header(token)
+        except JWTError as e:
+            raise AuthenticationFailed('Error decoding JWT header') from e
+
+        try:
+            jwks = get_jwks()
+        except RequestException as e:
+            logger.error(e)
+            raise AuthenticationFailed(e) from e
+
+        key = get_key(jwks, unverified_header)
+        if key is None:
+            raise AuthenticationFailed('kid matching failure')
+
+        try:
             decoded = jwt.decode(
                 token,
-                key=settings.OIDC_CLIENT_SECRET,
+                key=key,
+                algorithms=['RS256'],
                 audience=settings.OIDC_CLIENT_ID
             )
-
-        except InvalidTokenError as error:
-            raise AuthenticationFailed(error)
+        except JWTError as e:
+            logger.error(e)
+            raise AuthenticationFailed(e) from e
 
         sub = decoded.get('sub')
 
@@ -40,7 +73,6 @@ class Auth0JWTAuthentication(BaseAuthentication):
 
         try:
             user = User.objects.get(pk=sub)
-
         except User.DoesNotExist:
             user = User.objects.create(
                 pk=sub,

--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -1,9 +1,9 @@
 import logging
 
-import requests
 from django.conf import settings
 from jose import jwt
 from jose.exceptions import JWTError
+import requests
 from requests.exceptions import RequestException
 from rest_framework.authentication import (
     BaseAuthentication,

--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -16,6 +16,18 @@ from control_panel_api.models import User
 logger = logging.getLogger(__name__)
 
 
+def get_jwt(request):
+    try:
+        prefix, token = get_authorization_header(request).split()
+    except (ValueError, TypeError):
+        return None
+
+    if prefix != 'JWT'.encode():
+        return None
+
+    return token
+
+
 def get_jwks():
     response = requests.get(settings.OIDC_WELL_KNOWN_URL)
     return response.json()
@@ -53,12 +65,9 @@ def get_or_create_user(decoded_payload):
 
 class Auth0JWTAuthentication(BaseAuthentication):
     def authenticate(self, request):
-        try:
-            prefix, token = get_authorization_header(request).split()
-        except (ValueError, TypeError):
-            return None
+        token = get_jwt(request)
 
-        if prefix != 'JWT'.encode():
+        if token is None:
             return None
 
         try:

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -165,6 +165,7 @@ RSTUDIO_AUTH_CLIENT_SECRET = os.environ.get('RSTUDIO_AUTH_CLIENT_SECRET')
 
 LOGGING = {
     'version': 1,
+    'disable_existing_loggers': False,
     'formatters': {
         'default': {
             'format': '%(asctime)s %(name)s %(levelname)s %(message)s',
@@ -179,6 +180,10 @@ LOGGING = {
     },
     'loggers': {
         '': {
+            'handlers': ['console'],
+            'level': os.environ.get('LOG_LEVEL', 'DEBUG'),
+        },
+        'django': {
             'handlers': ['console'],
             'level': os.environ.get('LOG_LEVEL', 'DEBUG'),
         },

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -154,6 +154,7 @@ OIDC_DOMAIN = os.environ.get('OIDC_DOMAIN')
 OIDC_FIELD_USERNAME = 'nickname'
 OIDC_FIELD_EMAIL = 'email'
 OIDC_FIELD_NAME = 'name'
+OIDC_WELL_KNOWN_URL = f'https://{OIDC_DOMAIN}/.well-known/jwks.json'
 
 # Helm variables
 NFS_HOSTNAME = os.environ.get('NFS_HOSTNAME')

--- a/control_panel_api/tests/__init__.py
+++ b/control_panel_api/tests/__init__.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 
-
 POLICY_DOCUMENT_READWRITE = {
     'Version': '2012-10-17',
     'Statement': [
@@ -79,3 +78,27 @@ USER_IAM_ROLE_ASSUME_POLICY = {
         }
     ]
 }
+
+# The RSA key below was generated specifically for the authentication tests only
+PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCo/FYLtMEuzwVf5n0ml+znmXF3hgj/i4W0ZndaL7GL1C+JpdQQ
+yXGVKom2TyDMRPAwcL7D2shGO+dxAJQ0D2475Grk+rwBSBmtxea/glL7Fi6eMCKj
+B7vwFf0jw8mDhjfKBtBKOdfEaEs7+0D32XCkYnq9IFoHfA1uQMhlVFdiBwIDAQAB
+AoGABM0WjMKX8oKDPpRH3f7XBkV/ycuPGeOW6uc2YOOWAckHiLujaM6wYXKR8xIQ
+dn1G7blmUh43LnepPbasf0Yo9ZLPKKbo/AMd8nS59Q0WHlIKUJ9DLnfxjpEzigZ4
+PjEISBcmXbjg2Icq0b9xoeLC9X0aFEYbSGQJbA7L0snAOTECQQDgsKTxTxby1Ma4
+SYdKwxhxchb4BD3NjvFAyx/FDmVHtbezOhng1va1TsM3aB95xIu8K8SNSSm/Hgi0
+bDkVlVgLAkEAwIiN2EFXwioDjstyF8eC7leFoKKxykIZID+YerT6UoQd9Bu0trDe
+Mh0RVsSW4D5Y/CjV5v5f5NT8eoDNKbiPdQJAV26lYHkkNu3xPfjuunrcYhjBM1WD
+Lx/2ZP4lqKqHYrYle4qaU1GSws6ZTFAqH1oJ/fkSDOBxbDslq/+I3ws0LQJAIFAK
+tkupJd4VQMbmPBVw5P1tYNtNSWu0edQSjC2JgYXI3So1NyAR+okkWtKdm777Aj78
+P0tb3rTcNtcdF65w7QJBAIlfLWXrnjuJP4xdsJpubct+VoPZpEkojXp16zdEPSni
+Tk1/Hf+kxTTBR5xfmgtLCPmOU8d+qodjxI6JmZtfvVU=
+-----END RSA PRIVATE KEY-----"""
+
+PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCo/FYLtMEuzwVf5n0ml+znmXF3
+hgj/i4W0ZndaL7GL1C+JpdQQyXGVKom2TyDMRPAwcL7D2shGO+dxAJQ0D2475Grk
++rwBSBmtxea/glL7Fi6eMCKjB7vwFf0jw8mDhjfKBtBKOdfEaEs7+0D32XCkYnq9
+IFoHfA1uQMhlVFdiBwIDAQAB
+-----END PUBLIC KEY-----"""

--- a/control_panel_api/tests/test_authentication.py
+++ b/control_panel_api/tests/test_authentication.py
@@ -13,8 +13,6 @@ from rest_framework.status import (
 )
 from rest_framework.test import APITestCase
 
-from control_panel_api.aws import aws
-from control_panel_api.helm import helm
 from control_panel_api.models import User
 from control_panel_api.tests import PRIVATE_KEY, PUBLIC_KEY
 
@@ -65,10 +63,11 @@ mock_get_key.return_value = get_jwk()
 @override_settings(OIDC_DOMAIN='dev-analytics-moj.eu.auth0.com',
                    OIDC_CLIENT_SECRET='secret',
                    OIDC_CLIENT_ID='audience')
-@patch.object(aws, 'client', MagicMock())
-@patch.object(helm, 'config_user', MagicMock())
-@patch.object(helm, 'init_user', MagicMock())
 @patch('control_panel_api.authentication.get_key', mock_get_key)
+@patch('control_panel_api.aws.aws.client', MagicMock())
+@patch('control_panel_api.helm.helm.config_user', MagicMock())
+@patch('control_panel_api.helm.helm.init_user', MagicMock())
+@patch('requests.get', MagicMock())
 class Auth0JWTAuthenticationTestCase(APITestCase):
     def setUp(self):
         self.user = mommy.make(
@@ -108,7 +107,7 @@ class Auth0JWTAuthenticationTestCase(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='JWT bar')
         self.assert_access_denied()
 
-    @patch('requests.get')
+    @patch('control_panel_api.authentication.get_jwks')
     def test_bad_request_for_jwks(self, mock_request_get):
         mock_request_get.side_effect = Timeout
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ django-filter==1.0.4
 django-rest-swagger==2.1.2
 djangorestframework==3.7.3
 docutils==0.14
+ecdsa==0.13
+future==0.16.0
 google-auth==1.0.2
 gunicorn==19.7.1
 idna==2.6
@@ -31,9 +33,10 @@ py==1.5.1
 pyasn1==0.3.2
 pyasn1-modules==0.0.11
 pycparser==2.18
-PyJWT==1.5.3
+pycrypto==2.6.1
 pytest==3.2.5
 python-dateutil==2.6.1
+python-jose==1.4.0
 pytz==2017.3
 PyYAML==3.12
 raven==6.2.1


### PR DESCRIPTION
## What

Changes auth to RS256 using json web keys via auth0.

Library change to python-jose for more effective jwk handling.

Tests use a fresh rsa key only used for the test.

Also includes logging fix.

## How to review

1. ./manage.py test
2. Run the frontend with the app and login via github.

https://trello.com/c/vhfSv2Vv/546-change-jwt-signing-method-in-cp-api-to-rs256-to-match-k8s-api-2
