### PR TITLE
Use S3 hosted Helm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ kubectl cluster-info
 
 You need to tell Helm to use the AP charts:
 ```sh
-helm repo add mojanalytics https://ministryofjustice.github.io/analytics-platform-helm-charts/charts/
+helm repo add mojanalytics http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com
 helm repo update
 ```
 

--- a/helm-repositories.yaml
+++ b/helm-repositories.yaml
@@ -18,4 +18,4 @@ repositories:
   certFile: ""
   keyFile: ""
   name: mojanalytics
-  url: https://ministryofjustice.github.io/analytics-platform-helm-charts/charts/
+  url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com


### PR DESCRIPTION
* Helm chart packages and index are now hosted in S3, updated by Concourse. This change points the Control Panel helm command at that repository.