### PR TITLE
Update helm repo before each installation

### DIFF
--- a/control_panel_api/helm.py
+++ b/control_panel_api/helm.py
@@ -23,6 +23,8 @@ class Helm(object):
             )
 
     def upgrade_release(self, release, chart, *args):
+        self._helm_shell_command('repo update')
+
         default_flags = ['--install', '--wait']
         flags = list(args) + default_flags
         self._helm_command('upgrade', release, chart, *flags)


### PR DESCRIPTION
### What
Trello: https://trello.com/c/UcRhiW3Q
As currently the helm repository is updated on Docker image build, newly
released helm chart versions may not be available for the CP-API until
the next release.

I'm now running `helm repo update` before upgrading/install any release.

### Kind of related ticket
We originally thought a [user issue](https://trello.com/c/rsFE4N0z/716-iron-out-issues-from-rbac-investigate-ci-cp) was caused by a non-up-to-date CP installing an older version of an helm chart.

This was not the case but unless we don't do an `helm repo update` before each installation it's still potentially a problem.


