### PR TITLE
Normal users can list users

### DIFF
--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -56,17 +56,11 @@ class UserFilter(DjangoFilterBackend):
     """
     Filter to get visible users.
 
-    Currently superusers see everything, normal users see only themselves,
-    unauthenticated users see nothing.
+    Everyone can see all users.
     """
 
     def filter_queryset(self, request, queryset, view):
-        queryset = super().filter_queryset(request, queryset, view)
-
-        if is_superuser(request.user):
-            return queryset
-
-        return queryset.filter(pk=request.user.pk)
+        return super().filter_queryset(request, queryset, view)
 
 
 class UserS3BucketFilter(DjangoFilterBackend):

--- a/control_panel_api/filters.py
+++ b/control_panel_api/filters.py
@@ -52,17 +52,6 @@ class S3BucketFilter(DjangoFilterBackend):
         return queryset.accessible_by(request.user)
 
 
-class UserFilter(DjangoFilterBackend):
-    """
-    Filter to get visible users.
-
-    Everyone can see all users.
-    """
-
-    def filter_queryset(self, request, queryset, view):
-        return super().filter_queryset(request, queryset, view)
-
-
 class UserS3BucketFilter(DjangoFilterBackend):
     """
     Filter to get visible UserS3Bucket records.

--- a/control_panel_api/permissions.py
+++ b/control_panel_api/permissions.py
@@ -74,8 +74,9 @@ class S3BucketPermissions(BasePermission):
 
 class UserPermissions(BasePermission):
     """
-    Superusers can do anything, normal users can only access themselves,
-    unauthenticated users cannot do anything
+    Superusers can do anything.
+    Normal users can list all, retrieve/update only themselves.
+    Unauthenticated users cannot do anything.
     """
 
     def has_permission(self, request, view):
@@ -85,7 +86,7 @@ class UserPermissions(BasePermission):
         if request.user.is_anonymous():
             return False
 
-        return view.action not in ('create', 'destroy', 'list')
+        return view.action in ('list', 'retrieve', 'update', 'partial_update')
 
     def has_object_permission(self, request, view, obj):
         if is_superuser(request.user):

--- a/control_panel_api/tests/filters/test_user_filter.py
+++ b/control_panel_api/tests/filters/test_user_filter.py
@@ -1,6 +1,6 @@
 from model_mommy import mommy
 from rest_framework.reverse import reverse
-from rest_framework.status import HTTP_403_FORBIDDEN
+from rest_framework.status import HTTP_200_OK
 from rest_framework.test import APITestCase
 
 
@@ -21,8 +21,9 @@ class UserFilterTest(APITestCase):
         self.assertIn(self.superuser.auth0_id, user_ids)
         self.assertIn(self.normal_user.auth0_id, user_ids)
 
-    def test_normal_user_sees_nothing(self):
+    def test_normal_user_sees_everything(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse("user-list"))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(HTTP_200_OK, response.status_code)
+        self.assertEqual(len(response.data["results"]), 2)

--- a/control_panel_api/tests/permissions/test_user_permissions.py
+++ b/control_panel_api/tests/permissions/test_user_permissions.py
@@ -7,7 +7,6 @@ from rest_framework.status import (
     HTTP_201_CREATED,
     HTTP_204_NO_CONTENT,
     HTTP_403_FORBIDDEN,
-    HTTP_404_NOT_FOUND,
 )
 from rest_framework.test import APITestCase
 
@@ -36,11 +35,11 @@ class UserPermissionsTest(APITestCase):
         response = self.client.get(reverse('user-list'))
         self.assertEqual(HTTP_200_OK, response.status_code)
 
-    def test_list_as_normal_user_responds_403(self):
+    def test_list_as_normal_user_responds_OK(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(reverse('user-list'))
-        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(HTTP_200_OK, response.status_code)
 
     def test_detail_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
@@ -56,13 +55,12 @@ class UserPermissionsTest(APITestCase):
             reverse('user-detail', (self.normal_user.auth0_id,)))
         self.assertEqual(HTTP_200_OK, response.status_code)
 
-    def test_detail_as_normal_user_responds_404(self):
+    def test_detail_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         response = self.client.get(
             reverse('user-detail', (self.superuser.auth0_id,)))
-        # 404 raised before object permissions checked
-        self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 
     def test_delete_as_superuser_responds_OK(self):
         self.client.force_login(self.superuser)
@@ -108,12 +106,11 @@ class UserPermissionsTest(APITestCase):
             reverse('user-detail', (self.normal_user.auth0_id,)), data)
         self.assertEqual(HTTP_200_OK, response.status_code)
 
-    def test_update_as_normal_user_responds_404(self):
+    def test_update_as_normal_user_responds_403(self):
         self.client.force_login(self.normal_user)
 
         data = {'username': 'foo', 'auth0_id': 'github|888'}
         response = self.client.put(
             reverse('user-detail', (self.superuser.auth0_id,)), data)
-        # 404 raised before object permissions checked
-        self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
+        self.assertEqual(HTTP_403_FORBIDDEN, response.status_code)
 

--- a/control_panel_api/tests/test_authentication.py
+++ b/control_panel_api/tests/test_authentication.py
@@ -9,7 +9,6 @@ from rest_framework.reverse import reverse
 from rest_framework.status import (
     HTTP_200_OK,
     HTTP_403_FORBIDDEN,
-    HTTP_404_NOT_FOUND,
 )
 from rest_framework.test import APITestCase
 
@@ -80,12 +79,12 @@ class Auth0JWTAuthenticationTestCase(APITestCase):
             is_superuser=True
         )
 
-    def get_user(self):
+    def get_user(self, user):
         return self.client.get(
-            reverse('user-detail', args=[self.user.auth0_id]))
+            reverse('user-detail', args=[user.auth0_id]))
 
     def assert_status_code(self, code):
-        r = self.get_user()
+        r = self.get_user(self.user)
         self.assertEqual(code, r.status_code, r.content.decode('utf8'))
 
     def assert_access_denied(self):
@@ -93,9 +92,6 @@ class Auth0JWTAuthenticationTestCase(APITestCase):
 
     def assert_authenticated(self):
         self.assert_status_code(HTTP_200_OK)
-
-    def assert_not_found(self):
-        self.assert_status_code(HTTP_404_NOT_FOUND)
 
     def test_user_can_not_view(self):
         self.assert_access_denied()
@@ -155,8 +151,7 @@ class Auth0JWTAuthenticationTestCase(APITestCase):
         token = build_jwt_from_user(new_user)
 
         self.client.credentials(HTTP_AUTHORIZATION=f'JWT {token}')
-        # 404 is raised before object permissions are checked
-        self.assert_not_found()
+        self.get_user(new_user)
 
         created_user = User.objects.get(pk=new_user.auth0_id)
         self.assertIsNotNone(created_user)

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.http import JsonResponse
 from django.http.response import Http404
 from django.views.decorators.csrf import csrf_exempt
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.generics import GenericAPIView
@@ -20,7 +21,6 @@ from control_panel_api.exceptions import (
 from control_panel_api.filters import (
     AppFilter,
     S3BucketFilter,
-    UserFilter,
     UserS3BucketFilter,
 )
 from control_panel_api.k8s import proxy as k8s_proxy
@@ -84,7 +84,7 @@ def k8s_api_handler(request):
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    filter_backends = (UserFilter,)
+    filter_backends = (DjangoFilterBackend,)
     permission_classes = (UserPermissions,)
 
     @handle_external_exceptions


### PR DESCRIPTION
### What
Updated the User permissions/filtering to allow normal users to list all
users. This is a requirement coming from the Clive/UI.

The reason for this is to allow normal users to grant access to other users
to S3 bucket they are admin of.

The changes are in two areas:
- Users are not filtered anymore, e.g. all users are returned by `UserFilter`
- `UserPermissions` now allows `list` actions for everyone. Note that normal
  users will still only be able to retrieve/update their own user record only.

**NOTE**: I inverted the logic in `UserPermissions` to be a whitelist of
actions rather. It's easier to see what a normal user can do and also
generaly whitelists are safer.

**NOTE (on tests)**: Unauthorised users used to get a `404 NOT FOUND` because records were filtered out before reaching the permissions layer. Now that all users can list all users, they'll get a `403 UNAUTHORIZED`.


### Ticket
https://trello.com/c/ivwsh6FI/715-3-normal-users-can-list-users
