### PR TITLE
When deleting an S3 bucket, update the permissions on associations

### DIFF
--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -190,13 +190,6 @@ class AppS3BucketViewSet(viewsets.ModelViewSet):
 
         apps3bucket.aws_update()
 
-    @handle_external_exceptions
-    @transaction.atomic
-    def perform_destroy(self, instance):
-        instance.delete()
-
-        instance.aws_delete()
-
 
 class UserS3BucketViewSet(viewsets.ModelViewSet):
     queryset = UserS3Bucket.objects.all()
@@ -217,13 +210,6 @@ class UserS3BucketViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
 
         instance.aws_update()
-
-    @handle_external_exceptions
-    @transaction.atomic
-    def perform_destroy(self, instance):
-        instance.delete()
-
-        instance.aws_delete()
 
 
 class S3BucketViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
### Background
Permissions in DB are kept in two models `UserS3Bucket` and `AppS3Bucket`.
These records contains a reference to the S3 bucket.
When these records are deleted the user/app IAM role needs to be updated
to reflect the fact that these users/apps don't have access to the
corresponding S3 bucket.

### Problem
This happened when these records were deleted directly but not when deleted
inderectly when the deletion of an S3 bucket cascaded and deleted all the
associated records.

As we don't actually delete the S3 bucket in AWS a user/app would still
have access to that "deleted" S3 bucket.

### Solution
The solution is to listen to the `post_delete` signal which is [still triggered](https://stackoverflow.com/questions/8944207/overridden-delete-method-of-child-model-does-not-get-called-when-deleting-parent)
when a record is deleted by the cascading.

**NOTE**: I'm passing `dispatch_uid` when connecting the signal to avoid these being registered multiple times.

**NOTE**: As update the IAM roles when access to S3 bucket is revoked is now
performed by the signal, I deleted the custom `perform_destroy()` in the
views which were added to do that.

### Ticket
https://trello.com/c/f0gPNADq/720-4-delete-data-source-not-updating-permissions

### Issue
https://github.com/ministryofjustice/analytics-platform/issues/26
