### PR TITLE
Allow users' IAM roles to read inline policies

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -109,6 +109,11 @@ class AWSClient(object):
                     policy_arn=policy["PolicyArn"]
                 )
 
+    def attach_policy_to_role(self, policy_arn, role_name):
+        self._do('iam', 'attach_role_policy',
+            RoleName=role_name,
+            PolicyArn=policy_arn)
+
     def detach_policy_from_role(self, policy_arn, role_name):
         self._do('iam', 'detach_role_policy',
             RoleName=role_name,

--- a/control_panel_api/management/commands/grant_aws_roles_permission_to_read_inline_policies.py
+++ b/control_panel_api/management/commands/grant_aws_roles_permission_to_read_inline_policies.py
@@ -7,10 +7,10 @@ from django.conf import settings
 
 from control_panel_api.management.commands.dry_runnable import DryRunnable
 from control_panel_api.models import User
+from control_panel_api.services import READ_INLINE_POLICIES_POLICY_NAME as POLICY_NAME
 
 
 IAM = boto3.client('iam')
-POLICY_NAME = f'{settings.ENV}-read-user-roles-inline-policies'
 POLICY_ARN = f"{settings.IAM_ARN_BASE}:policy/{POLICY_NAME}"
 POLICY_DOCUMENT = {
     "Version": "2012-10-17",

--- a/control_panel_api/management/commands/grant_aws_roles_permission_to_read_inline_policies.py
+++ b/control_panel_api/management/commands/grant_aws_roles_permission_to_read_inline_policies.py
@@ -1,0 +1,81 @@
+import json
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+from django.conf import settings
+
+from control_panel_api.management.commands.dry_runnable import DryRunnable
+from control_panel_api.models import User
+
+
+IAM = boto3.client('iam')
+POLICY_NAME = f'{settings.ENV}-read-user-roles-inline-policies'
+POLICY_ARN = f"{settings.IAM_ARN_BASE}:policy/{POLICY_NAME}"
+POLICY_DOCUMENT = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "CanReadUserRolesInlinePolicies",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRolePolicy"
+            ],
+            "Resource": [
+                f"{settings.IAM_ARN_BASE}:role/{settings.ENV}_user_*",
+            ],
+        },
+    ],
+}
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_policy():
+    try:
+        IAM.create_policy(
+            PolicyName=POLICY_NAME,
+            PolicyDocument=json.dumps(POLICY_DOCUMENT),
+        )
+        logger.info(f'IAM policy "{POLICY_NAME}" created')
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'EntityAlreadyExists':
+            logger.warning(f'IAM policy "{POLICY_NAME}" already exists')
+        else:
+            raise e
+
+
+def attach_policy(role_name):
+    try:
+        IAM.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn=POLICY_ARN,
+        )
+    except ClientError as e:
+        if e.response['Error']['Code'] in ('NoSuchEntity', 'ValidationError'):
+            logger.warning(f'IAM role "{role_name}" not found or invalid')
+        else:
+            raise e
+
+
+class Command(DryRunnable):
+    """
+    Creates the "${ENV}-read-users-inline-policies" IAM role and attaches
+    it to all users' IAM roles
+
+    NOTE: Needs permissions to `iam:CreatePolicy` and `iam:AttachRolePolicy`
+    """
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        logger.info(f'Creating IAM policy "{POLICY_NAME}"...')
+        if not options['dry_run']:
+            create_policy()
+
+        for user in User.objects.all():
+            role_name = user.iam_role_name
+            logger.info(f'Attaching to IAM role "{role_name}"...')
+            if not options['dry_run']:
+                attach_policy(role_name)

--- a/control_panel_api/management/commands/grant_aws_roles_permission_to_read_inline_policies.py
+++ b/control_panel_api/management/commands/grant_aws_roles_permission_to_read_inline_policies.py
@@ -38,7 +38,6 @@ def create_policy():
             PolicyName=POLICY_NAME,
             PolicyDocument=json.dumps(POLICY_DOCUMENT),
         )
-        logger.info(f'IAM policy "{POLICY_NAME}" created')
     except ClientError as e:
         if e.response['Error']['Code'] == 'EntityAlreadyExists':
             logger.warning(f'IAM policy "{POLICY_NAME}" already exists')

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -43,6 +43,7 @@ class User(AbstractUser):
         services.create_role(
             self.iam_role_name, add_saml_statement=True,
             add_oidc_statement=True, oidc_sub=self.auth0_id)
+        services.grant_read_inline_policies(self.iam_role_name)
 
     def aws_delete_role(self):
         services.delete_role(self.iam_role_name)

--- a/control_panel_api/services.py
+++ b/control_panel_api/services.py
@@ -11,6 +11,7 @@ from control_panel_api.aws import (
 
 
 S3_POLICY_NAME = 's3-access'
+READ_INLINE_POLICIES_POLICY_NAME = f'{settings.ENV}-read-user-roles-inline-policies'
 
 
 logger = logging.getLogger(__name__)
@@ -104,6 +105,16 @@ def create_role(
         role_policy['Statement'].append(oidc_statement)
 
     aws.create_role(role_name, role_policy)
+
+
+def grant_read_inline_policies(role_name):
+    policy_arn = (
+        f'{settings.IAM_ARN_BASE}:policy/{READ_INLINE_POLICIES_POLICY_NAME}'
+    )
+    aws.attach_policy_to_role(
+        role_name=role_name,
+        policy_arn=policy_arn,
+    )
 
 
 @ignore_aws_exceptions

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -57,6 +57,13 @@ class AwsTestCase(TestCase):
             PolicyDocument=json.dumps(policy_document),
         )
 
+    def test_attach_policy_to_role(self):
+        aws.attach_policy_to_role('policyarn', 'rolename')
+        aws.client.return_value.attach_role_policy.assert_called_with(
+            RoleName='rolename',
+            PolicyArn='policyarn',
+        )
+
     def test_detach_policy_from_role(self):
         aws.detach_policy_from_role('policyarn', 'foo')
         aws.client.return_value.detach_role_policy.assert_called()

--- a/control_panel_api/tests/test_services.py
+++ b/control_panel_api/tests/test_services.py
@@ -125,3 +125,15 @@ class ServicesTestCase(TestCase):
         mock_client.return_value.create_role.assert_called_with(
             RoleName=role_name,
             AssumeRolePolicyDocument=json.dumps(USER_IAM_ROLE_ASSUME_POLICY))
+
+    def test_grant_read_inline_policies(self, mock_client):
+        role_name = "test_user_user"
+        services.grant_read_inline_policies(role_name)
+
+        mock_client.return_value.attach_role_policy.assert_called_with(
+            RoleName=role_name,
+            PolicyArn=(
+                f'{settings.IAM_ARN_BASE}:policy/'
+                f'{settings.ENV}-read-user-roles-inline-policies'
+            ),
+        )

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -182,10 +182,11 @@ class UserViewTest(AuthenticatedClientMixin, APITestCase):
         with self.assertRaises(User.DoesNotExist):
             User.objects.get(pk=data['auth0_id'])
 
+    @patch('control_panel_api.models.services.grant_read_inline_policies')
     @patch('control_panel_api.models.User.helm_create')
     @patch('control_panel_api.aws.AWSClient.create_role')
     def test_aws_error_existing_ignored(self, mock_create_role,
-                                        mock_helm_create):
+                                        mock_helm_create, mock_grant_read_inline_policies):
         e = type('EntityAlreadyExistsException', (ClientError,), {})
         mock_create_role.side_effect = e({}, 'CreateRole')
 


### PR DESCRIPTION
### What / Why
Users in RStudio using new version of S3Browser gets a permission error caused by their role not having the permission to read their `s3-access` inline policy (this inline policy is used to determine who can access which S3 buckets)

[See ticket](https://trello.com/c/TOj5GLE7/735-4-permission-fix-for-users-roles-not-able-to-read-their-inline-policy-in-rstudio) for more details.

### User creation changes
As before, when a user is created its IAM role is created.
In addition to this, we now attach the IAM policy which grants them access to the inline policies.

This IAM policy is created by a django command (see below).

### `grant_aws_roles_permission_to_read_inline_policies` - Django command
This Django command (`grant_aws_roles_permission_to_read_inline_policies`)
will:
- create an IAM policy (`${ENV}-read-user-roles-inline-policies`) to grant permission to read inline policies from
users' IAM roles
- then attach this IAM policy to each or the users' IAM roles

**NOTE**: There are no IAM policy variables to access the role ARN/name at runtime so this policy allow reading all users' roles inline policies
which is a bit loose but shouldn't be a security problem.
The alternative would be to have a policy per user but that would be
overkill.

### Ticket

https://trello.com/c/TOj5GLE7/735-4-permission-fix-for-users-roles-not-able-to-read-their-inline-policy-in-rstudio