### PR TITLE
Add helm delete for init-user and delete their namespace on User delete

### DIFF
--- a/control_panel_api/helm.py
+++ b/control_panel_api/helm.py
@@ -14,6 +14,14 @@ class Helm(object):
         if self.enabled:
             subprocess.run(['helm', command] + list(args), check=True)
 
+    def _helm_shell_command(self, command_string):
+        if self.enabled:
+            subprocess.run(
+                f'helm {command_string}',
+                shell=True,
+                check=True
+            )
+
     def upgrade_release(self, release, chart, *args):
         default_flags = ['--install', '--wait']
         flags = list(args) + default_flags
@@ -28,6 +36,16 @@ class Helm(object):
             '--set', f'Username={username_slug}',
             '--set', f'Email={email}',
             '--set', f'Fullname={fullname}',
+        )
+
+    def delete_user(self, username):
+        username_slug = sanitize_dns_label(username)
+        self._helm_command('delete', f'init-user-{username_slug}', '--purge')
+
+    def delete_namespace(self, username):
+        username_slug = sanitize_dns_label(username)
+        self._helm_shell_command(
+            f'delete --purge $(helm list -q --namespace user-{username_slug})'
         )
 
     def config_user(self, username):

--- a/control_panel_api/helm.py
+++ b/control_panel_api/helm.py
@@ -38,11 +38,11 @@ class Helm(object):
             '--set', f'Fullname={fullname}',
         )
 
-    def delete_user(self, username):
+    def uninstall_init_user_chart(self, username):
         username_slug = sanitize_dns_label(username)
         self._helm_command('delete', f'init-user-{username_slug}', '--purge')
 
-    def delete_namespace(self, username):
+    def uninstall_user_charts(self, username):
         username_slug = sanitize_dns_label(username)
         self._helm_shell_command(
             f'delete --purge $(helm list -q --namespace user-{username_slug})'

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -48,6 +48,10 @@ class User(AbstractUser):
         helm.init_user(self.username, self.email, self.get_full_name())
         helm.config_user(self.username)
 
+    def helm_delete(self):
+        helm.delete_namespace(self.username)
+        helm.delete_user(self.username)
+
 
 class App(TimeStampedModel):
     def _slugify(name):

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -49,8 +49,8 @@ class User(AbstractUser):
         helm.config_user(self.username)
 
     def helm_delete(self):
-        helm.delete_namespace(self.username)
-        helm.delete_user(self.username)
+        helm.uninstall_user_charts(self.username)
+        helm.uninstall_init_user_chart(self.username)
 
 
 class App(TimeStampedModel):

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -11,13 +11,14 @@ READONLY = 'readonly'
 logger = logging.getLogger(__name__)
 
 
-def ignore_existing(func):
+def ignore_aws_exceptions(func):
     """Decorates a function to catch and allow exceptions that are thrown for
     existing entities or already created buckets etc, and reraise all others
     """
     exception_names = (
         'BucketAlreadyOwnedByYou',
-        'EntityAlreadyExistsException'
+        'EntityAlreadyExistsException',
+        'NoSuchEntityException',
     )
 
     def inner(*args, **kwargs):
@@ -50,7 +51,7 @@ def _policy_arn(bucket_name, readwrite=False):
         _policy_name(bucket_name, readwrite))
 
 
-@ignore_existing
+@ignore_aws_exceptions
 def create_role(role_name, add_saml_statement=False):
     """See: `sts:AssumeRole` required by kube2iam
     https://github.com/jtblin/kube2iam#iam-roles"""
@@ -97,6 +98,7 @@ def create_role(role_name, add_saml_statement=False):
     aws.create_role(role_name, role_policy)
 
 
+@ignore_aws_exceptions
 def delete_role(role_name):
     aws.delete_role(role_name)
 
@@ -154,7 +156,7 @@ def get_policy_document(bucket_name_arn, readwrite):
     }
 
 
-@ignore_existing
+@ignore_aws_exceptions
 def create_bucket(bucket_name):
     aws.create_bucket(
         bucket_name,
@@ -166,7 +168,7 @@ def create_bucket(bucket_name):
         target_prefix=f"{bucket_name}/")
 
 
-@ignore_existing
+@ignore_aws_exceptions
 def create_bucket_policies(bucket_name, bucket_arn):
     """Create readwrite and readonly policies for s3 bucket"""
     readwrite = True

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -29,32 +29,20 @@ from control_panel_api.tests import (
 class UserTestCase(TestCase):
 
     def test_helm_create_user(self):
-        username = 'foo'
-        email = 'bar@baz.com'
-        name = 'bat'
-        user = User.objects.create(
-            username=username,
-            email=email,
-            name=name,
-        )
+        user = mommy.prepare('control_panel_api.User')
+
         user.helm_create()
 
-        helm.config_user.assert_called_with(username)
-        helm.init_user.assert_called_with(username, email, name)
+        helm.config_user.assert_called_with(user.username)
+        helm.init_user.assert_called_with(user.username, user.email, user.name)
 
     def test_helm_delete_user(self):
-        username = 'foo'
-        email = 'bar@baz.com'
-        name = 'bat'
-        user = User.objects.create(
-            username=username,
-            email=email,
-            name=name,
-        )
+        user = mommy.prepare('control_panel_api.User')
+
         user.helm_delete()
 
-        helm.uninstall_user_charts.assert_called_with(username)
-        helm.uninstall_init_user_chart.assert_called_with(username)
+        helm.uninstall_user_charts.assert_called_with(user.username)
+        helm.uninstall_init_user_chart.assert_called_with(user.username)
 
     def test_aws_create_role_calls_service(self):
         username = 'james'

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -24,8 +24,8 @@ from control_panel_api.tests import (
 @patch.object(aws, 'client', MagicMock())
 @patch.object(helm, 'config_user', MagicMock())
 @patch.object(helm, 'init_user', MagicMock())
-@patch.object(helm, 'delete_namespace', MagicMock())
-@patch.object(helm, 'delete_user', MagicMock())
+@patch.object(helm, 'uninstall_user_charts', MagicMock())
+@patch.object(helm, 'uninstall_init_user_chart', MagicMock())
 class UserTestCase(TestCase):
 
     def test_helm_create_user(self):
@@ -53,8 +53,8 @@ class UserTestCase(TestCase):
         )
         user.helm_delete()
 
-        helm.delete_namespace.assert_called_with(username)
-        helm.delete_user.assert_called_with(username)
+        helm.uninstall_user_charts.assert_called_with(username)
+        helm.uninstall_init_user_chart.assert_called_with(username)
 
     def test_aws_create_role_calls_service(self):
         username = 'james'

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -24,6 +24,8 @@ from control_panel_api.tests import (
 @patch.object(aws, 'client', MagicMock())
 @patch.object(helm, 'config_user', MagicMock())
 @patch.object(helm, 'init_user', MagicMock())
+@patch.object(helm, 'delete_namespace', MagicMock())
+@patch.object(helm, 'delete_user', MagicMock())
 class UserTestCase(TestCase):
 
     def test_helm_create_user(self):
@@ -39,6 +41,20 @@ class UserTestCase(TestCase):
 
         helm.config_user.assert_called_with(username)
         helm.init_user.assert_called_with(username, email, name)
+
+    def test_helm_delete_user(self):
+        username = 'foo'
+        email = 'bar@baz.com'
+        name = 'bat'
+        user = User.objects.create(
+            username=username,
+            email=email,
+            name=name,
+        )
+        user.helm_delete()
+
+        helm.delete_namespace.assert_called_with(username)
+        helm.delete_user.assert_called_with(username)
 
     def test_aws_create_role_calls_service(self):
         username = 'james'

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -107,13 +107,15 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
             set(users3bucket['s3bucket'])
         )
 
+    @patch('control_panel_api.models.User.helm_delete')
     @patch('control_panel_api.models.User.aws_delete_role')
-    def test_delete(self, mock_aws_delete_role):
+    def test_delete(self, mock_aws_delete_role, mock_helm_delete):
         response = self.client.delete(
             reverse('user-detail', (self.fixture.auth0_id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
 
         mock_aws_delete_role.assert_called()
+        mock_helm_delete.assert_called()
 
         response = self.client.get(
             reverse('user-detail', (self.fixture.auth0_id,)))

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -95,6 +95,7 @@ class UserViewSet(viewsets.ModelViewSet):
         instance.delete()
 
         instance.aws_delete_role()
+        instance.helm_delete()
 
 
 class GroupViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## What

User delete now deletes the helm chart and the user's namespace.

The helm command subprocess call needs to change to use some shell trickery.

Renamed decorator to more appropriate.

Test for calls.

## How to review

1. Create a user using API
2. Check for helm 
3. Delete user using API and check helm deleted

https://trello.com/c/zO7SL4ts/589-write-script-that-deletes-leanne-as-a-user-in-order-to-recreate-role-and-recognise-where-theres-an-issue