### PR TITLE
Revert "TEMPORARILY: Disable `alpha` deployment"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,17 +72,13 @@ jobs:
                 --user ${JENKINS_USER}:${JENKINS_TOKEN}
             fi
 
-      #################################################
-      ##  TEMPORARILY DISABLING DEPLOY TO ALPHA      ##
-      ##  REASON: MORE TESTING OF IAM POLICY REVAMP  ##
-      #################################################
-      # - deploy:
-      #     name: Deploy to alpha
-      #     command: |
-      #       if [ "${CIRCLE_BRANCH}" == "master" ]; then
-      #         curl ${ALPHA_JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
-      #           --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
-      #           --data COMMIT_HASH=${CIRCLE_SHA1} \
-      #           --data BRANCH_NAME=${CIRCLE_BRANCH} \
-      #           --user ${ALPHA_JENKINS_USER}:${ALPHA_JENKINS_TOKEN}
-      #       fi
+      - deploy:
+          name: Deploy to alpha
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              curl ${ALPHA_JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
+                --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
+                --data COMMIT_HASH=${CIRCLE_SHA1} \
+                --data BRANCH_NAME=${CIRCLE_BRANCH} \
+                --user ${ALPHA_JENKINS_USER}:${ALPHA_JENKINS_TOKEN}
+            fi


### PR DESCRIPTION
This reverts commit 58d3aa90dfa1870acaf3c66edb5dd05d88c9acec.

Re-enabling deployment in `alpha`, migration in `dev` worked as
expected

Ticket: https://trello.com/c/2nuxrwiq/586-5-iam-policies-change-from-1-per-bucket-to-1-per-user