### PR TITLE
Fix app customers infinite login loop

### DIFF
--- a/control_panel_api/auth0.py
+++ b/control_panel_api/auth0.py
@@ -45,7 +45,7 @@ class Auth0(object):
         return group.get_members()
 
     def add_group_member(self, group_name, email):
-        group = self.authorization_api.get_or_create(Group(name=group_name))
+        group = self.authorization_api.get(Group(name=group_name))
 
         user = self.authorization_api.get(User(
             email=email,

--- a/control_panel_api/auth0.py
+++ b/control_panel_api/auth0.py
@@ -45,7 +45,7 @@ class Auth0(object):
         return group.get_members()
 
     def add_group_member(self, group_name, email):
-        group = self.authorization_api.get(Group(name=group_name))
+        group = self.authorization_api.get_or_create(Group(name=group_name))
 
         user = self.authorization_api.get(User(
             email=email,

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -378,10 +378,8 @@ class AppCustomersAPIViewTest(AuthenticatedClientMixin, APITestCase):
         group = MagicMock()
         user = MagicMock()
         authz = api.authorization
-        authz.get.side_effect = [
-            group,
-            user
-        ]
+        authz.get_or_create.return_value = group
+        authz.get.return_value = user
 
         response = self.client.post(
             reverse('appcustomers-list', (self.app.id,)),
@@ -389,7 +387,7 @@ class AppCustomersAPIViewTest(AuthenticatedClientMixin, APITestCase):
 
         self.assertEqual(HTTP_201_CREATED, response.status_code)
 
-        authz.get.assert_any_call(Auth0Group(name=self.app.slug))
+        authz.get_or_create.assert_called_with(Auth0Group(name=self.app.slug))
 
         group.add_users.assert_called_with([
             {'user_id': user['user_id']}])
@@ -400,10 +398,8 @@ class AppCustomersAPIViewTest(AuthenticatedClientMixin, APITestCase):
         api = mock_auth0_client.return_value
         group = MagicMock()
         authz = api.authorization
-        authz.get.side_effect = [
-            group,
-            None
-        ]
+        authz.get_or_create.return_value = group
+        authz.get.return_value = None
         mgmt = api.management
         mgmt.create.return_value = Auth0User(user_id=123)
 

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -143,7 +143,7 @@ class AppCustomersAPIView(GenericAPIView):
     def get(self, request, *args, **kwargs):
         instance = self.get_object()
 
-        members = Auth0().get_group_members(instance.name)
+        members = Auth0().get_group_members(instance.slug)
 
         if members is None:
             raise Http404
@@ -158,7 +158,7 @@ class AppCustomersAPIView(GenericAPIView):
         serializer.is_valid(raise_exception=True)
 
         Auth0().add_group_member(
-            self.get_object().name,
+            self.get_object().slug,
             serializer.validated_data['email']
         )
 
@@ -170,7 +170,7 @@ class AppCustomersDetailAPIView(GenericAPIView):
     permission_classes = (IsSuperuser,)
 
     def delete(self, request, *args, **kwargs):
-        Auth0().delete_group_member(self.get_object().name, kwargs['user_id'])
+        Auth0().delete_group_member(self.get_object().slug, kwargs['user_id'])
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/run_tests
+++ b/run_tests
@@ -4,4 +4,4 @@ set -e -o pipefail
 
 export DJANGO_SETTINGS_MODULE="control_panel_api.settings.test"
 
-python3 wait_for_db && pytest --color=yes --spec --testmon control_panel_api
+python3 wait_for_db && pytest --color=yes --spec control_panel_api


### PR DESCRIPTION
## Why

* Customers created via the Control Panel API cannot login to the apps they are invited to - they receive a login link via email, but it does not log them in successfully.
* The reason is that the customers are (sometimes) added to an Auth0 Authorization Group with an incorrect name.
* The Control Panel API uses the app **name** (eg: `Crime_in_prisons`) to get _or create_ a Group.
* The Concourse deployment pipeline creates Groups with the app **slug** (eg: `crime-in-prisons`).
* This problem does not occur if the app name is identical to the slug.
* Because of this, customers are members of a valid Group, but which may not have permission to access the app, so they receive a login link email, but cannot use it to login.

# What

* Changed app customers code to get/create Auth0 authorization groups using the app slug, rather than the app name.