### PR TITLE
Prevent KeyError 'app' when updating apps3bucket

### DIFF
--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -30,11 +30,11 @@ class AppS3BucketSerializer(serializers.ModelSerializer):
         fields = ('id', 'url', 'app', 's3bucket', 'access_level')
 
     def update(self, instance, validated_data):
-        if instance.app != validated_data['app']:
+        if 'app' in validated_data and instance.app != validated_data['app']:
             raise serializers.ValidationError(
                 "App is not editable. Create a new record."
             )
-        if instance.s3bucket != validated_data['s3bucket']:
+        if 's3bucket' in validated_data and instance.s3bucket != validated_data['s3bucket']:
             raise serializers.ValidationError(
                 "S3Bucket is not editable. Create a new record."
             )


### PR DESCRIPTION
## What

Fix guards for changing `app` and `s3bucket` fields of apps3bucket object.
Update requests contain only fields to update and the apps3bucket id, and may (should) omit `app` and `s3bucket` fields.

See [Sentry](https://sentry.service.dsd.io/mojds/control-panel-api/issues/32536/)