### PR TITLE
Avoid python cryptography libressl dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
@@ -13,9 +13,17 @@ RUN apk add --no-cache \
         openssl \
         ca-certificates \
         libffi-dev \
-        libressl-dev \
-        postgresql-dev \
         python3-dev
+
+# Temporary bugfix for libressl
+# Postgres needs libressl-dev, but cryptography only works with openssl-dev
+RUN apk add --no-cache --virtual temp-ssl-fix \
+        openssl-dev \
+    && pip3 install cryptography==2.2.2 \
+    && apk del temp-ssl-fix \
+    && apk add --no-cache \
+        libressl-dev \
+        postgresql-dev
 
 # Install helm
 ENV HELM_VERSION 2.8.2


### PR DESCRIPTION
## What

* Python package `cryptography` v2.2.2 depends on openssl libraries being installed, but the latest Alpine Linux `libressl-dev` package is missing some required functions and so `cryptography` fails to compile
* Postgres client libraries also depend on openssl libraries, but fail to compile with the `openssl-dev` package ☹️ 
* This patch installs `openssl-dev`, compiles `cryptography`, then removes `openssl-dev` and installs `libressl-dev` and `postgresql-dev` to avoid the issue.
* Hopefully, this is only a temporary patch while libressl fix their package.