### PR TITLE
Refactor Elasticsearch to avoid credentials parsing bug

### DIFF
--- a/control_panel_api/elasticsearch.py
+++ b/control_panel_api/elasticsearch.py
@@ -1,13 +1,12 @@
 from django.conf import settings
-from elasticsearch import Elasticsearch as _Elasticsearch
-from elasticsearch_dsl import Q, Search
+from elasticsearch_dsl import Q, Search, connections
 from elasticsearch_dsl.query import Range
 
 
 def bucket_hits_aggregation(bucket_name, num_days=None):
-    client = _Elasticsearch(settings.ELASTICSEARCH_CONN)
+    connections.create_connection(hosts=settings.ELASTICSEARCH['connection'])
 
-    s = Search(using=client, index=settings.ELASTICSEARCH_INDEX_S3LOGS)
+    s = Search(index=settings.ELASTICSEARCH['index'])
 
     q1 = Q('term', **{'bucket.keyword': bucket_name})
     q2 = Q('terms',

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -167,8 +167,17 @@ RSTUDIO_AUTH_CLIENT_DOMAIN = os.environ.get('RSTUDIO_AUTH_CLIENT_DOMAIN', OIDC_D
 RSTUDIO_AUTH_CLIENT_ID = os.environ.get('RSTUDIO_AUTH_CLIENT_ID')
 RSTUDIO_AUTH_CLIENT_SECRET = os.environ.get('RSTUDIO_AUTH_CLIENT_SECRET')
 
-ELASTICSEARCH_CONN = os.environ.get('ELASTICSEARCH_CONN')
-ELASTICSEARCH_INDEX_S3LOGS = os.environ.get('ELASTICSEARCH_INDEX_S3LOGS', 's3logs-*')
+ELASTICSEARCH = {
+    'connection': {
+        'host': os.environ.get('ELASTICSEARCH_HOST'),
+        'port': os.environ.get('ELASTICSEARCH_PORT', 9243),
+        'http_auth': (
+            os.environ.get('ELASTICSEARCH_USERNAME'),
+            os.environ.get('ELASTICSEARCH_PASSWORD')
+        ),
+    },
+    'index': os.environ.get('ELASTICSEARCH_INDEX_S3LOGS', 's3logs-*'),
+}
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
## What

* Elasticsearch creds are currently passed to the Control Panel API in the `https://username:password@elasticsearch.host:port` format, but special characters in the password appear to be incorrectly parsed, resulting in [an exception](https://sentry.service.dsd.io/mojds/control-panel-api/issues/32514/)
* This change uses the `http_auth=(username, password)` argument to avoid the parsing stage and hopefully avoid the bug