### PR TITLE
Added flag to optionally use user JWT to authenticate with k8s

### DIFF
--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -7,6 +7,7 @@ def is_enabled(value):
 
 # These are boolean flags to enable/disable features in the API
 ENABLED = {
+    'k8s_rbac': is_enabled(os.environ.get('ENABLE_K8S_RBAC', False)),
     'write_to_cluster':
         is_enabled(os.environ.get('ENABLE_WRITE_TO_CLUSTER', True)),
 }


### PR DESCRIPTION
### What
When the `ENABLE_K8S_RBAC` environment variable is `True`
(`False` by default) we use the user JWT token from the request
`Authentication` header instead of the admin credentials read
from the k8s cluster/kubeconfig.

### Why
1) When RBAC is enabled the token will not be in the cluster config
2) Long term we want all requests to the k8s cluster to be made with the user JWT token

### Ticket
https://trello.com/c/jnzUyCeo/590-4-api-to-use-user-auth-token-to-make-requests-to-k8s
