### PR TITLE
Normal users can list/retrieve UserS3Buckets

### DIFF
--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -6,6 +6,7 @@ See: http://www.django-rest-framework.org/api-guide/filtering/#custom-generic-fi
 
 from django_filters.rest_framework import DjangoFilterBackend
 
+from control_panel_api.models import S3Bucket
 from control_panel_api.permissions import is_superuser
 
 
@@ -66,3 +67,27 @@ class UserFilter(DjangoFilterBackend):
             return queryset
 
         return queryset.filter(pk=request.user.pk)
+
+
+class UserS3BucketFilter(DjangoFilterBackend):
+    """
+    Filter to get visible UserS3Bucket records.
+
+    - Superusers see everything
+    - Normal users see only records for buckets they have access.
+      Normal users can also see records for other users that have access
+      to same data (but permissions will enforce they can't change these
+      records unless they're admin)
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        queryset = super().filter_queryset(request, queryset, view)
+
+        if is_superuser(request.user):
+            return queryset
+
+        accessible_buckets = S3Bucket.objects.filter(
+            users3buckets__user=request.user,
+        )
+
+        return queryset.filter(s3bucket=accessible_buckets)

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -91,9 +91,7 @@ class UserPermissions(BasePermission):
 
         return request.user == obj
 
-# NOTE: James is doing some work related to this class as well,
-#       that's why I'm not testing it - he'll add tests.
-#       Only thing relevant for filtering work is `list`/`retrive` actions
+
 class UserS3BucketPermissions(BasePermission):
     """
     - Superusers can do anything

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -91,6 +91,26 @@ class UserPermissions(BasePermission):
 
         return request.user == obj
 
+# NOTE: James is doing some work related to this class as well,
+#       that's why I'm not testing it - he'll add tests.
+#       Only thing relevant for filtering work is `list`/`retrive` actions
+class UserS3BucketPermissions(BasePermission):
+    """
+    - Superusers can do anything
+    - Normal users can list/retrieve UserS3Buckets
+
+    NOTE: Filters are applied before permissions
+    """
+
+    def has_permission(self, request, view):
+        if is_superuser(request.user):
+            return True
+
+        if request.user.is_anonymous():
+            return False
+
+        return view.action in ('list', 'retrieve')
+
 
 class ToolDeploymentPermissions(BasePermission):
 

--- a/control_panel_api/tests/filters/test_s3bucket_filter.py
+++ b/control_panel_api/tests/filters/test_s3bucket_filter.py
@@ -7,21 +7,26 @@ from rest_framework.test import APITestCase
 class S3BucketFilterTest(APITestCase):
 
     def setUp(self):
-        self.superuser = mommy.make("control_panel_api.User",
-                                    is_superuser=True)
-        self.normal_user = mommy.make("control_panel_api.User",
-                                      is_superuser=False)
+        self.superuser = mommy.make(
+            "control_panel_api.User",
+            is_superuser=True)
+        self.normal_user = mommy.make(
+            "control_panel_api.User",
+            is_superuser=False)
 
-        self.s3_bucket_1 = mommy.make("control_panel_api.S3Bucket",
-                                      name="test-bucket-1")
-        self.s3_bucket_2 = mommy.make("control_panel_api.S3Bucket",
-                                      name="test-bucket-2")
+        self.s3_bucket_1 = mommy.make(
+            "control_panel_api.S3Bucket",
+            name="test-bucket-1")
+        self.s3_bucket_2 = mommy.make(
+            "control_panel_api.S3Bucket",
+            name="test-bucket-2")
 
-        mommy.make("control_panel_api.UserS3Bucket",
-                   user=self.normal_user,
-                   s3bucket=self.s3_bucket_1,
-                   access_level='readonly',
-                   is_admin=False)
+        mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.normal_user,
+            s3bucket=self.s3_bucket_1,
+            access_level='readonly',
+            is_admin=False)
 
     def test_superuser_sees_everything(self):
         self.client.force_login(self.superuser)

--- a/control_panel_api/tests/filters/test_users3bucket_filter.py
+++ b/control_panel_api/tests/filters/test_users3bucket_filter.py
@@ -26,13 +26,19 @@ class UserS3BucketFilterTest(APITestCase):
             "control_panel_api.S3Bucket",
             name="test-bucket-2")
 
-        self.s3bucket_1_normal_user_access = self.normal_user.users3buckets.create(
+        self.s3bucket_1_normal_user_access = mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.normal_user,
             s3bucket=self.s3bucket_1,
             access_level=UserS3Bucket.READONLY)
-        self.s3bucket_1_other_user_access = self.other_user.users3buckets.create(
+        self.s3bucket_1_other_user_access = mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.other_user,
             s3bucket=self.s3bucket_1,
             access_level=UserS3Bucket.READONLY)
-        self.s3bucket_2_superuser_access = self.superuser.users3buckets.create(
+        self.s3bucket_2_superuser_access = mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.superuser,
             s3bucket=self.s3bucket_2,
             access_level=UserS3Bucket.READWRITE)
 

--- a/control_panel_api/tests/filters/test_users3bucket_filter.py
+++ b/control_panel_api/tests/filters/test_users3bucket_filter.py
@@ -1,6 +1,6 @@
 from model_mommy import mommy
 from rest_framework.reverse import reverse
-from rest_framework.status import HTTP_403_FORBIDDEN
+from rest_framework.status import HTTP_200_OK
 from rest_framework.test import APITestCase
 
 from control_panel_api.models import UserS3Bucket
@@ -14,17 +14,23 @@ class UserS3BucketFilterTest(APITestCase):
             "control_panel_api.User", is_superuser=True)
         self.normal_user = mommy.make(
             "control_panel_api.User", is_superuser=False)
+        self.normal_user_2 = mommy.make(
+            "control_panel_api.User", is_superuser=False)
         # Create some S3 buckets
         self.s3bucket_1 = mommy.make(
             "control_panel_api.S3Bucket", name="test-bucket-1")
         self.s3bucket_2 = mommy.make(
             "control_panel_api.S3Bucket", name="test-bucket-2")
         # Grant access to these S3 buckets
-        self.users3bucket_1 = self.normal_user.users3buckets.create(
+        self.s3bucket_1_normal_user_access = self.normal_user.users3buckets.create(
             s3bucket=self.s3bucket_1,
             access_level=UserS3Bucket.READONLY,
         )
-        self.users3bucket_2 = self.superuser.users3buckets.create(
+        self.s3bucket_1_normal_user_2_access = self.normal_user_2.users3buckets.create(
+            s3bucket=self.s3bucket_1,
+            access_level=UserS3Bucket.READONLY,
+        )
+        self.s3bucket_2_superuser_access = self.superuser.users3buckets.create(
             s3bucket=self.s3bucket_2,
             access_level=UserS3Bucket.READWRITE,
         )
@@ -35,12 +41,25 @@ class UserS3BucketFilterTest(APITestCase):
         response = self.client.get(reverse("users3bucket-list"))
         ids = [us["id"] for us in response.data["results"]]
 
-        self.assertEqual(len(ids), 2)
-        self.assertIn(self.users3bucket_1.id, ids)
-        self.assertIn(self.users3bucket_2.id, ids)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertEqual(len(ids), 3)
+        self.assertIn(self.s3bucket_1_normal_user_access.id, ids)
+        self.assertIn(self.s3bucket_1_normal_user_2_access.id, ids)
+        self.assertIn(self.s3bucket_2_superuser_access.id, ids)
 
-    def test_normal_user_sees_nothing(self):
+    def test_normal_user_only_sees_records_for_buckets_has_access_to(self):
+        """
+        NOTE: As per requirements, user can see all the `UserS3Bucket` records
+              for buckets he has access to. Basically can see which other
+              users have access to buckets he can read or write.
+        """
+
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse("users3bucket-list"))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+        ids = [us["id"] for us in response.data["results"]]
+        self.assertIn(self.s3bucket_1_normal_user_access.id, ids)
+        self.assertIn(self.s3bucket_1_normal_user_2_access.id, ids)
+        self.assertNotIn(self.s3bucket_2_superuser_access.id, ids)

--- a/control_panel_api/tests/filters/test_users3bucket_filter.py
+++ b/control_panel_api/tests/filters/test_users3bucket_filter.py
@@ -1,0 +1,46 @@
+from model_mommy import mommy
+from rest_framework.reverse import reverse
+from rest_framework.status import HTTP_403_FORBIDDEN
+from rest_framework.test import APITestCase
+
+from control_panel_api.models import UserS3Bucket
+
+
+class UserS3BucketFilterTest(APITestCase):
+
+    def setUp(self):
+        # Create users
+        self.superuser = mommy.make(
+            "control_panel_api.User", is_superuser=True)
+        self.normal_user = mommy.make(
+            "control_panel_api.User", is_superuser=False)
+        # Create some S3 buckets
+        self.s3bucket_1 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-1")
+        self.s3bucket_2 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-2")
+        # Grant access to these S3 buckets
+        self.users3bucket_1 = self.normal_user.users3buckets.create(
+            s3bucket=self.s3bucket_1,
+            access_level=UserS3Bucket.READONLY,
+        )
+        self.users3bucket_2 = self.superuser.users3buckets.create(
+            s3bucket=self.s3bucket_2,
+            access_level=UserS3Bucket.READWRITE,
+        )
+
+    def test_superuser_sees_everything(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(reverse("users3bucket-list"))
+        ids = [us["id"] for us in response.data["results"]]
+
+        self.assertEqual(len(ids), 2)
+        self.assertIn(self.users3bucket_1.id, ids)
+        self.assertIn(self.users3bucket_2.id, ids)
+
+    def test_normal_user_sees_nothing(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.get(reverse("users3bucket-list"))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)

--- a/control_panel_api/tests/filters/test_users3bucket_filter.py
+++ b/control_panel_api/tests/filters/test_users3bucket_filter.py
@@ -9,31 +9,32 @@ from control_panel_api.models import UserS3Bucket
 class UserS3BucketFilterTest(APITestCase):
 
     def setUp(self):
-        # Create users
         self.superuser = mommy.make(
-            "control_panel_api.User", is_superuser=True)
+            "control_panel_api.User",
+            is_superuser=True)
         self.normal_user = mommy.make(
-            "control_panel_api.User", is_superuser=False)
+            "control_panel_api.User",
+            is_superuser=False)
         self.normal_user_2 = mommy.make(
-            "control_panel_api.User", is_superuser=False)
-        # Create some S3 buckets
+            "control_panel_api.User",
+            is_superuser=False)
+
         self.s3bucket_1 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-1")
+            "control_panel_api.S3Bucket",
+            name="test-bucket-1")
         self.s3bucket_2 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-2")
-        # Grant access to these S3 buckets
+            "control_panel_api.S3Bucket",
+            name="test-bucket-2")
+
         self.s3bucket_1_normal_user_access = self.normal_user.users3buckets.create(
             s3bucket=self.s3bucket_1,
-            access_level=UserS3Bucket.READONLY,
-        )
+            access_level=UserS3Bucket.READONLY)
         self.s3bucket_1_normal_user_2_access = self.normal_user_2.users3buckets.create(
             s3bucket=self.s3bucket_1,
-            access_level=UserS3Bucket.READONLY,
-        )
+            access_level=UserS3Bucket.READONLY)
         self.s3bucket_2_superuser_access = self.superuser.users3buckets.create(
             s3bucket=self.s3bucket_2,
-            access_level=UserS3Bucket.READWRITE,
-        )
+            access_level=UserS3Bucket.READWRITE)
 
     def test_superuser_sees_everything(self):
         self.client.force_login(self.superuser)

--- a/control_panel_api/tests/filters/test_users3bucket_filter.py
+++ b/control_panel_api/tests/filters/test_users3bucket_filter.py
@@ -15,7 +15,7 @@ class UserS3BucketFilterTest(APITestCase):
         self.normal_user = mommy.make(
             "control_panel_api.User",
             is_superuser=False)
-        self.normal_user_2 = mommy.make(
+        self.other_user = mommy.make(
             "control_panel_api.User",
             is_superuser=False)
 
@@ -29,7 +29,7 @@ class UserS3BucketFilterTest(APITestCase):
         self.s3bucket_1_normal_user_access = self.normal_user.users3buckets.create(
             s3bucket=self.s3bucket_1,
             access_level=UserS3Bucket.READONLY)
-        self.s3bucket_1_normal_user_2_access = self.normal_user_2.users3buckets.create(
+        self.s3bucket_1_other_user_access = self.other_user.users3buckets.create(
             s3bucket=self.s3bucket_1,
             access_level=UserS3Bucket.READONLY)
         self.s3bucket_2_superuser_access = self.superuser.users3buckets.create(
@@ -45,7 +45,7 @@ class UserS3BucketFilterTest(APITestCase):
         self.assertEqual(HTTP_200_OK, response.status_code)
         self.assertEqual(len(ids), 3)
         self.assertIn(self.s3bucket_1_normal_user_access.id, ids)
-        self.assertIn(self.s3bucket_1_normal_user_2_access.id, ids)
+        self.assertIn(self.s3bucket_1_other_user_access.id, ids)
         self.assertIn(self.s3bucket_2_superuser_access.id, ids)
 
     def test_normal_user_only_sees_records_for_buckets_has_access_to(self):
@@ -62,5 +62,5 @@ class UserS3BucketFilterTest(APITestCase):
 
         ids = [us["id"] for us in response.data["results"]]
         self.assertIn(self.s3bucket_1_normal_user_access.id, ids)
-        self.assertIn(self.s3bucket_1_normal_user_2_access.id, ids)
+        self.assertIn(self.s3bucket_1_other_user_access.id, ids)
         self.assertNotIn(self.s3bucket_2_superuser_access.id, ids)

--- a/control_panel_api/tests/permissions/test_s3bucket_permissions.py
+++ b/control_panel_api/tests/permissions/test_s3bucket_permissions.py
@@ -20,19 +20,24 @@ class S3BucketPermissionsTest(APITestCase):
     def setUp(self):
         super().setUp()
 
-        self.superuser = mommy.make('control_panel_api.User',
-                                    is_superuser=True)
-        self.normal_user = mommy.make('control_panel_api.User',
-                                      is_superuser=False)
+        self.superuser = mommy.make(
+            'control_panel_api.User',
+            is_superuser=True)
+        self.normal_user = mommy.make(
+            'control_panel_api.User',
+            is_superuser=False)
 
-        self.s3bucket_1 = mommy.make("control_panel_api.S3Bucket",
-                                     name="test-bucket-1")
-        self.s3bucket_2 = mommy.make("control_panel_api.S3Bucket",
-                                     name="test-bucket-2")
+        self.s3bucket_1 = mommy.make(
+            "control_panel_api.S3Bucket",
+            name="test-bucket-1")
+        self.s3bucket_2 = mommy.make(
+            "control_panel_api.S3Bucket",
+            name="test-bucket-2")
 
-        mommy.make("control_panel_api.UserS3Bucket",
-                   user=self.normal_user,
-                   s3bucket=self.s3bucket_1)
+        mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.normal_user,
+            s3bucket=self.s3bucket_1)
 
     def test_list_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -18,6 +18,7 @@ from control_panel_api.filters import (
     AppFilter,
     S3BucketFilter,
     UserFilter,
+    UserS3BucketFilter,
 )
 from control_panel_api.models import (
     App,
@@ -33,6 +34,7 @@ from control_panel_api.permissions import (
     S3BucketPermissions,
     ToolDeploymentPermissions,
     UserPermissions,
+    UserS3BucketPermissions,
 )
 from control_panel_api.serializers import (
     AppS3BucketSerializer,
@@ -155,6 +157,8 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
 class UserS3BucketViewSet(viewsets.ModelViewSet):
     queryset = UserS3Bucket.objects.all()
     serializer_class = UserS3BucketSerializer
+    filter_backends = (UserS3BucketFilter,)
+    permission_classes = (UserS3BucketPermissions,)
 
     @handle_external_exceptions
     @transaction.atomic


### PR DESCRIPTION
### What

Allow normal users to see/list `UserS3Bucket`s

Normal users need to have visibility over which user S3 buckets they have access to and also other users having access to same data they have access to.

### How
As per requirements, a user will be able to see all `UserS3Bucket` records for buckets he can access to:
1. Given a list of S3 buckets a user has access to (there is a `UserS3Bucket`
   record for his user)
2. That user can see all `UserS3Bucket` records for buckets above (including `UserS3Bucket` records for other users that have access to same data)

### Notes
`UserS3BucketPermissions` is not tested as James is working on this class as well and he'll add tests.
I added this class mainly to test filtering is working as expected (and without this normal users will just get a `403`).

### Related PRs
This work is based on the changes in https://github.com/ministryofjustice/analytics-platform-control-panel/pull/96 ~I'm waiting for that to be reviewed/merged before I can go ahead with this one.~

### Ticket
https://trello.com/c/21llViWJ/632-3-buckets-permissions-normal-users-can-see-buckets-they-have-access-to-and-other-users-that-have-access-to-the-same-bucket