### PR TITLE
Add a method to run a single test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ static/
 *.pyc
 .pytest_cache
 .testmondata
+.vscode/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Then browse to http://localhost:8000/
 docker-compose -f docker-compose.test.yml up --abort-on-container-exit
 ```
 
+You can run a particular test using the pytest '-k' parameter:
+```sh
+docker-compose -f docker-compose.test.yml build && docker-compose -f docker-compose.test.yml run app ./run_tests -k TEST-NAME
+```
+
 ## Running directly on your machine
 
 ### Dependencies

--- a/run_tests
+++ b/run_tests
@@ -4,4 +4,4 @@ set -e -o pipefail
 
 export DJANGO_SETTINGS_MODULE="control_panel_api.settings.test"
 
-python3 wait_for_db && pytest --color=yes --spec control_panel_api
+python3 wait_for_db && pytest --color=yes --spec control_panel_api $@


### PR DESCRIPTION
Running just one test is a little quicker, but it is helpful for TDD and when you stick in a pdb break-point and want to try it for a particular test.
