### PR TITLE
Auth0 customers

### DIFF
--- a/control_panel_api/auth0.py
+++ b/control_panel_api/auth0.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+
+from moj_analytics.auth0_client import (
+    Auth0 as Auth0Client,
+    AuthorizationAPI,
+    Group,
+)
+
+
+class Auth0(object):
+    def __init__(self):
+        self.api = Auth0Client(
+            settings.OIDC_CLIENT_ID,
+            settings.OIDC_CLIENT_SECRET,
+            settings.OIDC_DOMAIN
+        )
+
+    @property
+    def authorization_api(self):
+        if not hasattr(self.api, 'authorization'):
+            self.api.access(AuthorizationAPI(
+                settings.OIDC_AUTH_EXTENSION_URL,
+                settings.OIDC_AUTH_EXTENSION_AUDIENCE,
+            ))
+
+        return self.api.authorization
+
+    def get_group_members(self, app_name):
+        group = self.authorization_api.get(Group(name=app_name))
+
+        if group is None:
+            return None
+
+        return group.get_members()
+
+
+auth0 = Auth0()

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -252,3 +252,10 @@ class UserSerializer(serializers.ModelSerializer):
             'is_superuser',
             'email_verified',
         )
+
+
+class GroupMemberSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    user_id = serializers.CharField(max_length=64)
+    nickname = serializers.CharField(max_length=64)
+    name = serializers.CharField(max_length=64)

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -156,6 +156,8 @@ OIDC_FIELD_USERNAME = 'nickname'
 OIDC_FIELD_EMAIL = 'email'
 OIDC_FIELD_NAME = 'name'
 OIDC_WELL_KNOWN_URL = f'https://{OIDC_DOMAIN}/.well-known/jwks.json'
+OIDC_AUTH_EXTENSION_URL = os.environ.get('OIDC_AUTH_EXTENSION_URL')
+OIDC_AUTH_EXTENSION_AUDIENCE = os.environ.get('OIDC_AUTH_EXTENSION_AUDIENCE', 'urn:auth0-authz-api')
 
 # Helm variables
 NFS_HOSTNAME = os.environ.get('NFS_HOSTNAME')

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -24,7 +24,6 @@ from control_panel_api.models import (
     UserApp,
     UserS3Bucket,
 )
-
 from control_panel_api.tests.test_authentication import (
     build_jwt_from_user,
     mock_get_keys,
@@ -319,9 +318,17 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
         mock_create_role.assert_called()
 
+    @patch('control_panel_api.auth0.Auth0.get_group_members')
+    def test_customers(self, mock_get_group_members):
+        mock_get_group_members.return_value = [{'email': 'foo@example.com'}]
+
+        response = self.client.get(reverse('app-customers', (self.fixture.id,)))
+
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        mock_get_group_members.assert_called()
+
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):
-
     def setUp(self):
         super().setUp()
 

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -320,12 +320,32 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
     @patch('control_panel_api.auth0.Auth0.get_group_members')
     def test_customers(self, mock_get_group_members):
-        mock_get_group_members.return_value = [{'email': 'foo@example.com'}]
+        mock_get_group_members.return_value = [{
+            "email": "a.user@digital.justice.gov.uk",
+            "user_id": "email|5955f7ee86da0c1d55foobar",
+            "nickname": "a.user",
+            "name": "a.user@digital.justice.gov.uk",
+            "foo": "bar",
+            "baz": "bat",
+        }]
 
         response = self.client.get(reverse('app-customers', (self.fixture.id,)))
 
         self.assertEqual(HTTP_200_OK, response.status_code)
         mock_get_group_members.assert_called()
+
+        self.assertEqual(1, len(response.data))
+
+        expected_fields = {
+            'email',
+            'user_id',
+            'nickname',
+            'name',
+        }
+        self.assertEqual(
+            expected_fields,
+            set(response.data[0]),
+        )
 
 
 class AppS3BucketViewTest(AuthenticatedClientMixin, APITestCase):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -5,11 +5,13 @@ from botocore.exceptions import ClientError
 from django.contrib.auth.models import Group
 from django.db import transaction
 from django.http import JsonResponse
+from django.http.response import Http404
 from django.views.decorators.csrf import csrf_exempt
-from rest_framework import viewsets, status
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.exceptions import ValidationError
+from rest_framework import status, viewsets
+from rest_framework.decorators import api_view, detail_route, permission_classes
+from rest_framework.response import Response
 
+from control_panel_api.auth0 import auth0
 from control_panel_api.exceptions import (
     AWSException,
     HelmException,
@@ -20,6 +22,7 @@ from control_panel_api.filters import (
     UserFilter,
     UserS3BucketFilter,
 )
+from control_panel_api.k8s import proxy as k8s_proxy
 from control_panel_api.models import (
     App,
     AppS3Bucket,
@@ -30,6 +33,7 @@ from control_panel_api.models import (
 )
 from control_panel_api.permissions import (
     AppPermissions,
+    IsSuperuser,
     K8sPermissions,
     S3BucketPermissions,
     ToolDeploymentPermissions,
@@ -45,9 +49,7 @@ from control_panel_api.serializers import (
     UserS3BucketSerializer,
     UserSerializer,
 )
-from control_panel_api.k8s import proxy as k8s_proxy
 from control_panel_api.tools import Tool
-
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +128,17 @@ class AppViewSet(viewsets.ModelViewSet):
         instance.delete()
 
         instance.aws_delete_role()
+
+    @detail_route(permission_classes=[IsSuperuser])
+    def customers(self, request, pk=None):
+        instance = self.get_object()
+
+        members = auth0.get_group_members(instance.name)
+
+        if members is None:
+            raise Http404
+
+        return Response(members)
 
 
 class AppS3BucketViewSet(viewsets.ModelViewSet):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -43,6 +43,7 @@ from control_panel_api.permissions import (
 from control_panel_api.serializers import (
     AppS3BucketSerializer,
     AppSerializer,
+    GroupMemberSerializer,
     GroupSerializer,
     S3BucketSerializer,
     UserAppSerializer,
@@ -138,7 +139,10 @@ class AppViewSet(viewsets.ModelViewSet):
         if members is None:
             raise Http404
 
-        return Response(members)
+        serializer = GroupMemberSerializer(data=members, many=True)
+        serializer.is_valid()
+
+        return Response(serializer.data)
 
 
 class AppS3BucketViewSet(viewsets.ModelViewSet):

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -248,6 +248,10 @@ class Role(AuthzResource):
             role=self['name']))
 
 
+class Member(AuthzResource):
+    pass
+
+
 class Group(AuthzResource):
 
     def add_role(self, role):
@@ -277,3 +281,9 @@ class Group(AuthzResource):
         print('Added users({users}) to group({group})'.format(
             users=', '.join(user['email'] for user in users),
             group=self['name']))
+
+    def get_members(self):
+        results = self.api.request(
+            'GET', f"groups/{self['_id']}/members")
+
+        return [Member(self, r) for r in results['users']]


### PR DESCRIPTION
## What

We store the list of "customers" in auth0, under a Group per app.

This endpoint basically proxies through to auth0 and returns the list of users.

Linked with PR https://github.com/ministryofjustice/analytics-platform-config/pull/36

## How to review

1. Run the api and access /apps/1/customers/

https://trello.com/c/9v9FtCdI/670-build-codebase-to-retrieve-auth0-group-members-from-an-app-agreed-on-a-url-structure-to-be-implemented-today