### PR TITLE
Switch from pycrypto dep because it is not maintained

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,14 +35,13 @@ py==1.5.4
 pyasn1==0.4.3
 pyasn1-modules==0.2.2
 pycparser==2.18
-pycrypto==2.6.1
 pytest==3.6.3
 pytest-django==3.3.2
 pytest-spec==1.1.0
 pytest-testmon==0.9.12
 pytest-watch==4.2.0
 python-dateutil==2.7.3
-python-jose==3.0.0
+python-jose[cryptography]==3.0.0
 pytz==2018.5
 PyYAML==3.13
 raven==6.9.0


### PR DESCRIPTION
## What

Switch from the 'pycrypto' dependency, because it is not maintained.
See discussion:
https://trello.com/c/hcCBYGHn/1274-pycrypto-in-controlpanel-is-not-maintained

## How to review

The tests pass, and includes some stuff on authenticating JWKs. I've not dug into it any further than this. I've not got controlpanel API and front-end running locally - perhaps someone who has try it or maybe we simply try on dev? I think logging in with Github should be enough of a test.
