### PR TITLE
Cache Auth0's JWKS to avoid expensive requests

### DIFF
--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.core.cache import cache
 from jose import jwt
 from jose.exceptions import JWTError
 import requests
@@ -29,8 +30,14 @@ def get_jwt(request):
 
 
 def get_jwks():
-    response = requests.get(settings.OIDC_WELL_KNOWN_URL)
-    return response.json()
+    jwks = cache.get(settings.OIDC_WELL_KNOWN_URL)
+
+    if not jwks:
+        response = requests.get(settings.OIDC_WELL_KNOWN_URL)
+        jwks = response.json()
+        cache.set(settings.OIDC_WELL_KNOWN_URL, jwks)
+
+    return jwks
 
 
 def get_matching_key(kid, jwks):


### PR DESCRIPTION
### What
As part of the authentication the JWT token provided by the user
needs to be verified against Auth0's public key exposed at
well-known URL.

Currently we make a request to the well-known URL every time,
this is OK but time consuming, especially considering that these
keys don't change very often.

I'm tweaking `authentication.get_jwks()` to look for these keys into
[Django cache](https://docs.djangoproject.com/en/1.7/topics/cache/#django-s-cache-framework) before making a request to Auth0.

I'm keeping it simple and just using default memory cache.
The default timeout for cache values is [5 minutes](https://docs.djangoproject.com/en/1.7/topics/cache/#cache-arguments).


### How to review

1. Start the server
2. Make a couple of request using the UI
3. Do you notice anything different? No? Good.


### Ticket
No ticket, I went a bit "wild" on this one and just played with it. Sorry.