### PR TITLE
Make sentry optional and ignore exceptions when running in the django shell

### DIFF
--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 
 def is_enabled(value):
@@ -144,10 +145,15 @@ IAM_ARN_BASE = os.environ.get('IAM_ARN_BASE', '')
 K8S_WORKER_ROLE_NAME = os.environ.get('K8S_WORKER_ROLE_NAME', '')
 SAML_PROVIDER = os.environ.get('SAML_PROVIDER', '')
 
-RAVEN_CONFIG = {
-    'dsn': os.environ.get('SENTRY_DSN', ''),
-    'environment': ENV,
-}
+if os.environ.get('SENTRY_DSN'):
+    this_is_running_in_the_django_shell = "shell" in sys.argv
+    RAVEN_CONFIG = {
+        'dsn': os.environ.get('SENTRY_DSN', ''),
+        'environment': ENV,
+        'ignore_exceptions': ('*') if this_is_running_in_the_django_shell else (),
+    }
+else:
+    INSTALLED_APPS.remove('raven.contrib.django.raven_compat')
 
 OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID')
 OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET')


### PR DESCRIPTION
Accelerator doesn't have a Sentry instance, so this PR makes it optional - otherwise we all exceptions are compounded with another Raven/Sentry exception.

Secondly, when you shell onto a box and use `python3 manage.py shell`, every exception that occurs through you mistyping shouldn't be recorded by Sentry. This PR stops shell exceptions being recorded in Sentry. There are lots of these errors in our Sentry currently, and these distract from real errors. This code change is from: https://github.com/getsentry/raven-python/issues/1179#issuecomment-406722844

## How to review

Now when I cause an exception in a shell, Sentry says it will ignore it:
```
$ kubectl exec -i -t cpanel-master-cpanel-7dcb47b778-6bd4w -- python3 ./manage.py shell
2018-09-24 13:26:24,973 raven.contrib.django.client.DjangoClient DEBUG Configuring Raven for host: https://sentry.service.dsd.io
Python 3.6.5 (default, Aug 22 2018, 14:20:40)
[GCC 6.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> raise Exception('Dave test')
2018-09-24 13:26:28,216 raven.contrib.django.client.DjangoClient INFO Not capturing exception due to filters: <class 'Exception'>
Traceback (most recent call last):
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
Exception: Dave test
Traceback (most recent call last):
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
Exception: Dave test
```
