### PR TITLE
Add patch for kubernetes client bug

### DIFF
--- a/control_panel_api/k8s.py
+++ b/control_panel_api/k8s.py
@@ -68,12 +68,14 @@ class Config(object):
             try:
                 k8s_config.load_incluster_config()
             except ConfigException as e:
+                from control_panel_api import k8s_patch
                 k8s_config.load_kube_config()
 
-            self.host = k8s_client.configuration.host
+            conf = k8s_client.configuration.Configuration()
+            self.host = conf.host
             if not settings.ENABLED['k8s_rbac']:
-                self.authorization = k8s_client.configuration.api_key['authorization']
-            self.ssl_ca_cert = k8s_client.configuration.ssl_ca_cert
+                self.authorization = conf.api_key['authorization']
+            self.ssl_ca_cert = conf.ssl_ca_cert
 
             self._loaded = True
 

--- a/control_panel_api/k8s_patch.py
+++ b/control_panel_api/k8s_patch.py
@@ -1,0 +1,45 @@
+import base64
+import datetime
+import json
+from datetime import timezone
+
+import kubernetes
+from kubernetes.config.kube_config import _is_expired
+
+
+def load_token(self):
+    if 'auth-provider' not in self._user:
+        return
+
+    provider = self._user['auth-provider']
+
+    if ('name' not in provider
+            or 'config' not in provider
+            or provider['name'] != 'oidc'):
+        return
+
+    parts = provider['config']['id-token'].split('.')
+
+    if len(parts) != 3:  # Not a valid JWT
+        return None
+
+    jwt_attributes = json.loads(
+        base64.b64decode(parts[1] + '==').decode('utf-8')
+    )
+
+    expire = jwt_attributes.get('exp')
+
+    if ((expire is not None) and
+        (_is_expired(
+            datetime.datetime.fromtimestamp(expire, tz=timezone.utc)))):
+        self._refresh_oidc(provider)
+
+        if self._config_persister:
+            self._config_persister(self._config.value)
+
+    self.token = f"Bearer {provider['config']['id-token']}"
+
+    return self.token
+
+
+kubernetes.config.kube_config.KubeConfigLoader._load_oid_token = load_token


### PR DESCRIPTION
# What

* Added a temporary patch for [a bug in the current version of the Python Kubernetes client](https://github.com/kubernetes-client/python/issues/525) which fails to correctly decode the base64 encoded OIDC token. This causes the API to raise an exception on access.
* The Kubernetes client has also changed how configuration is available, so I have changed the API code around the initialization of the client to match the new interface