### PR TITLE
App Customers (Auth0 group members)

### DIFF
--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -256,6 +256,13 @@ class UserSerializer(serializers.ModelSerializer):
 
 class GroupMemberSerializer(serializers.Serializer):
     email = serializers.EmailField()
-    user_id = serializers.CharField(max_length=64)
-    nickname = serializers.CharField(max_length=64)
-    name = serializers.CharField(max_length=64)
+    user_id = serializers.CharField(max_length=64, required=False)
+    nickname = serializers.CharField(max_length=64, required=False)
+    name = serializers.CharField(max_length=64, required=False)
+
+    class Meta:
+        read_only_fields = (
+            'user_id',
+            'nickname',
+            'name',
+        )

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -343,7 +343,7 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
             "baz": "bat",
         }]
 
-        response = self.client.get(reverse('app-customers', (self.fixture.id,)))
+        response = self.client.get(reverse('appcustomers-list', (self.fixture.id,)))
 
         self.assertEqual(HTTP_200_OK, response.status_code)
         mock_get_group_members.assert_called()

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -28,6 +28,7 @@ from control_panel_api.tests.test_authentication import (
     build_jwt_from_user,
     mock_get_keys,
 )
+from moj_analytics.auth0_client import Group, User as Auth0User
 
 
 class AuthenticatedClientMixin(object):
@@ -332,8 +333,14 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
 
         mock_create_role.assert_called()
 
+
+class AppCustomersAPIViewTest(AuthenticatedClientMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.fixture = mommy.make('control_panel_api.App')
+
     @patch('control_panel_api.auth0.Auth0.get_group_members')
-    def test_customers(self, mock_get_group_members):
+    def test_get(self, mock_get_group_members):
         mock_get_group_members.return_value = [{
             "email": "a.user@digital.justice.gov.uk",
             "user_id": "email|5955f7ee86da0c1d55foobar",
@@ -343,7 +350,8 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
             "baz": "bat",
         }]
 
-        response = self.client.get(reverse('appcustomers-list', (self.fixture.id,)))
+        response = self.client.get(
+            reverse('appcustomers-list', (self.fixture.id,)))
 
         self.assertEqual(HTTP_200_OK, response.status_code)
         mock_get_group_members.assert_called()
@@ -359,6 +367,87 @@ class AppViewTest(AuthenticatedClientMixin, APITestCase):
         self.assertEqual(
             expected_fields,
             set(response.data[0]),
+        )
+
+    @patch('control_panel_api.auth0.auth0.api')
+    def test_post(self, mock_api):
+        api_get_user_response = {'user_id': 123}
+        mock_api.authorization.get.return_value = api_get_user_response
+
+        data = {'email': 'foo@example.com'}
+
+        response = self.client.post(
+            reverse('appcustomers-list', (self.fixture.id,)), data)
+
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+        mock_api.authorization.get_or_create.assert_called_with(
+            Group(name=self.fixture.name)
+        )
+
+        mock_api.authorization.get.assert_called_with(
+            Auth0User(email=data['email'])
+        )
+
+        mock_api.authorization.get_or_create.return_value.add_users.assert_called_with(
+            [{'user_id': api_get_user_response['user_id']}]
+        )
+
+    @patch('control_panel_api.auth0.auth0.api')
+    def test_post_create_user(self, mock_api):
+        api_create_user_response = {'user_id': 123}
+
+        mock_api.authorization.get.return_value = None
+        mock_api.management.create.return_value = api_create_user_response
+
+        data = {'email': 'foo@example.com'}
+
+        response = self.client.post(
+            reverse('appcustomers-list', (self.fixture.id,)), data)
+
+        self.assertEqual(HTTP_201_CREATED, response.status_code)
+
+        mock_api.authorization.get_or_create.assert_called_with(
+            Group(name=self.fixture.name)
+        )
+
+        mock_api.authorization.get.assert_called_with(
+            Auth0User(email=data['email'])
+        )
+
+        mock_api.management.create.assert_called_with(
+            Auth0User(
+                connection='email',
+                email=data['email'],
+                email_verified=True,
+            )
+        )
+
+        mock_api.authorization.get_or_create.return_value.add_users.assert_called_with(
+            [{'user_id': api_create_user_response['user_id']}]
+        )
+
+
+class AppCustomersDetailAPIView(AuthenticatedClientMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.fixture = mommy.make('control_panel_api.App')
+
+    @patch('control_panel_api.auth0.auth0.api')
+    def test_delete(self, mock_api):
+        user_id = 'email|12345'
+
+        response = self.client.delete(
+            reverse('appcustomers-detail', (self.fixture.id, user_id)))
+
+        self.assertEqual(HTTP_204_NO_CONTENT, response.status_code)
+
+        mock_api.authorization.get.assert_called_with(
+            Group(name=self.fixture.name)
+        )
+
+        mock_api.authorization.get.return_value.delete_users.assert_called_with(
+            [{'user_id': user_id}]
         )
 
 

--- a/control_panel_api/urls.py
+++ b/control_panel_api/urls.py
@@ -19,6 +19,8 @@ schema_view = get_swagger_view(title='Control Panel API')
 urlpatterns = [
     url(r'^$', schema_view),
     url(r'^', include(router.urls)),
+    url(r'^apps/(?P<pk>[0-9]+)/customers/$', views.AppCustomersAPIView.as_view(), name='appcustomers-list'),
+    url(r'^apps/(?P<pk>[0-9]+)/customers/(?P<user_id>[\w\d\|]+)/$', views.AppCustomersDetailAPIView.as_view(), name='appcustomers-detail'),
     url(r'^k8s/.+', views.k8s_api_handler),
     url(r'^tools/(?P<tool_name>[-a-z]+)/deployments/$', views.tool_deployments_list, name='tool-deployments-list'),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -261,7 +261,7 @@ class Group(AuthzResource):
     def add_role(self, role):
         response = self.api.request(
             'PATCH',
-            'groups/{_id}/roles'.format(**self),
+            f"groups/{self['_id']}/roles",
             json=[role['_id']]
         )
 
@@ -275,7 +275,7 @@ class Group(AuthzResource):
     def add_users(self, users):
         response = self.api.request(
             'PATCH',
-            'groups/{_id}/members'.format(**self),
+            f"groups/{self['_id']}/members",
             json=[user['user_id'] for user in users]
         )
 
@@ -285,7 +285,7 @@ class Group(AuthzResource):
     def delete_users(self, users):
         response = self.api.request(
             'DELETE',
-            'groups/{_id}/members'.format(**self),
+            f"groups/{self['_id']}/members",
             json=[user['user_id'] for user in users]
         )
 

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -14,6 +14,10 @@ class AddGroupMemberError(Exception):
     pass
 
 
+class DeleteGroupMemberError(Exception):
+    pass
+
+
 class AddGroupRoleError(Exception):
     pass
 
@@ -278,9 +282,15 @@ class Group(AuthzResource):
         if 'error' in response:
             raise AddGroupMemberError(response['message'])
 
-        print('Added users({users}) to group({group})'.format(
-            users=', '.join(user['email'] for user in users),
-            group=self['name']))
+    def delete_users(self, users):
+        response = self.api.request(
+            'DELETE',
+            'groups/{_id}/members'.format(**self),
+            json=[user['user_id'] for user in users]
+        )
+
+        if 'error' in response:
+            raise DeleteGroupMemberError(response['message'])
 
     def get_members(self):
         results = self.api.request(


### PR DESCRIPTION
## What

Endpoint to manage app customers (create and delete), via auth0 authorization extension using groups and users.

## How to review

1. Run tests.
2. Create an app, then add customers to the app.
3. Check auth0 authorization extension groups and users.

https://trello.com/c/eI4eInCe/430-add-ability-to-see-list-of-emails-that-have-access-to-an-app-and-change