### PR TITLE
Fix adding platform users as customers

### DIFF
--- a/control_panel_api/auth0.py
+++ b/control_panel_api/auth0.py
@@ -74,7 +74,7 @@ class Auth0(object):
                     email_verified=True,
                     **user_options))
 
-        group.add_users(list(users_to_add.values()))
+        group.add_users(users_to_add.values())
 
     def delete_group_members(self, group_name, user_ids):
         group = self.authorization_api.get(Group(name=group_name))

--- a/control_panel_api/models.py
+++ b/control_panel_api/models.py
@@ -9,6 +9,7 @@ from django_extensions.db.fields import AutoSlugField
 from django_extensions.db.models import TimeStampedModel
 
 from control_panel_api import services, validators
+from control_panel_api.auth0 import Auth0
 from control_panel_api.helm import helm
 from control_panel_api.utils import sanitize_dns_label
 
@@ -103,6 +104,20 @@ class App(TimeStampedModel):
             repo_name = repo_name[:-4]
 
         return repo_name.rsplit('/', 1)[1]
+
+    def get_customers(self):
+        return Auth0().get_group_members(group_name=self.slug)
+
+    def add_customers(self, emails):
+        Auth0().add_group_members(
+            group_name=self.slug,
+            emails=emails,
+            user_options={'connection': 'email'})
+
+    def delete_customers(self, user_ids):
+        Auth0().delete_group_members(
+            group_name=self.slug,
+            user_ids=user_ids)
 
 
 class UserApp(TimeStampedModel):

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -203,7 +203,7 @@ class AppTestCase(TestCase):
 
         self.assertEqual(
             expected_customer_emails,
-            sorted(map(itemgetter('email'), customers)))
+            list(map(itemgetter('email'), customers)))
 
     @patch('control_panel_api.auth0.Auth0Client')
     def test_add_customers(self, mock_auth0_client):

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+from operator import itemgetter
 from unittest.mock import MagicMock, call, patch
 
 from django.conf import settings
@@ -6,6 +7,7 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from model_mommy import mommy
 
+from control_panel_api.auth0 import User as Auth0User
 from control_panel_api.aws import aws
 from control_panel_api.helm import helm
 from control_panel_api.models import (
@@ -187,6 +189,83 @@ class AppTestCase(TestCase):
 
         aws.client.return_value.delete_role.assert_called_with(
             RoleName=expected_role_name)
+
+    @patch('control_panel_api.auth0.Auth0Client')
+    def test_get_customers(self, auth0):
+        auth0.return_value.authorization.get.return_value.get_members.return_value = [
+            {'email': 'test@example.com'}
+        ]
+
+        app = App.objects.create(repo_url='https://example.com/repo_name')
+        customers = app.get_customers()
+
+        expected_customer_emails = ['test@example.com']
+
+        self.assertEqual(
+            expected_customer_emails,
+            sorted(map(itemgetter('email'), customers)))
+
+    @patch('control_panel_api.auth0.Auth0Client')
+    def test_add_customers(self, mock_auth0_client):
+        app = App.objects.create(repo_url='https://example.com/repo_name')
+        auth0 = mock_auth0_client.return_value
+        authz = auth0.authorization
+        mgmt = auth0.management
+        group = authz.get.return_value
+        emails = [
+            'test1@example.com',
+            'test2@example.com'
+        ]
+
+        def mock_create_user(user):
+            return Auth0User(user, user_id=emails.index(user['email']))
+
+        mgmt.create.side_effect = mock_create_user
+
+        def new_user(email):
+            return Auth0User(
+                email=email,
+                email_verified=True,
+                connection='email')
+
+        def existing_user(email):
+            return Auth0User(new_user(email), user_id=emails.index(email))
+
+        def assert_case(all_users, expected_created, expected_added):
+            authz.get_all.return_value = all_users
+
+            app.add_customers(emails)
+
+            mgmt.create.assert_has_calls(
+                [call(user) for user in expected_created],
+                any_order=True)
+
+            group.add_users.assert_called_with(expected_added)
+
+        assert_case(
+            all_users=[],
+            expected_created=map(new_user, emails),
+            expected_added=list(map(existing_user, emails)))
+
+        assert_case(
+            all_users=[existing_user('test1@example.com')],
+            expected_created=[new_user('test2@example.com')],
+            expected_added=list(map(existing_user, emails)))
+
+        assert_case(
+            all_users=list(map(existing_user, emails)),
+            expected_created=[],
+            expected_added=list(map(existing_user, emails)))
+
+    @patch('control_panel_api.auth0.Auth0Client')
+    def test_delete_customers(self, mock_auth0_client):
+        app = App.objects.create(repo_url='https://example.com/repo_name')
+        auth0 = mock_auth0_client.return_value
+        authz = auth0.authorization
+        group = authz.get.return_value
+        app.delete_customers(['email|123'])
+        group.delete_users.assert_called_with([
+            {'user_id': 'email|123'}])
 
 
 class S3BucketTestCase(TestCase):

--- a/control_panel_api/tests/test_models.py
+++ b/control_panel_api/tests/test_models.py
@@ -240,7 +240,8 @@ class AppTestCase(TestCase):
                 [call(user) for user in expected_created],
                 any_order=True)
 
-            group.add_users.assert_called_with(expected_added)
+            args, kwargs = group.add_users.call_args
+            assert list(args[0]) == expected_added
 
         assert_case(
             all_users=[],

--- a/control_panel_api/tests/test_views.py
+++ b/control_panel_api/tests/test_views.py
@@ -393,7 +393,8 @@ class AppCustomersAPIViewTest(AuthenticatedClientMixin, APITestCase):
 
         authz.get.assert_called_with(Auth0Group(name=self.app.slug))
 
-        group.add_users.assert_called_with([user])
+        args, kwargs = group.add_users.call_args
+        assert list(args[0]) == [user]
 
     @patch('control_panel_api.auth0.Auth0Client')
     def test_post_create_user(self, mock_auth0_client):
@@ -418,8 +419,8 @@ class AppCustomersAPIViewTest(AuthenticatedClientMixin, APITestCase):
                 email=data['email'],
                 email_verified=True))
 
-        group.add_users.assert_called_with([
-            {'user_id': 123}])
+        args, kwargs = group.add_users.call_args
+        assert list(args[0]) == [{'user_id': 123}]
 
 
 class AppCustomersDetailAPIView(AuthenticatedClientMixin, APITestCase):

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -143,7 +143,7 @@ class AppCustomersAPIView(GenericAPIView):
         app = self.get_object()
         customers = app.get_customers()
 
-        if not customers:
+        if customers is None:
             raise Http404
 
         serializer = self.get_serializer(data=customers, many=True)


### PR DESCRIPTION
## What

* Refactored customer management as methods on App model - the View was dealing with too low a level of abstraction, reading and writing Auth0 Authorization API resources. Instead, this has been abstracted by a simpler interface on the App model: `App.get_customers`, `App.add_customers` and `App.delete_customers`
* Fixed the logic in `add_customers` to ensure the user resource(s) from Auth0 have `connection: 'email'` - which is what differentiates "customers" from platform users.
