### PR TITLE
Migration to add OIDC statement to all users' trust policies

### DIFF
--- a/control_panel_api/management/commands/add_oidc_statement_to_users_roles.py
+++ b/control_panel_api/management/commands/add_oidc_statement_to_users_roles.py
@@ -8,6 +8,9 @@ from django.core.management.base import BaseCommand
 from control_panel_api.models import User
 
 
+OIDC_PROVIDER_ARN = f'{settings.IAM_ARN_BASE}:oidc-provider/{settings.OIDC_DOMAIN}/'
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,9 +24,11 @@ class Command(BaseCommand):
             iam_role = iam.Role(user.iam_role_name)
             assume_role_policy_document = iam_role.assume_role_policy_document
 
-            if not self._has_oidc_statement(assume_role_policy_document):
+            if _has_oidc_statement(assume_role_policy_document):
+                logger.info(f'OIDC statement already found in "{user.iam_role_name}" trust policy. Skipping.')
+            else:
                 # Add OIDC statement
-                oidc_statement = self._oidc_statement(user.auth0_id)
+                oidc_statement = _oidc_statement(user.auth0_id)
                 assume_role_policy_document['Statement'].append(oidc_statement)
 
                 # Update role trust policy
@@ -32,34 +37,30 @@ class Command(BaseCommand):
                     PolicyDocument=json.dumps(assume_role_policy_document)
                 )
                 logger.info(f'OIDC statement added to "{user.iam_role_name}" trust policy.')
-            else:
-                logger.info(f'OIDC statement already found in "{user.iam_role_name}" trust policy. Skipping.')
 
-    def _oidc_statement(self, oidc_sub):
-        return {
-            "Effect": "Allow",
-            "Principal": {
-                "Federated": self._oidc_provider_arn,
+
+def _has_oidc_statement(document):
+    for statement in document['Statement']:
+        try:
+            oidc_provider_arn = statement['Principal']['Federated']
+            if oidc_provider_arn == OIDC_PROVIDER_ARN:
+                return True
+        except KeyError:
+            pass
+
+    return False
+
+
+def _oidc_statement(oidc_sub):
+    return {
+        "Effect": "Allow",
+        "Principal": {
+            "Federated": OIDC_PROVIDER_ARN,
+        },
+        "Action": "sts:AssumeRoleWithWebIdentity",
+        "Condition": {
+            "StringEquals": {
+                f"{settings.OIDC_DOMAIN}/:sub": oidc_sub,
             },
-            "Action": "sts:AssumeRoleWithWebIdentity",
-            "Condition": {
-                "StringEquals": {
-                    f"{settings.OIDC_DOMAIN}/:sub": oidc_sub,
-                },
-            },
-        }
-
-    def _has_oidc_statement(self, document):
-        for statement in document['Statement']:
-            try:
-                oidc_provider_arn = statement['Principal']['Federated']
-                if oidc_provider_arn == self._oidc_provider_arn:
-                    return True
-            except KeyError:
-                pass
-
-        return False
-
-    @property
-    def _oidc_provider_arn(self):
-        return f"{settings.IAM_ARN_BASE}:oidc-provider/{settings.OIDC_DOMAIN}/"
+        },
+    }

--- a/control_panel_api/management/commands/add_oidc_statement_to_users_roles.py
+++ b/control_panel_api/management/commands/add_oidc_statement_to_users_roles.py
@@ -1,0 +1,65 @@
+import json
+import logging
+
+import boto3
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from control_panel_api.models import User
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Adds OIDC statement to all users roles trust policies"
+
+    def handle(self, *args, **options):
+        iam = boto3.resource('iam')
+        for user in User.objects.all():
+            # Read role trust policy
+            iam_role = iam.Role(user.iam_role_name)
+            assume_role_policy_document = iam_role.assume_role_policy_document
+
+            if not self._has_oidc_statement(assume_role_policy_document):
+                # Add OIDC statement
+                oidc_statement = self._oidc_statement(user.auth0_id)
+                assume_role_policy_document['Statement'].append(oidc_statement)
+
+                # Update role trust policy
+                assume_role_policy = iam_role.AssumeRolePolicy()
+                assume_role_policy.update(
+                    PolicyDocument=json.dumps(assume_role_policy_document)
+                )
+                logger.info(f'OIDC statement added to "{user.iam_role_name}" trust policy.')
+            else:
+                logger.info(f'OIDC statement already found in "{user.iam_role_name}" trust policy. Skipping.')
+
+    def _oidc_statement(self, oidc_sub):
+        return {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": self._oidc_provider_arn,
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    f"{settings.OIDC_DOMAIN}/:sub": oidc_sub,
+                },
+            },
+        }
+
+    def _has_oidc_statement(self, document):
+        for statement in document['Statement']:
+            try:
+                oidc_provider_arn = statement['Principal']['Federated']
+                if oidc_provider_arn == self._oidc_provider_arn:
+                    return True
+            except KeyError:
+                pass
+
+        return False
+
+    @property
+    def _oidc_provider_arn(self):
+        return f"{settings.IAM_ARN_BASE}:oidc-provider/{settings.OIDC_DOMAIN}/"


### PR DESCRIPTION
### Why
Because without this trust policy users will not be able to log in to AWS using OIDC.

### What

The migration will loop through the users:
1) read the role's trust policy
2) check if the trust policy has already the OIDC statement
3) If not, it will add it to the document
4) Will write back the new role trust policy (if needed)

### boto3 relevant documentation
* [`IAM.Role()`](https://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.Role)
* [`IAM.Role.assume_role_policy_document`](https://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.Role.assume_role_policy_document)
* [`IAM.AssumeRolePolicy()`](https://boto3.readthedocs.io/en/latest/reference/services/iam.html#assumerolepolicy)
* [`IAM.AssumeRolePolicy.update()`](https://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.AssumeRolePolicy.update)
### Related PRs
This is related to Kerin's PR: https://github.com/ministryofjustice/analytics-platform-control-panel/pull/84

### Ticket
https://trello.com/c/Vy7ImBcn/602-4-sso-aws-federated-login-user-roles-migration