### PR TITLE
Bump dependencies as suggested by dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asn1crypto==0.24.0
 auth0-python==3.2.2
-boto3==1.7.25
-botocore==1.10.25
+boto3==1.7.29
+botocore==1.10.29
 cachetools==2.1.0
 certifi==2018.4.16
 cffi==1.11.5
@@ -19,7 +19,7 @@ ecdsa==0.13
 elasticsearch==6.2.0
 elasticsearch-dsl==6.1.0
 future==0.16.0
-google-auth==1.4.1
+google-auth==1.4.2
 gunicorn==19.8.1
 idna==2.6
 ipaddress==1.0.22
@@ -28,15 +28,15 @@ Jinja2==2.10
 jmespath==0.9.3
 kubernetes==6.0.0
 MarkupSafe==1.0
-model-mommy==1.5.1
+model-mommy==1.6.0
 openapi-codec==1.3.2
 psycopg2==2.7.4
 py==1.5.3
-pyasn1==0.4.2
+pyasn1==0.4.3
 pyasn1-modules==0.2.1
 pycparser==2.18
 pycrypto==2.6.1
-pytest==3.5.1
+pytest==3.6.0
 pytest-django==3.2.1
 pytest-spec==1.1.0
 pytest-testmon==0.9.11
@@ -53,4 +53,3 @@ simplejson==3.15.0
 six==1.11.0
 uritemplate==3.0.0
 urllib3==1.22
-websocket-client==0.47.0


### PR DESCRIPTION
* Bump botocore from 1.10.25 to 1.10.29
* Bump google-auth from 1.4.1 to 1.4.2
* Bump model-mommy from 1.5.1 to 1.6.0
* Bump boto3 from 1.7.25 to 1.7.29
* Bump pyasn1 from 0.4.2 to 0.4.3
* Bump pytest from 3.5.1 to 3.6.0

* Removed websocket-client as it doesn't seem to be used