### PR TITLE
Bump versions as directed by dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-asn1crypto==0.23.0
+asn1crypto==0.24.0
 auth0-python==3.2.2
-boto3==1.7.23
-botocore==1.10.19
-cachetools==2.0.1
+boto3==1.7.25
+botocore==1.10.25
+cachetools==2.1.0
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
@@ -40,7 +40,7 @@ pytest==3.5.1
 pytest-django==3.2.1
 pytest-spec==1.1.0
 pytest-testmon==0.9.11
-pytest-watch==4.1.0
+pytest-watch==4.2.0
 python-dateutil==2.7.3
 python-jose==3.0.0
 pytz==2018.4


### PR DESCRIPTION
## What

* Bump boto3 from 1.7.23 to 1.7.25
* Bump botocore from 1.10.19 to 1.10.25
* Bump pytest-watch from 4.1.0 to 4.2.0
* Bump asn1crypto from 0.23.0 to 0.24.0
* Bump cachetools from 2.0.1 to 2.1.0