### PR TITLE
UserS3Bucket permissions

### DIFF
--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -49,7 +49,7 @@ class S3BucketFilter(DjangoFilterBackend):
         if is_superuser(request.user):
             return queryset
 
-        return queryset.filter(users3buckets__user=request.user)
+        return queryset.accessible_by(request.user)
 
 
 class UserFilter(DjangoFilterBackend):

--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -86,8 +86,6 @@ class UserS3BucketFilter(DjangoFilterBackend):
         if is_superuser(request.user):
             return queryset
 
-        accessible_buckets = S3Bucket.objects.filter(
-            users3buckets__user=request.user,
-        )
+        accessible_buckets = S3Bucket.objects.accessible_by(request.user)
 
-        return queryset.filter(s3bucket=accessible_buckets)
+        return queryset.filter(s3bucket__in=accessible_buckets)

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -115,9 +115,9 @@ class UserApp(TimeStampedModel):
         ordering = ('id',)
 
 
-class S3BucketManager(models.Manager):
+class S3BucketQuerySet(models.QuerySet):
     def accessible_by(self, user):
-        return self.get_queryset().filter(
+        return self.filter(
             users3buckets__user=user,
         )
 
@@ -136,7 +136,7 @@ class S3Bucket(TimeStampedModel):
     created_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
     is_data_warehouse = models.BooleanField(default=False)
 
-    objects = S3BucketManager()
+    objects = S3BucketQuerySet.as_manager()
 
     class Meta:
         ordering = ('name',)

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -115,6 +115,14 @@ class UserApp(TimeStampedModel):
         ordering = ('id',)
 
 
+class S3BucketManager(models.Manager):
+    def accessible_by_admin(self, user):
+        return self.get_queryset().filter(
+            users3buckets__user=user,
+            users3buckets__is_admin=True,
+        )
+
+
 class S3Bucket(TimeStampedModel):
     name = models.CharField(unique=True, max_length=63, validators=[
         validators.validate_env_prefix,
@@ -123,6 +131,8 @@ class S3Bucket(TimeStampedModel):
     ])
     created_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
     is_data_warehouse = models.BooleanField(default=False)
+
+    objects = S3BucketManager()
 
     class Meta:
         ordering = ('name',)
@@ -272,3 +282,6 @@ class UserS3Bucket(AccessToS3Bucket):
 
     def aws_role_name(self):
         return self.user.iam_role_name
+
+    def user_is_admin(self, user):
+        return self.user == user and self.is_admin

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -116,9 +116,13 @@ class UserApp(TimeStampedModel):
 
 
 class S3BucketManager(models.Manager):
-    def accessible_by_admin(self, user):
+    def accessible_by(self, user):
         return self.get_queryset().filter(
             users3buckets__user=user,
+        )
+
+    def accessible_by_admin(self, user):
+        return self.accessible_by(user).filter(
             users3buckets__is_admin=True,
         )
 

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -121,7 +121,7 @@ class S3BucketQuerySet(models.QuerySet):
             users3buckets__user=user,
         )
 
-    def accessible_by_admin(self, user):
+    def administered_by(self, user):
         return self.accessible_by(user).filter(
             users3buckets__is_admin=True,
         )

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -122,7 +122,8 @@ class S3BucketQuerySet(models.QuerySet):
         )
 
     def administered_by(self, user):
-        return self.accessible_by(user).filter(
+        return self.filter(
+            users3buckets__user=user,
             users3buckets__is_admin=True,
         )
 

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -108,7 +108,7 @@ class UserS3BucketPermissions(BasePermission):
         serializer = UserS3BucketSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        accessible_buckets = S3Bucket.objects.accessible_by_admin(request.user)
+        accessible_buckets = S3Bucket.objects.administered_by(request.user)
 
         if serializer.validated_data['s3bucket'] in accessible_buckets:
             return True
@@ -120,7 +120,7 @@ class UserS3BucketPermissions(BasePermission):
         if obj.user_is_admin(request.user):
             return True
 
-        if obj.s3bucket in S3Bucket.objects.accessible_by_admin(request.user):
+        if obj.s3bucket in S3Bucket.objects.administered_by(request.user):
             return True
 
 

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -99,7 +99,10 @@ class UserS3BucketPermissions(BasePermission):
         if is_superuser(request.user):
             return True
 
-        if view.action not in ('create',):
+        if request.user.is_anonymous():
+            return False
+
+        if view.action != 'create':
             return True
 
         serializer = UserS3BucketSerializer(data=request.data)

--- a/control_panel_api/tests/permissions/test_s3bucket_permissions.py
+++ b/control_panel_api/tests/permissions/test_s3bucket_permissions.py
@@ -11,12 +11,9 @@ from rest_framework.status import (
 )
 from rest_framework.test import APITestCase
 
-from control_panel_api.aws import aws
 
-
-@patch.object(aws, 'client', MagicMock())
+@patch('control_panel_api.aws.aws.client', MagicMock())
 class S3BucketPermissionsTest(APITestCase):
-
     def setUp(self):
         super().setUp()
 

--- a/control_panel_api/tests/permissions/test_users3bucket_permissions.py
+++ b/control_panel_api/tests/permissions/test_users3bucket_permissions.py
@@ -1,0 +1,166 @@
+from unittest.mock import MagicMock, patch
+
+from model_mommy import mommy
+from rest_framework.reverse import reverse
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
+)
+from rest_framework.test import APITestCase
+
+from control_panel_api.models import AccessToS3Bucket
+
+
+@patch('control_panel_api.aws.aws.client', MagicMock())
+class UserS3Buckets(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.superuser = mommy.make(
+            'control_panel_api.User',
+            auth0_id='github|user_1',
+            is_superuser=True,
+        )
+        self.normal_user = mommy.make(
+            'control_panel_api.User',
+            username='alice normal',
+            auth0_id='github|user_2',
+            is_superuser=False,
+        )
+
+        self.user_1 = mommy.make(
+            "control_panel_api.User",
+            is_superuser=False,
+        )
+        self.s3bucket_1 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-1")
+        self.s3bucket_2 = mommy.make(
+            "control_panel_api.S3Bucket", name="test-bucket-2")
+
+        self.users3bucket_admin = mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.normal_user,
+            s3bucket=self.s3bucket_1,
+            access_level=AccessToS3Bucket.READWRITE,
+            is_admin=True,
+        )
+        self.users3bucket_non_admin = mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.normal_user,
+            s3bucket=self.s3bucket_2,
+            access_level=AccessToS3Bucket.READWRITE,
+            is_admin=False,
+        )
+        self.users3bucket_2_admin = mommy.make(
+            "control_panel_api.UserS3Bucket",
+            user=self.user_1,
+            s3bucket=self.s3bucket_1,
+            access_level=AccessToS3Bucket.READWRITE,
+            is_admin=True,
+        )
+
+    def test_create_superuser_ok(self):
+        self.client.force_login(self.superuser)
+
+        data = {
+            'user': self.user_1.auth0_id,
+            's3bucket': self.s3bucket_2.id,
+            'access_level': AccessToS3Bucket.READWRITE,
+        }
+        response = self.client.post(reverse('users3bucket-list'), data)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    def test_create_normal_user_bad_data_400(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'doesnt': 'matter'}
+        response = self.client.post(reverse('users3bucket-list'), data)
+        self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
+
+    def test_create_normal_user_other_admin_ok(self):
+        self.client.force_login(self.normal_user)
+
+        data = {
+            'user': mommy.make('control_panel_api.User').auth0_id,
+            's3bucket': self.s3bucket_1.id,
+            'access_level': AccessToS3Bucket.READWRITE,
+            'is_admin': True,
+        }
+        response = self.client.post(reverse('users3bucket-list'), data)
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+    def test_create_normal_user_non_admin_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {
+            'user': mommy.make('control_panel_api.User').auth0_id,
+            's3bucket': self.s3bucket_2.id,
+            'access_level': AccessToS3Bucket.READWRITE,
+            'is_admin': True,
+        }
+        response = self.client.post(reverse('users3bucket-list'), data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_super_user_owner_admin_ok(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.delete(
+            reverse('users3bucket-detail', (self.users3bucket_admin.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_delete_normal_user_owner_admin_ok(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('users3bucket-detail', (self.users3bucket_admin.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_delete_normal_user_other_admin_ok(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('users3bucket-detail', (self.users3bucket_2_admin.id,)))
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_delete_normal_user_owner_non_admin_403(self):
+        self.client.force_login(self.normal_user)
+
+        response = self.client.delete(
+            reverse('users3bucket-detail', (self.users3bucket_non_admin.id,)))
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_update_super_user_owner_admin_ok(self):
+        self.client.force_login(self.superuser)
+
+        data = {'access_level': AccessToS3Bucket.READONLY}
+        response = self.client.patch(
+            reverse('users3bucket-detail', (self.users3bucket_admin.id,)), data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_update_normal_user_owner_admin_ok(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'access_level': AccessToS3Bucket.READONLY}
+        response = self.client.patch(
+            reverse('users3bucket-detail', (self.users3bucket_admin.id,)), data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_update_normal_user_other_admin_ok(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'access_level': AccessToS3Bucket.READONLY}
+        response = self.client.patch(
+            reverse('users3bucket-detail', (self.users3bucket_2_admin.id,)),
+            data)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+
+    def test_update_normal_user_non_admin_403(self):
+        self.client.force_login(self.normal_user)
+
+        data = {'access_level': AccessToS3Bucket.READONLY}
+        response = self.client.patch(
+            reverse('users3bucket-detail', (self.users3bucket_non_admin.id,)),
+            data)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -6,25 +6,22 @@ from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_204_NO_CONTENT,
-    HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
 )
 from rest_framework.test import APITestCase
 
-from control_panel_api.aws import aws
-from control_panel_api.models import AccessToS3Bucket, AppS3Bucket
+from control_panel_api.models import AppS3Bucket
 
 
-@patch.object(aws, 'client', MagicMock())
+@patch('control_panel_api.aws.aws.client', MagicMock())
 class AppPermissionsTest(APITestCase):
     def setUp(self):
         super().setUp()
-        # Create users
         self.superuser = mommy.make(
             'control_panel_api.User', is_superuser=True)
         self.normal_user = mommy.make(
             'control_panel_api.User', is_superuser=False)
-        # Create some apps
+
         self.app_1 = mommy.make(
             "control_panel_api.App", name="App 1")
         self.app_2 = mommy.make(
@@ -54,8 +51,7 @@ class AppPermissionsTest(APITestCase):
         response = self.client.get(reverse('app-detail', (self.app_1.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    @patch('boto3.client')
-    def test_delete_as_superuser_responds_OK(self, mock_client):
+    def test_delete_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         response = self.client.delete(
@@ -69,8 +65,7 @@ class AppPermissionsTest(APITestCase):
             reverse('app-detail', (self.app_1.id,)))
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    @patch('boto3.client')
-    def test_create_as_superuser_responds_OK(self, mock_client):
+    def test_create_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
 
         data = {'name': 'foo', 'repo_url': 'https://example.com'}
@@ -101,28 +96,27 @@ class AppPermissionsTest(APITestCase):
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 
-@patch.object(aws, 'client', MagicMock())
+@patch('control_panel_api.aws.aws.client', MagicMock())
 class AppS3BucketPermissionsTest(APITestCase):
     def setUp(self):
         super().setUp()
-        # Create users
         self.superuser = mommy.make(
             "control_panel_api.User", is_superuser=True)
         self.normal_user = mommy.make(
             "control_panel_api.User", is_superuser=False)
-        # Create some apps
+
         self.app_1 = mommy.make(
             "control_panel_api.App", name="App 1")
         self.app_2 = mommy.make(
             "control_panel_api.App", name="App 2")
-        # Create some S3 buckets
+
         self.s3bucket_1 = mommy.make(
             "control_panel_api.S3Bucket", name="test-bucket-1")
         self.s3bucket_2 = mommy.make(
             "control_panel_api.S3Bucket", name="test-bucket-2")
         self.s3bucket_3 = mommy.make(
             "control_panel_api.S3Bucket", name="test-bucket-3")
-        # Grant access to these S3 buckets
+
         self.apps3bucket_1 = self.app_1.apps3buckets.create(
             s3bucket=self.s3bucket_1,
             access_level=AppS3Bucket.READONLY,
@@ -208,158 +202,6 @@ class AppS3BucketPermissionsTest(APITestCase):
         data = {'doesnt': 'matter'}
         response = self.client.put(
             reverse('apps3bucket-detail', (self.apps3bucket_1.id,)), data)
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-
-@patch('control_panel_api.aws.aws.client', MagicMock())
-class UserS3Buckets(APITestCase):
-    def setUp(self):
-        super().setUp()
-        self.superuser = mommy.make(
-            'control_panel_api.User',
-            auth0_id='github|user_1',
-            is_superuser=True,
-        )
-        self.normal_user = mommy.make(
-            'control_panel_api.User',
-            username='alice normal',
-            auth0_id='github|user_2',
-            is_superuser=False,
-        )
-
-        self.user_1 = mommy.make(
-            "control_panel_api.User",
-            is_superuser=False,
-        )
-        self.s3bucket_1 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-1")
-        self.s3bucket_2 = mommy.make(
-            "control_panel_api.S3Bucket", name="test-bucket-2")
-
-        self.users3bucket_admin = mommy.make(
-            "control_panel_api.UserS3Bucket",
-            user=self.normal_user,
-            s3bucket=self.s3bucket_1,
-            access_level=AccessToS3Bucket.READWRITE,
-            is_admin=True,
-        )
-        self.users3bucket_non_admin = mommy.make(
-            "control_panel_api.UserS3Bucket",
-            user=self.normal_user,
-            s3bucket=self.s3bucket_2,
-            access_level=AccessToS3Bucket.READWRITE,
-            is_admin=False,
-        )
-        self.users3bucket_2_admin = mommy.make(
-            "control_panel_api.UserS3Bucket",
-            user=self.user_1,
-            s3bucket=self.s3bucket_1,
-            access_level=AccessToS3Bucket.READWRITE,
-            is_admin=True,
-        )
-
-    def test_create_superuser_ok(self):
-        self.client.force_login(self.superuser)
-
-        data = {
-            'user': self.user_1.auth0_id,
-            's3bucket': self.s3bucket_2.id,
-            'access_level': AccessToS3Bucket.READWRITE,
-        }
-        response = self.client.post(reverse('users3bucket-list'), data)
-        self.assertEqual(HTTP_201_CREATED, response.status_code)
-
-    def test_create_normal_user_bad_data_400(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'doesnt': 'matter'}
-        response = self.client.post(reverse('users3bucket-list'), data)
-        self.assertEqual(HTTP_400_BAD_REQUEST, response.status_code)
-
-    def test_create_normal_user_other_admin_ok(self):
-        self.client.force_login(self.normal_user)
-
-        data = {
-            'user': mommy.make('control_panel_api.User').auth0_id,
-            's3bucket': self.s3bucket_1.id,
-            'access_level': AccessToS3Bucket.READWRITE,
-            'is_admin': True,
-        }
-        response = self.client.post(reverse('users3bucket-list'), data)
-        self.assertEqual(HTTP_201_CREATED, response.status_code)
-
-    def test_create_normal_user_non_admin_403(self):
-        self.client.force_login(self.normal_user)
-
-        data = {
-            'user': mommy.make('control_panel_api.User').auth0_id,
-            's3bucket': self.s3bucket_2.id,
-            'access_level': AccessToS3Bucket.READWRITE,
-            'is_admin': True,
-        }
-        response = self.client.post(reverse('users3bucket-list'), data)
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_delete_super_user_owner_admin_ok(self):
-        self.client.force_login(self.superuser)
-
-        response = self.client.delete(
-            reverse('users3bucket-detail', (self.users3bucket_admin.id,)))
-        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
-
-    def test_delete_normal_user_owner_admin_ok(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.delete(
-            reverse('users3bucket-detail', (self.users3bucket_admin.id,)))
-        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
-
-    def test_delete_normal_user_other_admin_ok(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.delete(
-            reverse('users3bucket-detail', (self.users3bucket_2_admin.id,)))
-        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
-
-    def test_delete_normal_user_owner_non_admin_403(self):
-        self.client.force_login(self.normal_user)
-
-        response = self.client.delete(
-            reverse('users3bucket-detail', (self.users3bucket_non_admin.id,)))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
-
-    def test_update_super_user_owner_admin_ok(self):
-        self.client.force_login(self.superuser)
-
-        data = {'access_level': AccessToS3Bucket.READONLY}
-        response = self.client.patch(
-            reverse('users3bucket-detail', (self.users3bucket_admin.id,)), data)
-        self.assertEqual(HTTP_200_OK, response.status_code)
-
-    def test_update_normal_user_owner_admin_ok(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'access_level': AccessToS3Bucket.READONLY}
-        response = self.client.patch(
-            reverse('users3bucket-detail', (self.users3bucket_admin.id,)), data)
-        self.assertEqual(HTTP_200_OK, response.status_code)
-
-    def test_update_normal_user_other_admin_ok(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'access_level': AccessToS3Bucket.READONLY}
-        response = self.client.patch(
-            reverse('users3bucket-detail', (self.users3bucket_2_admin.id,)),
-            data)
-        self.assertEqual(HTTP_200_OK, response.status_code)
-
-    def test_update_normal_user_non_admin_403(self):
-        self.client.force_login(self.normal_user)
-
-        data = {'access_level': AccessToS3Bucket.READONLY}
-        response = self.client.patch(
-            reverse('users3bucket-detail', (self.users3bucket_non_admin.id,)),
-            data)
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
 

--- a/control_panel_api/tests/test_permissions.py
+++ b/control_panel_api/tests/test_permissions.py
@@ -463,8 +463,8 @@ class ToolDeploymentPermissionsTest(APITestCase):
         )
         self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
-    @patch('control_panel_api.views.Tool')
-    def test_normal_user_can_deploy_tool(self, mock_tool):
+    @patch('control_panel_api.views.Tool', MagicMock())
+    def test_normal_user_can_deploy_tool(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.post(
@@ -474,8 +474,8 @@ class ToolDeploymentPermissionsTest(APITestCase):
         )
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-    @patch('control_panel_api.views.Tool')
-    def test_superuser_can_deploy_tool(self, mock_tool):
+    @patch('control_panel_api.views.Tool', MagicMock())
+    def test_superuser_can_deploy_tool(self):
         self.client.force_login(self.superuser)
 
         response = self.client.post(


### PR DESCRIPTION
## What

This implements the permissions for users3bucket and also merges Aldo's filter work.

## How to review

1. Run the tests

https://trello.com/c/d7ztSVXv/635-3-users3bucket-permissions-a-normal-user-can-create-a-new-record-if-that-user-is-an-existing-admin-of-the-s3bucket