### PR TITLE
Remove Jenkins deploy tasks from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,25 +60,3 @@ jobs:
             docker tag app "quay.io/mojanalytics/control-panel:${CIRCLE_BRANCH}"
             docker push "quay.io/mojanalytics/control-panel:${CIRCLE_SHA1}"
             docker push "quay.io/mojanalytics/control-panel:${CIRCLE_BRANCH}"
-
-      - deploy:
-          name: Deploy to dev
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              curl ${JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
-                --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
-                --data COMMIT_HASH=${CIRCLE_SHA1} \
-                --data BRANCH_NAME=${CIRCLE_BRANCH} \
-                --user ${JENKINS_USER}:${JENKINS_TOKEN}
-            fi
-
-      - deploy:
-          name: Deploy to alpha
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              curl ${ALPHA_JENKINS_URL}/job/control-panel/job/api/buildWithParameters \
-                --data token=${JENKINS_JOB_TRIGGER_TOKEN} \
-                --data COMMIT_HASH=${CIRCLE_SHA1} \
-                --data BRANCH_NAME=${CIRCLE_BRANCH} \
-                --user ${ALPHA_JENKINS_USER}:${ALPHA_JENKINS_TOKEN}
-            fi


### PR DESCRIPTION
## What

* Remove calls to Jenkins to deploy builds that pass tests to dev and alpha - because Jenkins is dead.