### PR TITLE
Create user IAM role when they create for the 1st time

### DIFF
--- a/control_panel_api/authentication.py
+++ b/control_panel_api/authentication.py
@@ -67,6 +67,7 @@ def get_or_create_user(decoded_payload):
             name=decoded_payload.get(settings.OIDC_FIELD_NAME),
         )
         user.save()
+        user.aws_create_role()
         user.helm_create()
 
     return user

--- a/control_panel_api/tests/test_authentication.py
+++ b/control_panel_api/tests/test_authentication.py
@@ -137,8 +137,10 @@ class Auth0JWTAuthenticationTestCase(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'JWT {token}')
         self.assert_authenticated()
 
+    @patch('control_panel_api.authentication.User.helm_create')
+    @patch('control_panel_api.authentication.User.aws_create_role')
     @patch('control_panel_api.authentication.get_jwks', mock_get_keys)
-    def test_unknown_valid_user_is_created(self):
+    def test_unknown_valid_user_is_created(self, mock_aws_create_role, mock_helm_create):
         new_user = mommy.prepare(
             'control_panel_api.User',
             email='new@example.com',
@@ -159,3 +161,6 @@ class Auth0JWTAuthenticationTestCase(APITestCase):
         self.assertEqual(new_user.username, created_user.username)
         self.assertEqual(new_user.name, created_user.name)
         self.assertEqual(new_user.email, created_user.email)
+
+        mock_helm_create.assert_called()
+        mock_aws_create_role.assert_called()


### PR DESCRIPTION
### What
This will create the user IAM role the first time they logs into the CP-API (`authentication` module).

### Background
When a user logs for the first time, the `authentication` module
detects that the user is not in the DB yet and creates it.
It also install the `init_user`/`config_user` helm charts for the user (they create the user namespace in kubernetes and other related resources).

It now also creates the user IAM role as well (as the `POST /users` endpoint already does).

This was not a problem before before users' IAM roles were created
by an AWS Lambda function when the user was added to the GitHub org.
As we'll move away from that model, it's important that the CP
creates these IAM roles.

**NOTE**: I manually triggered the `User.aws_create_role()` in `dev` on a
user which already has the IAM role and it worked fine. e.g. this
is idempotent.


### Ticket
https://trello.com/c/Op8lIxJi/740-2-iam-role-not-created-when-user-logs-first-time
