### PR TITLE
Fix bug preventing user/app deletion

### DIFF
--- a/control_panel_api/aws.py
+++ b/control_panel_api/aws.py
@@ -94,6 +94,7 @@ class AWSClient(object):
         """Delete the given IAM role."""
 
         self._detach_role_policies(role_name)
+        self._delete_role_inline_policies(role_name)
         self._do('iam', 'delete_role', RoleName=role_name)
 
     def _detach_role_policies(self, role_name):
@@ -106,8 +107,26 @@ class AWSClient(object):
             for policy in policies["AttachedPolicies"]:
                 self.detach_policy_from_role(
                     role_name=role_name,
-                    policy_arn=policy["PolicyArn"]
+                    policy_arn=policy["PolicyArn"],
                 )
+
+    def _delete_role_inline_policies(self, role_name):
+        """Deletes all inline policies in the given role"""
+
+        policies = self._do(
+            'iam', 'list_role_policies', RoleName=role_name)
+
+        if policies:
+            for policy_name in policies["PolicyNames"]:
+                self.delete_role_inline_policy(
+                    role_name=role_name,
+                    policy_name=policy_name,
+                )
+
+    def delete_role_inline_policy(self, policy_name, role_name):
+        self._do('iam', 'delete_role_policy',
+            RoleName=role_name,
+            PolicyName=policy_name)
 
     def attach_policy_to_role(self, policy_arn, role_name):
         self._do('iam', 'attach_role_policy',

--- a/control_panel_api/tests/test_aws.py
+++ b/control_panel_api/tests/test_aws.py
@@ -65,8 +65,11 @@ class AwsTestCase(TestCase):
         )
 
     def test_detach_policy_from_role(self):
-        aws.detach_policy_from_role('policyarn', 'foo')
-        aws.client.return_value.detach_role_policy.assert_called()
+        aws.detach_policy_from_role('policy_arn', 'role_name')
+        aws.client.return_value.detach_role_policy.assert_called_with(
+            RoleName='role_name',
+            PolicyArn='policy_arn',
+        )
 
     def test_create_role(self):
         role_name = "a_role"


### PR DESCRIPTION
### What
When a user/app is deleted we also delete their IAM role.
In order to delete an IAM role all its attached managed policies and inline policies need to be deleted first or the operation will fail.

We already detached all the managed policies attached but we didn't delete the role inline policies. As (most) or the roles now have an `s3-access` inline policy the operation was failing raising a `DeleteConflict` error.

### Solution
The `aws.delete_role()` method now list/delete all role's inline policies before deleting the IAM role itself.

### Required permissions
The [CP-API IAM role](https://github.com/ministryofjustice/analytics-platform-ops/blob/master/infra/terraform/modules/control_panel_api/role.tf) will need to have the ability to perform the following AWS operations:
- [x] [iam:ListRolePolicies](https://iam.cloudonaut.io/reference/iam/ListRolePolicies.html)
- [x] [iam:DeleteRolePolicy](https://iam.cloudonaut.io/reference/iam/DeleteRolePolicy.html)

I'm going to work on adding them now.

### Other details considerations

The user/app DB record is deleted before we delete its IAM role.
When a user/app is deleted the associated records (`users3buckets`/`apps3buckets`) are deleted as well.
When these are deleted the corresponsing user/app IAM role's `s3-access` inline policy is updated to revoke access to that S3 bucket.

This means that even if an error occurred the user/app will not have any access to S3 buckets.

As the `perform_destroy` method is wrapped in a DB transaction, therefore when this error occurs the transaction is rolled back and these records are restored. The fact that these records will still be there is confusing for the user but as mentioned above the user/app will not have access to any S3 bucket.

### GitHub Issue
https://github.com/ministryofjustice/analytics-platform/issues/33

### Ticket

https://trello.com/c/04FsXha3/984-cant-delete-users