### PR TITLE
On bucket create set default bucket encryption to AES256

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -22,6 +22,19 @@ class AWSClient(object):
             ACL=acl,
             CreateBucketConfiguration={'LocationConstraint': region})
 
+    def put_bucket_encryption(self, name):
+        self._do('s3', 'put_bucket_encryption',
+            Bucket=name,
+            ServerSideEncryptionConfiguration={
+                 'Rules': [
+                     {
+                         'ApplyServerSideEncryptionByDefault': {
+                             'SSEAlgorithm': 'AES256'
+                         }
+                     }
+                 ]
+            })
+
     def put_bucket_logging(self, name, target_bucket, target_prefix):
         self._do('s3', 'put_bucket_logging',
             Bucket=name,

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -164,6 +164,7 @@ def create_bucket(bucket_name):
         bucket_name,
         target_bucket=settings.LOGS_BUCKET_NAME,
         target_prefix=f"{bucket_name}/")
+    aws.put_bucket_encryption(bucket_name)
 
 
 @ignore_existing

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
 from django.conf import settings
 from django.test.testcases import SimpleTestCase, TestCase
@@ -8,14 +8,13 @@ from model_mommy import mommy
 from control_panel_api import services
 from control_panel_api.aws import aws
 from control_panel_api.models import (
-    App,
     AppS3Bucket,
-    S3Bucket,
 )
 from control_panel_api.tests import (
     POLICY_DOCUMENT_READONLY,
     POLICY_DOCUMENT_READWRITE,
-    USER_IAM_ROLE_ASSUME_POLICY)
+    USER_IAM_ROLE_ASSUME_POLICY,
+)
 
 
 @patch.object(aws, 'client', MagicMock())
@@ -57,6 +56,16 @@ class ServicesTestCase(TestCase):
                     'TargetBucket': 'moj-test-logs',
                     'TargetPrefix': 'test-bucketname/'
                 }
+            })
+
+        aws.client.return_value.put_bucket_encryption.assert_called_with(
+            Bucket='test-bucketname',
+            ServerSideEncryptionConfiguration={
+                'Rules': [{
+                    'ApplyServerSideEncryptionByDefault': {
+                        'SSEAlgorithm': 'AES256'
+                    }
+                }]
             })
 
     def test_create_bucket_policies(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asn1crypto==0.23.0
 auth0-python==3.1.3
-boto3==1.4.7
-botocore==1.7.3
+boto3==1.5.15
+botocore==1.8.29
 cachetools==2.0.1
 certifi==2017.7.27.1
 cffi==1.11.2
@@ -42,7 +42,7 @@ PyYAML==3.12
 raven==6.2.1
 requests==2.18.4
 rsa==3.4.2
-s3transfer==0.1.11
+s3transfer==0.1.12
 simplejson==3.11.1
 six==1.10.0
 uritemplate==3.0.0


### PR DESCRIPTION
## What

On bucket create set default bucket encryption to AES256

## How to review

1. Create a bucket.
2. Check aws console for enabled encryption.

https://trello.com/c/NJsrt6fe/584-2-enable-bucket-level-encryption-for-user-created-buckets