### PR TITLE
Add tagging to data warehouse bucket on create

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -50,14 +50,14 @@ class AWSClient(object):
         """Put bucket tagging
 
         :param name: Bucket name
-        :param tags: List of tags (key, value) e.g. [('buckettype', 'datawarehouse')]
+        :param tags: Tags {key: value} e.g. {'buckettype': 'datawarehouse'}
         :type name: str
-        :type tags: list(tuple)
+        :type tags: dict
         """
         self._do('s3', 'put_bucket_tagging',
             Bucket=name,
             Tagging={
-                'TagSet': [{'Key': k, 'Value': v} for k, v in tags]
+                'TagSet': [{'Key': k, 'Value': v} for k, v in tags.items()]
             })
 
     def get_inline_policy_document(self, role_name, policy_name):

--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -57,7 +57,7 @@ class AWSClient(object):
         self._do('s3', 'put_bucket_tagging',
             Bucket=name,
             Tagging={
-                'TagSet': [{'Key': k, 'Value': v} for k, v in tags.items()]
+                'TagSet': [{'Key': str(k), 'Value': str(v)} for k, v in tags.items()]
             })
 
     def get_inline_policy_document(self, role_name, policy_name):

--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -46,6 +46,20 @@ class AWSClient(object):
                 }
             })
 
+    def put_bucket_tagging(self, name, tags):
+        """Put bucket tagging
+
+        :param name: Bucket name
+        :param tags: List of tags (key, value) e.g. [('buckettype', 'datawarehouse')]
+        :type name: str
+        :type tags: list(tuple)
+        """
+        self._do('s3', 'put_bucket_tagging',
+            Bucket=name,
+            Tagging={
+                'TagSet': [{'Key': k, 'Value': v} for k, v in tags]
+            })
+
     def get_inline_policy_document(self, role_name, policy_name):
         if not self.enabled:
             return None

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -132,7 +132,7 @@ class S3Bucket(TimeStampedModel):
         return f"arn:aws:s3:::{self.name}"
 
     def aws_create(self):
-        services.create_bucket(self.name)
+        services.create_bucket(self.name, self.is_data_warehouse)
 
     def create_users3bucket(self, user):
         users3bucket = UserS3Bucket.objects.create(

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -105,7 +105,7 @@ def create_bucket(bucket_name, is_data_warehouse):
     if is_data_warehouse:
         aws.put_bucket_tagging(
             bucket_name,
-            tags=[('buckettype', 'datawarehouse')]
+            tags={'buckettype': 'datawarehouse'}
         )
 
 

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -91,7 +91,7 @@ def delete_role(role_name):
 
 
 @ignore_aws_exceptions
-def create_bucket(bucket_name):
+def create_bucket(bucket_name, is_data_warehouse):
     aws.create_bucket(
         bucket_name,
         region=settings.BUCKET_REGION,
@@ -101,6 +101,12 @@ def create_bucket(bucket_name):
         target_bucket=settings.LOGS_BUCKET_NAME,
         target_prefix=f"{bucket_name}/")
     aws.put_bucket_encryption(bucket_name)
+
+    if is_data_warehouse:
+        aws.put_bucket_tagging(
+            bucket_name,
+            tags=[('buckettype', 'datawarehouse')]
+        )
 
 
 @contextmanager

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -182,7 +182,6 @@ class AppTestCase(TestCase):
 class S3BucketTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        # Create an S3 bucket
         cls.s3_bucket_1 = S3Bucket.objects.create(name="test-bucket-1")
 
     def test_arn(self):
@@ -195,7 +194,10 @@ class S3BucketTestCase(TestCase):
     def test_bucket_create(self, mock_create_bucket):
         self.s3_bucket_1.aws_create()
 
-        mock_create_bucket.assert_called()
+        mock_create_bucket.assert_called_with(
+            self.s3_bucket_1.name,
+            self.s3_bucket_1.is_data_warehouse,
+        )
 
     @patch('control_panel_api.models.UserS3Bucket.aws_create')
     def test_create_users3bucket(self, mock_aws_create):


### PR DESCRIPTION
## What

Add tagging to data warehouse bucket on create.

Had to rewrite the test patch as that method does not work for multiple mock testing.

## How to review

1. Create a datawarehouse bucket and check the tags aws console