### PR TITLE
Enable bulk adding customers

### DIFF
--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -262,7 +262,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class AppCustomerSerializer(serializers.Serializer):
-    email = serializers.EmailField()
+    email = serializers.CharField()
     user_id = serializers.CharField(max_length=64, required=False)
     nickname = serializers.CharField(max_length=64, required=False)
     name = serializers.CharField(max_length=64, required=False)

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -158,14 +158,14 @@ class AppCustomersAPIView(GenericAPIView):
         return Response(serializer.data)
 
     def post(self, request, *args, **kwargs):
-        data = request.data
-        delimiters = re.compile(r'[,; ]+')
-
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         app = self.get_object()
+
+        delimiters = re.compile(r'[,; ]+')
         emails = delimiters.split(serializer.validated_data['email'])
+
         errors = []
         for email in emails:
             validator = EmailValidator(

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -1,17 +1,23 @@
+import logging
+import re
+from subprocess import CalledProcessError
+
 from botocore.exceptions import ClientError
 from django.contrib.auth.models import Group
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import EmailValidator
 from django.db import transaction
 from django.http import JsonResponse
 from django.http.response import Http404
 from django.views.decorators.csrf import csrf_exempt
 from django_filters.rest_framework import DjangoFilterBackend
 from elasticsearch import TransportError
-import logging
 from rest_framework import status, viewsets
 from rest_framework.decorators import api_view, detail_route, permission_classes
+from rest_framework.exceptions import ValidationError
+from rest_framework.fields import get_error_detail
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
-from subprocess import CalledProcessError
 
 from control_panel_api.elasticsearch import bucket_hits_aggregation
 from control_panel_api.exceptions import (
@@ -152,11 +158,26 @@ class AppCustomersAPIView(GenericAPIView):
         return Response(serializer.data)
 
     def post(self, request, *args, **kwargs):
+        data = request.data
+        delimiters = re.compile(r'[,; ]+')
+
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         app = self.get_object()
-        app.add_customers([serializer.validated_data['email']])
+        emails = delimiters.split(serializer.validated_data['email'])
+        errors = []
+        for email in emails:
+            validator = EmailValidator(
+                message=f'{email} is not a valid email address')
+            try:
+                validator(email)
+            except DjangoValidationError as error:
+                errors.extend(get_error_detail(error))
+        if errors:
+            raise ValidationError(errors)
+
+        app.add_customers(emails)
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -117,7 +117,7 @@ class API(object):
         if key is None:
             key = f'{resource_class.__name__.lower()}s'
 
-        params = resource_class.get_all_params
+        params = resource_class.get_all_params.copy()
 
         resources = []
         total = None

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -142,6 +142,9 @@ class API(object):
             if len(resources) >= total:
                 break
 
+            if len(response[key]) < 1:
+                break
+
             params['page'] = params.get('page', 1) + 1
 
         return [resource_class(self, r) for r in resources]


### PR DESCRIPTION
## What

* Enable adding customers in bulk by submitting a delimited string of email addresses. Delimiters may be any of space, comma or semi-colon, and may be mixed in the same string.
* Raise a ValidationError if any of the email addresses are invalid - no customers will be created or added to the app if any of the emails is invalid
* Also fixed a bug with listing customers multiple times

## How to review

1. Using an HTTP client, POST a list of email addresses to the add-customers API endpoint, eg:
```shell
curl --header "Content-Type: application/json" \
     --user "your-username:your-password" \
     --request POST \
     --data '{"email":"test1@example.com, test2@example.com, test3@example.com"}' \
     http://localhost:8000/apps/1/customers/
```
2. See that multiple customers are added to the app

See [Trello #1275](https://trello.com/c/N1bJpFMl)