### PR TITLE
Handle better update of S3 policies when `write_to_cluster` is disabled

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -52,6 +52,9 @@ class AWSClient(object):
             PolicyDocument=json.dumps(policy_document))
 
     def get_inline_policy_document(self, role_name, policy_name):
+        if not self.enabled:
+            return None
+
         try:
             result = self._do('iam', 'get_role_policy',
                 RoleName=role_name,

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -1,5 +1,4 @@
 import json
-
 from unittest.case import TestCase
 from unittest.mock import MagicMock, call, patch
 
@@ -50,6 +49,11 @@ class AwsTestCase(TestCase):
         aws.client.return_value.get_role_policy.side_effect = not_found_error
 
         document = aws.get_inline_policy_document(role_name, policy_name)
+        self.assertEqual(document, None)
+
+    @patch.object(aws, 'enabled', False)
+    def test_get_inline_policy_document_when_not_writing_to_cluster(self):
+        document = aws.get_inline_policy_document('test-user-role', 's3-access')
         self.assertEqual(document, None)
 
     def test_put_role_policy(self):


### PR DESCRIPTION
### What

When this flag is disabled the policy `get_role_policy()` will return
`None` (as expected because we don't talk to AWS).
The problem is that we try to access the `PolicyDocument` of `None` and this
is not obviously working.

**NOTE**: This only affects us locally when `write_to_cluster` is disabled.

### Ticket
https://trello.com/c/MxSKSCuR/608-1-fix-grant-revoke-access-locally-when-writetocluster-is-false
