### PR TITLE
Lambda functions "data" migrations

### DIFF
--- a/control_panel_api/management/commands/dry_runnable.py
+++ b/control_panel_api/management/commands/dry_runnable.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+
+
+class DryRunnable(BaseCommand):
+    """
+    Add --dry-run flat to command. User will expect command to not
+    have side effects.
+
+    NOTE: The input will be available in `options['dry_run']`, you
+    will have to add the logic to not have side effects in your command.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            dest='dry_run',
+            help="Run command without side effects",
+            default=False,
+            action='store_true',
+        )

--- a/control_panel_api/management/commands/migrate_lambda_data_0_dump_user_policies.py
+++ b/control_panel_api/management/commands/migrate_lambda_data_0_dump_user_policies.py
@@ -1,0 +1,58 @@
+import json
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+from django.core.management.base import BaseCommand
+
+from control_panel_api.models import User
+
+
+READWRITE = 'readwrite'
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    NOTE: Needs permission to perform `iam:ListAttachedRolePolicies` action
+    """
+
+
+    help = ("For each of the users in the DB, it collects its attached IAM "
+            "policies and prints this data to stdout")
+
+    def handle(self, *args, **options):
+        iam = boto3.client('iam')
+
+        dump = {}
+
+        for user in User.objects.all():
+            username = user.username
+            role_name = user.iam_role_name
+
+            dump[username] = {
+                'iam_role_name': role_name,
+                'attached_policies': [],
+            }
+
+            try:
+                policies = iam.list_attached_role_policies(
+                    RoleName=role_name,
+                    MaxItems=1000,
+                )
+                if policies:
+                    dump[username]['attached_policies'] = policies["AttachedPolicies"]
+            except ClientError as e:
+                if e.response['Error']['Code'] in ('NoSuchEntity', 'ValidationError'):
+                    logger.warning(
+                        f'Error reading policies from IAM role "{role_name}": '
+                        f'user "{user.username}" ("{user.pk}"): {e}'
+                    )
+                    dump[username]['error'] = str(e)
+                    continue
+                else:
+                    raise e
+
+        print(json.dumps(dump, indent=4))

--- a/control_panel_api/management/commands/migrate_lambda_data_0_dump_user_policies.py
+++ b/control_panel_api/management/commands/migrate_lambda_data_0_dump_user_policies.py
@@ -8,20 +8,18 @@ from django.core.management.base import BaseCommand
 from control_panel_api.models import User
 
 
-READWRITE = 'readwrite'
-
-
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
     """
-    NOTE: Needs permission to perform `iam:ListAttachedRolePolicies` action
+    For each of the users in the DB, it collects its attached IAM policies
+    and prints this data to stdout.
+
+    NOTE: Needs permission to perform `iam:ListAttachedRolePolicies` action.
     """
 
-
-    help = ("For each of the users in the DB, it collects its attached IAM "
-            "policies and prints this data to stdout")
+    help = __doc__
 
     def handle(self, *args, **options):
         iam = boto3.client('iam')

--- a/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
@@ -15,7 +15,7 @@ READWRITE = 'readwrite'
 logger = logging.getLogger(__name__)
 
 
-def _eligible(policy_name):
+def _is_eligible(policy_name):
     return (policy_name.startswith(f'{settings.ENV}-') and
             not policy_name.startswith(f'{settings.ENV}-app-') and
             policy_name.endswith(READWRITE))
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         for policy in results['Policies']:
             policy_name = policy['PolicyName']
 
-            if _eligible(policy_name):
+            if _is_eligible(policy_name):
                 bucket_name = _bucket_name(policy_name)
 
                 if not S3Bucket.objects.filter(name=bucket_name).exists():

--- a/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
@@ -47,7 +47,8 @@ class Command(BaseCommand):
             if _is_eligible(policy_name):
                 bucket_name = _bucket_name(policy_name)
 
-                if not S3Bucket.objects.filter(name=bucket_name).exists():
+                s3bucket = S3Bucket.objects.filter(name=bucket_name).first()
+                if not s3bucket:
                     if not DRYRUN:
                         S3Bucket.objects.create(
                             name=bucket_name,
@@ -57,8 +58,9 @@ class Command(BaseCommand):
                         f'Created S3 bucket "{bucket_name}" record '
                         f'for IAM policy "{policy_name}"'
                     )
-                else:
+                elif not s3bucket.is_data_warehouse:
                     logger.warning(
                         f'S3 bucket "{bucket_name}" record '
-                        f'for IAM policy "{policy_name}" already exists'
+                        f'for IAM policy "{policy_name}" already exists and '
+                        f'it is not a data warehouse bucket'
                     )

--- a/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
@@ -1,28 +1,20 @@
 import logging
-import re
 import os
 
 import boto3
-from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from control_panel_api.management.commands.migrate_lambdas_data_utils import (
+    bucket_name,
+    is_eligible,
+)
 from control_panel_api.models import S3Bucket
 
+
 DRYRUN = os.environ.get('DRYRUN', 'false').lower() == 'true'
-READWRITE = 'readwrite'
 
 
 logger = logging.getLogger(__name__)
-
-
-def _is_eligible(policy_name):
-    return (policy_name.startswith(f'{settings.ENV}-') and
-            not policy_name.startswith(f'{settings.ENV}-app-') and
-            policy_name.endswith(READWRITE))
-
-
-def _bucket_name(policy_name):
-    return re.sub(f'-{READWRITE}$', '', policy_name)
 
 
 class Command(BaseCommand):
@@ -44,23 +36,25 @@ class Command(BaseCommand):
         for policy in results['Policies']:
             policy_name = policy['PolicyName']
 
-            if _is_eligible(policy_name):
-                bucket_name = _bucket_name(policy_name)
+            if not is_eligible(policy_name):
+                continue
 
-                s3bucket = S3Bucket.objects.filter(name=bucket_name).first()
-                if not s3bucket:
-                    if not DRYRUN:
-                        S3Bucket.objects.create(
-                            name=bucket_name,
-                            is_data_warehouse=True,
-                        )
-                    logger.info(
-                        f'Created S3 bucket "{bucket_name}" record '
-                        f'for IAM policy "{policy_name}"'
+            s3bucket_name = bucket_name(policy_name)
+
+            s3bucket = S3Bucket.objects.filter(name=s3bucket_name).first()
+            if not s3bucket:
+                if not DRYRUN:
+                    S3Bucket.objects.create(
+                        name=s3bucket_name,
+                        is_data_warehouse=True,
                     )
-                elif not s3bucket.is_data_warehouse:
-                    logger.warning(
-                        f'S3 bucket "{bucket_name}" record '
-                        f'for IAM policy "{policy_name}" already exists and '
-                        f'it is not a data warehouse bucket'
-                    )
+                logger.info(
+                    f'Created S3 bucket "{s3bucket_name}" record '
+                    f'for IAM policy "{policy_name}"'
+                )
+            elif not s3bucket.is_data_warehouse:
+                logger.warning(
+                    f'S3 bucket "{s3bucket_name}" record '
+                    f'for IAM policy "{policy_name}" already exists and '
+                    f'it is not a data warehouse bucket'
+                )

--- a/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
@@ -53,6 +53,12 @@ class Command(BaseCommand):
                             name=bucket_name,
                             is_data_warehouse=True,
                         )
-                    logger.info(f'Created S3 bucket "{bucket_name}" record for IAM policy "{policy_name}"')
+                    logger.info(
+                        f'Created S3 bucket "{bucket_name}" record '
+                        f'for IAM policy "{policy_name}"'
+                    )
                 else:
-                    logger.debug(f'S3 bucket "{bucket_name}" record for IAM policy "{policy_name}" already exists')
+                    logger.warning(
+                        f'S3 bucket "{bucket_name}" record '
+                        f'for IAM policy "{policy_name}" already exists'
+                    )

--- a/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
@@ -11,9 +11,6 @@ from control_panel_api.management.commands.migrate_lambdas_data_utils import (
 from control_panel_api.models import S3Bucket
 
 
-DRYRUN = os.environ.get('DRYRUN', 'false').lower() == 'true'
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -24,6 +21,15 @@ class Command(BaseCommand):
 
 
     help = "Add records for S3 buckets created by AWS Lambda functions."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            dest='dry_run',
+            help="Run command without side effects",
+            default=False,
+            action='store_true',
+        )
 
     def handle(self, *args, **options):
         iam = boto3.client('iam')
@@ -43,7 +49,7 @@ class Command(BaseCommand):
 
             s3bucket = S3Bucket.objects.filter(name=s3bucket_name).first()
             if not s3bucket:
-                if not DRYRUN:
+                if not options["dry_run"]:
                     S3Bucket.objects.create(
                         name=s3bucket_name,
                         is_data_warehouse=True,

--- a/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_1_buckets.py
@@ -1,0 +1,52 @@
+import logging
+import re
+
+import boto3
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from control_panel_api.models import S3Bucket
+
+
+READWRITE = 'readwrite'
+
+
+logger = logging.getLogger(__name__)
+
+
+def _eligible(policy_name):
+    return (policy_name.startswith(f'{settings.ENV}-') and
+            not policy_name.startswith(f'{settings.ENV}-app-') and
+            policy_name.endswith(READWRITE))
+
+
+def _bucket_name(policy_name):
+    return re.sub(f'-{READWRITE}$', '', policy_name)
+
+
+class Command(BaseCommand):
+    help = "Add records for S3 buckets created by AWS Lambda functions."
+
+    def handle(self, *args, **options):
+        iam_client = boto3.client('iam')
+
+        results = iam_client.list_policies(
+            Scope='Local',  # Customer managed policies only
+            OnlyAttached=True,  # Ignore non-attached policies
+            MaxItems=1000,
+        )
+
+        for policy in results['Policies']:
+            policy_name = policy['PolicyName']
+
+            if _eligible(policy_name):
+                bucket_name = _bucket_name(policy_name)
+
+                if not S3Bucket.objects.filter(name=bucket_name).exists():
+                    S3Bucket.objects.create(
+                        name=bucket_name,
+                        is_data_warehouse=True,
+                    )
+                    logger.info(f'Created S3 bucket "{bucket_name}" record for IAM policy "{policy_name}"')
+                else:
+                    logger.debug(f'S3 bucket "{bucket_name}" record for IAM policy "{policy_name}" already exists')

--- a/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
@@ -31,6 +31,11 @@ def _bucket_name(policy_name):
 
 
 class Command(BaseCommand):
+    """
+    NOTE: Needs permission to perform `iam:ListAttachedRolePolicies` action
+    """
+
+
     help = ("Add UserS3Bucket records to reflect access to team S3 buckets "
             "granted by AWS Lambda functions.")
 

--- a/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
@@ -47,7 +47,10 @@ class Command(BaseCommand):
         for user in users:
             role_name = user.iam_role_name
 
-            logger.info(f'Migrating user "{user.username}" ("{user.auth0_id}"): Reading policies from role "{role_name}"...')
+            logger.info(
+                f'Migrating user "{user.username}" ("{user.auth0_id}"): '
+                f'Reading policies from role "{role_name}"...'
+            )
             try:
                 policies = iam.list_attached_role_policies(
                     RoleName=role_name,
@@ -55,7 +58,10 @@ class Command(BaseCommand):
                 )
             except ClientError as e:
                 if e.response['Error']['Code'] in ('NoSuchEntity', 'ValidationError'):
-                    logger.warning(f'Error while reading policies from IAM role "{role_name}" - user "{user.username}" ("{user.pk}"): - {e}')
+                    logger.warning(
+                        f'Error reading policies from IAM role "{role_name}": '
+                        f'user "{user.username}" ("{user.pk}"): {e}'
+                    )
                     continue
                 else:
                     raise e
@@ -67,7 +73,10 @@ class Command(BaseCommand):
                         bucket_name = _bucket_name(policy_name)
                         s3bucket = S3Bucket.objects.filter(name=bucket_name)
                         if not s3bucket.exists():
-                            logger.warning(f'S3 bucket "{bucket_name}" corresponding to IAM policy "{policy_name}" not found')
+                            logger.warning(
+                                f'S3 bucket "{bucket_name}" not found: '
+                                f'corresponding to IAM policy "{policy_name}"'
+                            )
                             continue
 
                         s3bucket = s3bucket.first()
@@ -84,8 +93,16 @@ class Command(BaseCommand):
                                         s3bucket=s3bucket,
                                         access_level=READWRITE,
                                     )
-                                logger.info(f'UserS3Bucket created for ({user.username}, {bucket_name})')
+                                logger.info(
+                                    f'UserS3Bucket created: '
+                                    f'({user.username}, {bucket_name})'
+                                )
                             except Exception as e:
-                                logger.error(f'Failed to create UserS3Bucket for ({user.username}, {bucket_name}): {e}')
+                                logger.critical(
+                                    f'Failed to create UserS3Bucket: '
+                                    f'for ({user.username}, {bucket_name}): {e}'
+                                )
                         else:
-                            logger.warning(f'Already found UserS3Bucket for ({user.username}, {bucket_name})')
+                            logger.warning(
+                                f'Existing UserS3Bucket ({user.username}, {bucket_name}) found'
+                            )

--- a/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
@@ -18,7 +18,6 @@ from control_panel_api.models import (
 )
 
 
-DRYRUN = os.environ.get('DRYRUN', 'false').lower() == 'true'
 READWRITE = 'readwrite'
 
 
@@ -33,6 +32,15 @@ class Command(BaseCommand):
 
     help = ("Add UserS3Bucket records to reflect access to team S3 buckets "
             "granted by AWS Lambda functions.")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            dest='dry_run',
+            help="Run command without side effects",
+            default=False,
+            action='store_true',
+        )
 
     def handle(self, *args, **options):
         iam = boto3.client('iam')
@@ -83,7 +91,7 @@ class Command(BaseCommand):
                 )
                 if not users3bucket.exists():
                     try:
-                        if not DRYRUN:
+                        if not options["dry_run"]:
                             UserS3Bucket.objects.create(
                                 user=user,
                                 s3bucket=s3bucket,

--- a/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
@@ -1,12 +1,10 @@
 import logging
-import re
-import os
 
 import boto3
 from botocore.exceptions import ClientError
 from django.conf import settings
-from django.core.management.base import BaseCommand
 
+from control_panel_api.management.commands.dry_runnable import DryRunnable
 from control_panel_api.management.commands.migrate_lambdas_data_utils import (
     bucket_name,
     is_eligible,
@@ -24,23 +22,15 @@ READWRITE = 'readwrite'
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(DryRunnable):
     """
-    NOTE: Needs permission to perform `iam:ListAttachedRolePolicies` action
+    Add UserS3Bucket records to reflect access to team S3 buckets granted by
+    AWS Lambda functions.
+
+    NOTE: Needs permission to perform `iam:ListAttachedRolePolicies` action.
     """
 
-
-    help = ("Add UserS3Bucket records to reflect access to team S3 buckets "
-            "granted by AWS Lambda functions.")
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--dry-run',
-            dest='dry_run',
-            help="Run command without side effects",
-            default=False,
-            action='store_true',
-        )
+    help = __doc__
 
     def handle(self, *args, **options):
         iam = boto3.client('iam')

--- a/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
@@ -1,0 +1,77 @@
+import logging
+import re
+import os
+
+import boto3
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from control_panel_api.models import (
+    S3Bucket,
+    User,
+    UserS3Bucket,
+)
+
+
+DRYRUN = os.environ.get('DRYRUN', 'false').lower() == 'true'
+READWRITE = 'readwrite'
+
+
+logger = logging.getLogger(__name__)
+
+
+def _eligible(policy_name):
+    return (policy_name.startswith(f'{settings.ENV}-') and
+            not policy_name.startswith(f'{settings.ENV}-app-') and
+            policy_name.endswith(READWRITE))
+
+
+def _bucket_name(policy_name):
+    return re.sub(f'-{READWRITE}$', '', policy_name)
+
+
+class Command(BaseCommand):
+    help = ("Add UserS3Bucket records to reflect access to team S3 buckets "
+            "granted by AWS Lambda functions.")
+
+    def handle(self, *args, **options):
+        iam = boto3.client('iam')
+
+        users = User.objects.all()
+        for user in users:
+            role_name = user.iam_role_name
+
+            policies = iam.list_attached_role_policies(
+                RoleName=role_name,
+                MaxItems=1000,
+            )
+
+            if policies:
+                for policy in policies["AttachedPolicies"]:
+                    policy_name = policy["PolicyName"]
+                    if _eligible(policy_name):
+                        bucket_name = _bucket_name(policy_name)
+                        s3bucket = S3Bucket.objects.filter(name=bucket_name)
+                        if not s3bucket.exists():
+                            logger.warning(f'S3 bucket "{bucket_name}" corresponding to IAM policy "{policy_name}" not found')
+                            continue
+
+                        s3bucket = s3bucket.first()
+
+                        users3bucket = UserS3Bucket.objects.filter(
+                            user=user,
+                            s3bucket=s3bucket,
+                        )
+                        if not users3bucket.exists():
+                            try:
+                                if not DRYRUN:
+                                    UserS3Bucket.objects.create(
+                                        user=user,
+                                        s3bucket=s3bucket,
+                                        access_level=READWRITE,
+                                    )
+                                logger.info(f'UserS3Bucket created for ({user.username}, {bucket_name})')
+                            except Exception as e:
+                                logger.error(f'Failed to create UserS3Bucket for ({user.username}, {bucket_name}): {e}')
+                        else:
+                            logger.warning(f'Already found UserS3Bucket for ({user.username}, {bucket_name})')

--- a/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_2_users3buckets.py
@@ -21,7 +21,7 @@ READWRITE = 'readwrite'
 logger = logging.getLogger(__name__)
 
 
-def _eligible(policy_name):
+def _is_eligible(policy_name):
     return (policy_name.startswith(f'{settings.ENV}-') and
             not policy_name.startswith(f'{settings.ENV}-app-') and
             policy_name.endswith(READWRITE))
@@ -63,7 +63,7 @@ class Command(BaseCommand):
             if policies:
                 for policy in policies["AttachedPolicies"]:
                     policy_name = policy["PolicyName"]
-                    if _eligible(policy_name):
+                    if _is_eligible(policy_name):
                         bucket_name = _bucket_name(policy_name)
                         s3bucket = S3Bucket.objects.filter(name=bucket_name)
                         if not s3bucket.exists():

--- a/control_panel_api/management/commands/migrate_lambdas_data_utils.py
+++ b/control_panel_api/management/commands/migrate_lambdas_data_utils.py
@@ -1,0 +1,16 @@
+import re
+
+from django.conf import settings
+
+
+READWRITE = 'readwrite'
+
+
+def is_eligible(policy_name):
+    return (policy_name.startswith(f'{settings.ENV}-') and
+            not policy_name.startswith(f'{settings.ENV}-app-') and
+            policy_name.endswith(READWRITE))
+
+
+def bucket_name(policy_name):
+    return re.sub(f'-{READWRITE}$', '', policy_name)

--- a/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
+++ b/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
@@ -1,11 +1,10 @@
 import logging
-import os
 
 from botocore.exceptions import ClientError
 from django.conf import settings
-from django.core.management.base import BaseCommand
 
 from control_panel_api.aws import aws, S3AccessPolicy
+from control_panel_api.management.commands.dry_runnable import DryRunnable
 from control_panel_api.models import (
     AppS3Bucket,
     UserS3Bucket,
@@ -37,17 +36,8 @@ def _policy_arn(bucket_name, readwrite=False):
         _policy_name(bucket_name, readwrite))
 
 
-class Command(BaseCommand):
+class Command(DryRunnable):
     help = "Convert data access policies from managed to inline."
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--dry-run',
-            dest='dry_run',
-            help="Run command without side effects",
-            default=False,
-            action='store_true',
-        )
 
     def handle(self, *args, **options):
         for klass in [UserS3Bucket, AppS3Bucket]:

--- a/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
+++ b/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py
@@ -1,7 +1,8 @@
 import logging
 
 from botocore.exceptions import ClientError
-from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+from django.core.management.base import BaseCommand
 
 from control_panel_api.aws import aws, S3AccessPolicy
 from control_panel_api.models import (


### PR DESCRIPTION
### What
We want to dismiss lambda functions which currently handles GitHub events to create team buckets, etc...

This means we need to add the records for these buckets, who has access to them, etc...to the control panel DB.

### Migrations
#### 1. S3 Buckets
The first of the migrations (`migrate_lambdas_data_1_buckets.py`) loops through the IAM policies which are attached to at least an IAM role and for each of them:
1. checks if 
   1. policy name starts with the current env name
   2. policy name ends with `-readwrite`, as lambda functions only used these policies
   3. ignore policies for app data buckets ("app buckets" are not "data warehouse buckets" and they're added directly via CP)
2. checks if S3 bucket already exists in CP
3. if not, it creates the `S3Bucket` record with `is_data_warehouse` flag set to true.

#### 2. Create `UserS3Bucket` records
Once we have all the data warehouse `S3Bucket` records in the DB we need to add the `UserS3Bucket` records so that CP-API knows who can access what.

1. For each of the users
2. We determine the user IAM role name and list the IAM policies attached to it
3. For each of the relevant policies
3a. We filter out policies for other environments, non-readwrite policies, policies for "app" buckets and in general ignore any IAM policy with a name not matching the template as these are probably policies for things like AWS Glue, etc...
4. For each of these IAM policy (named something like `dev-*-readwrite`) we create a `UserS3Bucket` record for the corresponding user with access level `readwrite` and to the corresponding S3 bucket (which at this point, after migration above, should already have a record in DB).

#### 3. Update roles to grant access as in `UserS3Bucket` records
Once we have these new `UserS3Bucket` records in the DB, we'll need to update the IAM roles to update their `s3-access` inline policy to grant access to these S3 bucket they had access before via managed policies attached to their role.

We already wrote and used [this migration](https://github.com/ministryofjustice/analytics-platform-control-panel/blob/master/control_panel_api/management/commands/migrate_s3_access_roles_to_inline_policies.py) when we initially moved from managed policies to a single inline policy so we're going to re-use it.

This migration loops through `UserS3bucket` (and `AppS3Bucket`) records and for each of them:
1. read the corresponding IAM role `s3-access` inline policy
2. grant access to the S3 bucket
3. writes the inline policy back to the role
3. Detaches the corresponding managed policy

### NOTES
#### About `DRYRUN` option
These migrations have a `DRYRUN` option which allow them to be run without actually having side effects. This is very useful to preview what changes the migrations will make before actually migrating the data (by looking at the logs)

```bash
$ DRYRUN=true python3 manage.py ...
```

#### Duplication / Design
I preferred to split this migration/task in smaller migration to avoid having a massive complex migration doing a lot of things. Yes, the steps are related but relatively self contained.

As a result, there are a couple of very simple utility functions (`_is_eligible()` and `_bucket_name()`) which are duplicated in migration 1 and 2. I don't think it's worth adding some sort of shared library for this. And I also like the idea of these migration being self contained so that changes outside them are not affecting them (e.g. we may need to run them again later at some point).

These migrations should also be idempotent.

### Ticket
https://trello.com/c/Me2RD6ek/696-5-script-that-copies-data-access-permissions-from-existing-lambda-created-policies-to-to-s3-access-inline-policy-and-adds-these