### PR TITLE
Normal users can create/retrieve/list S3 buckets

### DIFF
--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -33,14 +33,22 @@ class AppFilter(SuperusersOnlyFilter):
     pass
 
 
-class S3BucketFilter(SuperusersOnlyFilter):
+class S3BucketFilter(DjangoFilterBackend):
     """
-    Filter to get visible users.
+    Filter to get visible S3 buckets.
 
-    Currently superusers see everything, others see nothing.
+    - Superusers see everything
+    - Normal users see only S3 buckets they have access to (looking at
+      UserS3Bucket records)
     """
 
-    pass
+    def filter_queryset(self, request, queryset, view):
+        queryset = super().filter_queryset(request, queryset, view)
+
+        if is_superuser(request.user):
+            return queryset
+
+        return queryset.filter(users3buckets__user=request.user)
 
 
 class UserFilter(DjangoFilterBackend):

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -51,8 +51,22 @@ class AppPermissions(IsSuperuser):
     pass
 
 
-class S3BucketPermissions(IsSuperuser):
-    pass
+class S3BucketPermissions(BasePermission):
+    """
+    - Superusers can do anything
+    - Normal users can only list buckets they have access to
+
+    NOTE: Filters are applied before permissions
+    """
+
+    def has_permission(self, request, view):
+        if is_superuser(request.user):
+            return True
+
+        if request.user.is_anonymous():
+            return False
+
+        return view.action in ('list')
 
 
 class UserPermissions(BasePermission):

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -54,7 +54,7 @@ class AppPermissions(IsSuperuser):
 class S3BucketPermissions(BasePermission):
     """
     - Superusers can do anything
-    - Normal users can only list buckets they have access to
+    - Normal users can create S3 buckets and list buckets they have access to
 
     NOTE: Filters are applied before permissions
     """
@@ -66,7 +66,7 @@ class S3BucketPermissions(BasePermission):
         if request.user.is_anonymous():
             return False
 
-        return view.action in ('list')
+        return view.action in ('create', 'list')
 
 
 class UserPermissions(BasePermission):

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -54,7 +54,8 @@ class AppPermissions(IsSuperuser):
 class S3BucketPermissions(BasePermission):
     """
     - Superusers can do anything
-    - Normal users can create S3 buckets and list buckets they have access to
+    - Normal users can create S3 buckets and list/retrieve buckets they have
+      access to
 
     NOTE: Filters are applied before permissions
     """
@@ -66,7 +67,7 @@ class S3BucketPermissions(BasePermission):
         if request.user.is_anonymous():
             return False
 
-        return view.action in ('create', 'list')
+        return view.action in ('create', 'list', 'retrieve')
 
 
 class UserPermissions(BasePermission):

--- a/control_panel_api/tests/filters/test_s3bucket_filter.py
+++ b/control_panel_api/tests/filters/test_s3bucket_filter.py
@@ -7,29 +7,27 @@ from rest_framework.test import APITestCase
 class S3BucketFilterTest(APITestCase):
 
     def setUp(self):
-        # Create users
-        self.superuser = mommy.make(
-            "control_panel_api.User", is_superuser=True)
-        self.normal_user = mommy.make(
-            "control_panel_api.User", is_superuser=False)
-        # Create some S3 buckets
-        self.s3_bucket_1 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-1")
-        self.s3_bucket_2 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-2")
-        # Normal user has access to s3_bucket_1
-        self.normal_user.users3buckets.create(
-            s3bucket=self.s3_bucket_1,
-            access_level='readonly',
-            is_admin=False,
-        )
+        self.superuser = mommy.make("control_panel_api.User",
+                                    is_superuser=True)
+        self.normal_user = mommy.make("control_panel_api.User",
+                                      is_superuser=False)
+
+        self.s3_bucket_1 = mommy.make("control_panel_api.S3Bucket",
+                                      name="test-bucket-1")
+        self.s3_bucket_2 = mommy.make("control_panel_api.S3Bucket",
+                                      name="test-bucket-2")
+
+        mommy.make("control_panel_api.UserS3Bucket",
+                   user=self.normal_user,
+                   s3bucket=self.s3_bucket_1,
+                   access_level='readonly',
+                   is_admin=False)
 
     def test_superuser_sees_everything(self):
         self.client.force_login(self.superuser)
 
         response = self.client.get(reverse("s3bucket-list"))
-        s3_bucket_ids = [s3bucket["id"]
-                         for s3bucket in response.data["results"]]
+        s3_bucket_ids = [b["id"] for b in response.data["results"]]
         self.assertEqual(len(s3_bucket_ids), 2)
         self.assertIn(self.s3_bucket_1.id, s3_bucket_ids)
         self.assertIn(self.s3_bucket_2.id, s3_bucket_ids)

--- a/control_panel_api/tests/permissions/test_s3bucket_permissions.py
+++ b/control_panel_api/tests/permissions/test_s3bucket_permissions.py
@@ -19,18 +19,20 @@ class S3BucketPermissionsTest(APITestCase):
 
     def setUp(self):
         super().setUp()
-        # Create users
-        self.superuser = mommy.make(
-            'control_panel_api.User', is_superuser=True)
-        self.normal_user = mommy.make(
-            'control_panel_api.User', is_superuser=False)
-        # Create some S3 buckets
-        self.s3bucket_1 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-1")
-        self.s3bucket_2 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-2")
-        # Normal user has access to s3bucket_1
-        self.normal_user.users3buckets.create(s3bucket=self.s3bucket_1)
+
+        self.superuser = mommy.make('control_panel_api.User',
+                                    is_superuser=True)
+        self.normal_user = mommy.make('control_panel_api.User',
+                                      is_superuser=False)
+
+        self.s3bucket_1 = mommy.make("control_panel_api.S3Bucket",
+                                     name="test-bucket-1")
+        self.s3bucket_2 = mommy.make("control_panel_api.S3Bucket",
+                                     name="test-bucket-2")
+
+        mommy.make("control_panel_api.UserS3Bucket",
+                   user=self.normal_user,
+                   s3bucket=self.s3bucket_1)
 
     def test_list_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)

--- a/control_panel_api/tests/permissions/test_s3bucket_permissions.py
+++ b/control_panel_api/tests/permissions/test_s3bucket_permissions.py
@@ -35,11 +35,11 @@ class S3BucketPermissionsTest(APITestCase):
         response = self.client.get(reverse('s3bucket-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
 
-    def test_list_as_normal_user_responds_403(self):
+    def test_list_as_normal_user_responds_OK(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse('s3bucket-list'))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(HTTP_200_OK, response.status_code)
 
     def test_detail_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)

--- a/control_panel_api/tests/permissions/test_s3bucket_permissions.py
+++ b/control_panel_api/tests/permissions/test_s3bucket_permissions.py
@@ -76,12 +76,12 @@ class S3BucketPermissionsTest(APITestCase):
         response = self.client.post(reverse('s3bucket-list'), data)
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    def test_create_as_normal_user_responds_403(self):
+    def test_create_as_normal_user_responds_OK(self):
         self.client.force_login(self.normal_user)
 
         data = {'name': 'test-bucket'}
         response = self.client.post(reverse('s3bucket-list'), data)
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
 
     def test_update_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)


### PR DESCRIPTION
### What
Normal users can now:
- Create S3 buckets
- List/Retrieve them, user will see only S3 buckets he has access to

### Background
The authoritative source of true when it comes to which users can access what is the list of `UserS3Bucket` records.
Each of this record grant a given user access to an S3 bucket with a certain access level (readonly/readwrite).

### NOTES
- Django filters are applied before permissions, therefore if a record is filtered out by the filter class the user will not be able to perform any operation on that record (e.g. he would get a `404`)
- All others permissions are maintained as before, e.g. normal users cannot update or delete S3 buckets (tests cover these and did not change)

In order to determine if a user has the ability to see an S3 bucket we check if the user has a record for this S3 bucket for his user (with any access level).

### Ticket
https://trello.com/c/JALNEbcN/630-3-buckets-permissions-normal-users-can-create-s3-buckets-becomes-admin