### PR TITLE
pyyaml upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pytest-watch==4.2.0
 python-dateutil==2.7.5
 python-jose[cryptography]==3.0.1
 pytz==2018.9
-PyYAML==3.13
+PyYAML==4.2b4
 raven==6.10.0
 requests==2.21.0
 rsa==4.0


### PR DESCRIPTION
Upgrade to the latest (pre-release) pyyaml for security fix.

pyyaml is used by the kubernetes python client. They [looked at upgrading their requirements](https://github.com/kubernetes-client/python/pull/718) but decided in favour of [changing their calls of yaml.load to yaml.safe_load](https://github.com/kubernetes-client/python-base/pull/111), however that is not yet released.

So in the meantime I think it is fine to use this pre-release pyyaml. The only checks I've done so far are seeing it pass the tests.