### PR TITLE
Stop reams of unnecessary logs

### DIFF
--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -202,6 +202,12 @@ LOGGING = {
             'handlers': ['console'],
             'level': os.environ.get('LOG_LEVEL', 'DEBUG'),
         },
+        'django.template': {
+            # Get rid of noisy debug messages
+            'handlers': ['console'],
+            'level': os.environ.get('LOG_LEVEL', 'INFO'),
+            'propagate': False,
+        },
         'django': {
             'handlers': ['console'],
             'level': os.environ.get('LOG_LEVEL', 'DEBUG'),


### PR DESCRIPTION
Merging this PR will stop the reams of unnecessary DEBUGs flooding the log, caused when the readiness probe hits the log-in page every 5 seconds.

Fixes: https://github.com/ministryofjustice/analytics-platform-control-panel/issues/336

More about this sort of error:
https://github.com/encode/django-rest-framework/issues/3736

## What

The logging options now filter out DEBUG level for the django template rendered, whilst still allowing DEBUG level for elsewhere in django and the app.

## How to review

1. Run the container on dev
2. See the logs aren't filling with stuff the whole time as the readiness check hits /auth/login - hooray!