### PR TITLE
Clean-up after IAM policy revamp

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -46,11 +46,6 @@ class AWSClient(object):
                 }
             })
 
-    def create_policy(self, name, policy_document):
-        self._do('iam', 'create_policy',
-            PolicyName=name,
-            PolicyDocument=json.dumps(policy_document))
-
     def get_inline_policy_document(self, role_name, policy_name):
         if not self.enabled:
             return None
@@ -73,9 +68,6 @@ class AWSClient(object):
             PolicyName=policy_name,
             PolicyDocument=json.dumps(policy_document)
         )
-
-    def delete_policy(self, policy_arn):
-        self._do('iam', 'delete_policy', PolicyArn=policy_arn)
 
     def create_role(self, role_name, assume_role_policy):
         """Creates IAM role with the given name"""
@@ -103,43 +95,9 @@ class AWSClient(object):
                     policy_arn=policy["PolicyArn"]
                 )
 
-    def detach_policy_from_entities(self, policy_arn):
-        """
-        Get all entities to which policy is attached first then call separate
-        detach operations
-        """
-        entities = self._do(
-            'iam', 'list_entities_for_policy', PolicyArn=policy_arn)
-
-        if entities:
-
-            for role in entities["PolicyRoles"]:
-                self.detach_policy_from_role(policy_arn, role["RoleName"])
-
-            for group in entities["PolicyGroups"]:
-                self.detach_policy_from_group(policy_arn, group["GroupName"])
-
-            for user in entities["PolicyUsers"]:
-                self.detach_policy_from_user(policy_arn, user["UserName"])
-
-    def attach_policy_to_role(self, policy_arn, role_name):
-        self._do('iam', 'attach_role_policy',
-            RoleName=role_name,
-            PolicyArn=policy_arn)
-
     def detach_policy_from_role(self, policy_arn, role_name):
         self._do('iam', 'detach_role_policy',
             RoleName=role_name,
-            PolicyArn=policy_arn)
-
-    def detach_policy_from_group(self, policy_arn, group_name):
-        self._do('iam', 'detach_group_policy',
-            GroupName=group_name,
-            PolicyArn=policy_arn)
-
-    def detach_policy_from_user(self, policy_arn, user_name):
-        self._do('iam', 'detach_user_policy',
-            UserName=user_name,
             PolicyArn=policy_arn)
 
 

--- a/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
+++ b/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
@@ -8,11 +8,33 @@ from control_panel_api.models import (
     AppS3Bucket,
     UserS3Bucket,
 )
-# Using "private" method to get the policy ARN - no point in duplicating it
-from control_panel_api.services import _policy_arn
+
+
+READWRITE = 'readwrite'
+READONLY = 'readonly'
 
 
 logger = logging.getLogger(__name__)
+
+
+# Copied from `services`
+def _policy_name(bucket_name, readwrite=False):
+    """
+    Prefix the policy name with bucket name, postfix with access level
+    eg: dev-james-readwrite
+    """
+    return "{}-{}".format(bucket_name, READWRITE if readwrite else READONLY)
+
+
+# Copied from `services`
+def _policy_arn(bucket_name, readwrite=False):
+    """
+    Return full bucket policy arn
+    eg: arn:aws:iam::1337:policy/bucketname-readonly
+    """
+    return "{}:policy/{}".format(
+        settings.IAM_ARN_BASE,
+        _policy_name(bucket_name, readwrite))
 
 
 class Command(BaseCommand):

--- a/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
+++ b/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
@@ -17,7 +17,6 @@ READONLY = 'readonly'
 logger = logging.getLogger(__name__)
 
 
-# Copied from `services`
 def _policy_name(bucket_name, readwrite=False):
     """
     Prefix the policy name with bucket name, postfix with access level
@@ -26,7 +25,6 @@ def _policy_name(bucket_name, readwrite=False):
     return "{}-{}".format(bucket_name, READWRITE if readwrite else READONLY)
 
 
-# Copied from `services`
 def _policy_arn(bucket_name, readwrite=False):
     """
     Return full bucket policy arn

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -133,11 +133,6 @@ class S3Bucket(TimeStampedModel):
 
     def aws_create(self):
         services.create_bucket(self.name)
-        services.create_bucket_policies(self.name, self.arn)
-
-    def aws_delete(self):
-        """Note we do not destroy the actual data, just the policies"""
-        services.delete_bucket_policies(self.name)
 
     def create_users3bucket(self, user):
         users3bucket = UserS3Bucket.objects.create(

--- a/control_panel_api/tests/__init__.py
+++ b/control_panel_api/tests/__init__.py
@@ -1,31 +1,5 @@
 from django.conf import settings
 
-POLICY_DOCUMENT_READWRITE = {
-    'Version': '2012-10-17',
-    'Statement': [
-        {'Sid': 'ListBucketsInConsole', 'Effect': 'Allow', 'Action': ['s3:GetBucketLocation', 's3:ListAllMyBuckets'],
-         'Resource': 'arn:aws:s3:::*'},
-        {'Sid': 'ListObjects', 'Action': ['s3:ListBucket'], 'Effect': 'Allow', 'Resource': [
-            'arn:aws:s3:::test-bucketname']},
-        {'Sid': 'ReadObjects', 'Action': ['s3:GetObject', 's3:GetObjectAcl', 's3:GetObjectVersion'], 'Effect': 'Allow',
-         'Resource': 'arn:aws:s3:::test-bucketname/*'},
-        {'Sid': 'UpdateRenameAndDeleteObjects',
-         'Action': ['s3:DeleteObject', 's3:DeleteObjectVersion', 's3:PutObject',
-                    's3:PutObjectAcl', 's3:RestoreObject'], 'Effect': 'Allow', 'Resource': 'arn:aws:s3:::test-bucketname/*'}
-    ]
-}
-
-POLICY_DOCUMENT_READONLY = {
-    'Version': '2012-10-17',
-    'Statement': [
-        {'Sid': 'ListBucketsInConsole', 'Effect': 'Allow', 'Action': ['s3:GetBucketLocation', 's3:ListAllMyBuckets'],
-         'Resource': 'arn:aws:s3:::*'},
-        {'Sid': 'ListObjects', 'Action': ['s3:ListBucket'], 'Effect': 'Allow', 'Resource': [
-            'arn:aws:s3:::test-bucketname']},
-        {'Sid': 'ReadObjects', 'Action': ['s3:GetObject', 's3:GetObjectAcl', 's3:GetObjectVersion'], 'Effect': 'Allow',
-         'Resource': 'arn:aws:s3:::test-bucketname/*'}
-    ]
-}
 
 APP_IAM_ROLE_ASSUME_POLICY = {
     "Version": "2012-10-17",

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -18,17 +18,6 @@ class AwsTestCase(TestCase):
         aws.put_bucket_logging('bucketname', 'target_bucket', 'target_prefix')
         aws.client.return_value.put_bucket_logging.assert_called()
 
-    def test_create_policy_json_encoded(self):
-        aws.create_policy('bucketname', {'foo': 'bar'})
-        aws.client.return_value.create_policy.assert_called_with(
-            PolicyName='bucketname',
-            PolicyDocument='{"foo": "bar"}'
-        )
-
-    def test_delete_policy(self):
-        aws.delete_policy('policyarn')
-        aws.client.return_value.delete_policy.assert_called()
-
     def test_get_inline_policy_document_when_found(self):
         role_name = 'test-user-rolename'
         policy_name = 's3-access'
@@ -68,47 +57,9 @@ class AwsTestCase(TestCase):
             PolicyDocument=json.dumps(policy_document),
         )
 
-    def test_detach_policy_from_entities(self):
-        aws.client.return_value.list_entities_for_policy.return_value = {
-            'PolicyRoles': [{'RoleName': 'foo'}],
-            'PolicyGroups': [{'GroupName': 'bar'}],
-            'PolicyUsers': [{'UserName': 'baz'}],
-        }
-
-        aws.detach_policy_from_entities('policyarn')
-
-        aws.client.return_value.list_entities_for_policy.assert_called()
-        aws.client.return_value.detach_role_policy.assert_called_with(
-            RoleName='foo',
-            PolicyArn='policyarn',
-        )
-        aws.client.return_value.detach_group_policy.assert_called_with(
-            GroupName='bar',
-            PolicyArn='policyarn',
-        )
-        aws.client.return_value.detach_user_policy.assert_called_with(
-            UserName='baz',
-            PolicyArn='policyarn',
-        )
-
-    def test_attach_policy_to_role(self):
-        aws.attach_policy_to_role('policyarn', 'rolename')
-        aws.client.return_value.attach_role_policy.assert_called_with(
-            RoleName='rolename',
-            PolicyArn='policyarn',
-        )
-
     def test_detach_policy_from_role(self):
         aws.detach_policy_from_role('policyarn', 'foo')
         aws.client.return_value.detach_role_policy.assert_called()
-
-    def test_detach_policy_from_group(self):
-        aws.detach_policy_from_group('policyarn', 'foo')
-        aws.client.return_value.detach_group_policy.assert_called()
-
-    def test_detach_policy_from_user(self):
-        aws.detach_policy_from_user('policyarn', 'foo')
-        aws.client.return_value.detach_user_policy.assert_called()
 
     def test_create_role(self):
         role_name = "a_role"

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -192,19 +192,10 @@ class S3BucketTestCase(TestCase):
         )
 
     @patch('control_panel_api.services.create_bucket')
-    @patch('control_panel_api.services.create_bucket_policies')
-    def test_bucket_create(self, mock_create_bucket_policies,
-                           mock_create_bucket):
+    def test_bucket_create(self, mock_create_bucket):
         self.s3_bucket_1.aws_create()
 
-        mock_create_bucket_policies.assert_called()
         mock_create_bucket.assert_called()
-
-    @patch('control_panel_api.services.delete_bucket_policies')
-    def test_bucket_delete(self, mock_delete_bucket_policies):
-        self.s3_bucket_1.aws_delete()
-
-        mock_delete_bucket_policies.assert_called()
 
     @patch('control_panel_api.models.UserS3Bucket.aws_create')
     def test_create_users3bucket(self, mock_aws_create):

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -613,13 +613,10 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
             set(users3bucket['user'])
         )
 
-    @patch('control_panel_api.models.S3Bucket.aws_delete')
-    def test_delete(self, mock_aws_delete):
+    def test_delete(self):
         response = self.client.delete(
             reverse('s3bucket-detail', (self.fixture.id,)))
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
-
-        mock_aws_delete.assert_called()
 
         response = self.client.get(
             reverse('s3bucket-detail', (self.fixture.id,)))
@@ -674,8 +671,6 @@ class S3BucketViewTest(AuthenticatedClientMixin, APITestCase):
         fixtures = (
             ('control_panel_api.aws.AWSClient.create_bucket',
              'BucketAlreadyOwnedByYou'),
-            ('control_panel_api.aws.AWSClient.create_policy',
-             'EntityAlreadyExistsException'),
         )
 
         for patch_func, aws_exception in fixtures:

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -194,13 +194,6 @@ class S3BucketViewSet(viewsets.ModelViewSet):
 
         instance.create_users3bucket(user=self.request.user)
 
-    @handle_external_exceptions
-    @transaction.atomic
-    def perform_destroy(self, instance):
-        instance.delete()
-
-        instance.aws_delete()
-
 
 class UserAppViewSet(viewsets.ModelViewSet):
     queryset = UserApp.objects.all()


### PR DESCRIPTION
### Why
Permissions to S3 are not in managed IAM policies anymore.
They're in the user role `s3-access` inline policy.

### What
This means we can delete a bunch of functions which attach/detach policies,
etc...
 - `aws.attach_policy_to_role()`
 - `aws.create_policy()`
 - `aws.delete_policy()`
 - `aws.detach_policy_from_entities()`
 - `aws.detach_policy_from_group()`
 - `aws.detach_policy_from_user()`
 - `models.S3Bucket.aws_delete()`
 - `services.create_bucket_policies()`
 - `services.delete_bucket_policies()`
 - `services.get_policy_document()`
 - `views.S3BucketViewSet.perform_destroy()`

I also moved `_policy_name()` and `_policy_aen()` from the `services` module
into the `migrate_s3_access_roles_to_inline_policies` migration which
is the only place using them. This is not strictly necessary in theory
as I already run this migration but I preferred to keep this migration
functioning.

### Related PR
[Use one inline IAM policy per role](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/88)

### Ticket
Kind of part of: https://trello.com/c/2nuxrwiq/586-5-iam-policies-change-from-1-per-bucket-to-1-per-user