### PR TITLE
List more than 25 customers for an app

### DIFF
--- a/control_panel_api/management/commands/import_k8s_users.py
+++ b/control_panel_api/management/commands/import_k8s_users.py
@@ -43,7 +43,7 @@ def get_auth0_users():
     )
     api.access(ManagementAPI(settings.OIDC_DOMAIN))
 
-    return list(api.management.get_all_pages(Auth0User, connection='github'))
+    return list(api.management.get_all(Auth0User, connection='github'))
 
 
 def get_auth0_ids():

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -93,7 +93,7 @@ class API(object):
         response = self.request('POST', endpoint, json=resource)
 
         if 'error' in response:
-            raise CreateResourceError(response['message'])
+            raise CreateResourceError(response)
 
         print('Created {resource}({attrs})'.format(
             resource=resource.__class__.__name__.lower(),
@@ -269,7 +269,7 @@ class Group(AuthzResource):
         )
 
         if 'error' in response:
-            raise AddGroupRoleError(response['message'])
+            raise AddGroupRoleError(response)
 
         print('Added role({role}) to group({group})'.format(
             role=role['name'],
@@ -283,7 +283,7 @@ class Group(AuthzResource):
         )
 
         if 'error' in response:
-            raise AddGroupMemberError(response['message'])
+            raise AddGroupMemberError(response)
 
     def delete_users(self, users):
         response = self.api.request(
@@ -293,7 +293,7 @@ class Group(AuthzResource):
         )
 
         if 'error' in response:
-            raise DeleteGroupMemberError(response['message'])
+            raise DeleteGroupMemberError(response)
 
     def get_members(self):
         results = self.api.request(

--- a/moj_analytics/tests/conftest.py
+++ b/moj_analytics/tests/conftest.py
@@ -226,3 +226,27 @@ def given_a_role_exists(request, config, mock_resources, state):
     data = [Role(name='role1', applicationId='app1')]
     mock_resources(config['authz_url'], 'roles', data, authz_format)
     state['roles'] = data
+
+
+@pytest.fixture
+def given_more_than_100_users_exist(request, config, responses):
+    total = 150
+    per_page = 100
+
+    data = [
+        User(email=f'test{i}@example.com', connection='email')
+        for i in range(total)
+    ]
+
+    for i in range(0, total, per_page):
+        responses.add_callback(
+            'GET',
+            f'https://{config["domain"]}/api/v2/users',
+            json_response({
+                'start': 0,
+                'limit': per_page,
+                'length': (total - i),
+                'total': total,
+                'users': data[i:i+100]
+            })
+        )

--- a/moj_analytics/tests/conftest.py
+++ b/moj_analytics/tests/conftest.py
@@ -238,15 +238,15 @@ def given_more_than_100_users_exist(request, config, responses):
         for i in range(total)
     ]
 
-    for i in range(0, total, per_page):
+    for start in range(0, total, per_page):
         responses.add_callback(
             'GET',
             f'https://{config["domain"]}/api/v2/users',
             json_response({
                 'start': 0,
                 'limit': per_page,
-                'length': (total - i),
+                'length': (total - start),
                 'total': total,
-                'users': data[i:i+100]
+                'users': data[start:start+per_page]
             })
         )

--- a/moj_analytics/tests/test_auth0_client.py
+++ b/moj_analytics/tests/test_auth0_client.py
@@ -19,7 +19,6 @@ class TestAuth0Client(object):
         users = auth0.management.get_all(User)
         assert len(users) == 150
 
-
     @pytest.mark.usefixtures(
         'given_valid_api_client_credentials',
         'given_access_to_the_management_api',

--- a/moj_analytics/tests/test_auth0_client.py
+++ b/moj_analytics/tests/test_auth0_client.py
@@ -13,6 +13,16 @@ class TestAuth0Client(object):
     @pytest.mark.usefixtures(
         'given_valid_api_client_credentials',
         'given_access_to_the_management_api',
+        'given_more_than_100_users_exist',
+    )
+    def test_it_can_list_more_than_100_users(self, auth0):
+        users = auth0.management.get_all(User)
+        assert len(users) == 150
+
+
+    @pytest.mark.usefixtures(
+        'given_valid_api_client_credentials',
+        'given_access_to_the_management_api',
     )
     def test_it_can_create_a_client(self, auth0):
 


### PR DESCRIPTION
## What

* Fix for [issue #38](https://github.com/ministryofjustice/analytics-platform/issues/38)
* Refactored `get_all` to get all pages of results, not just the first.
* Removed `get_all_pages` function

## How to review

1. Add 25 customers to an App in the Control Panel
2. Add 1 more customer
3. See that more than 25 customers are listed
