### PR TITLE
Bump versions

### DIFF
--- a/control_panel_api/helm.py
+++ b/control_panel_api/helm.py
@@ -22,7 +22,7 @@ class Helm(object):
                     stderr=subprocess.PIPE,
                     check=True)
             except subprocess.CalledProcessError as error:
-                log.error(error.stdout)
+                log.error(error.stderr)
                 raise error
 
 
@@ -36,7 +36,7 @@ class Helm(object):
                     check=True
                 )
             except subprocess.CalledProcessError as error:
-                log.error(error.stdout)
+                log.error(error.stderr)
                 raise error
 
     def upgrade_release(self, release, chart, *args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asn1crypto==0.24.0
 auth0-python==3.2.2
-boto3==1.7.29
-botocore==1.10.29
+boto3==1.7.32
+botocore==1.10.32
 cachetools==2.1.0
 certifi==2018.4.16
 cffi==1.11.5
@@ -9,7 +9,7 @@ chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
 cryptography==2.2.2
-Django==2.0.5
+Django==2.0.6
 django-extensions==2.0.7
 django-filter==1.1.0
 django-rest-swagger==2.2.0
@@ -19,7 +19,7 @@ ecdsa==0.13
 elasticsearch==6.2.0
 elasticsearch-dsl==6.1.0
 future==0.16.0
-google-auth==1.4.2
+google-auth==1.5.0
 gunicorn==19.8.1
 idna==2.6
 ipaddress==1.0.22
@@ -45,11 +45,11 @@ python-dateutil==2.7.3
 python-jose==3.0.0
 pytz==2018.4
 PyYAML==3.12
-raven==6.8.0
+raven==6.9.0
 requests==2.18.4
 rsa==3.4.2
 s3transfer==0.1.13
 simplejson==3.15.0
 six==1.11.0
 uritemplate==3.0.0
-urllib3==1.22
+urllib3==1.23


### PR DESCRIPTION
## What

* Bump urllib3 from 1.22 to 1.23
* Bump botocore from 1.10.29 to 1.10.32
* Bump boto3 from 1.7.29 to 1.7.32
* Bump django from 2.0.5 to 2.0.6
* Bump google-auth from 1.4.2 to 1.5.0
* Bump raven from 6.8.0 to 6.9.0

* Also, fix typo in helm client - log output on stderr, not stdout.