### PR TITLE
Tidy up, fix warnings and use a Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 ENV HELM_VERSION 2.9.1
 ENV HELM_HOME /tmp/helm
 ENV DJANGO_SETTINGS_MODULE "control_panel_api.settings"
-ENV USE_VENV=false
 
 WORKDIR /home/control-panel
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,7 @@ PORT=8000
 PROJECT=control-panel
 MODULE=control_panel_api
 VENV=venv
-ifneq (${USE_VENV}, false)
-	BIN=${VENV}/bin
-	USE_VENV=true
-else
-	BIN=/usr/bin
-endif
+BIN=${VENV}/bin
 
 -include .env
 export
@@ -16,9 +11,7 @@ export
 .PHONY: collectstatic dependencies help run test wait_for_db
 
 venv/bin:
-	@if ${USE_VENV} && [ ! -d "${VENV}" ] ; then python3 -m venv venv ; fi
-
-usr/bin:
+	@if ${USE_VENV} && [ ! -d "${VENV}" ] ; then python3 -m venv ${VENV} ; fi
 
 ## dependencies: Install dependencies
 dependencies: ${BIN} requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,118 @@
+HOST=0.0.0.0
+PORT=8000
+PROJECT=control-panel
+MODULE=control_panel_api
+VENV=venv
+ifneq (${USE_VENV}, false)
+	BIN=${VENV}/bin
+	USE_VENV=true
+else
+	BIN=/usr/bin
+endif
+
+-include .env
+export
+
+.PHONY: collectstatic createdb createuser dependencies help migrations nocreatedb nocreateuser run test wait_for_db
+
+venv/bin:
+	@if ${USE_VENV} && [ ! -d "${VENV}" ] ; then python3 -m venv venv ; fi
+
+usr/bin:
+
+## dependencies: Install dependencies
+dependencies: ${BIN} requirements.txt
+	@echo
+	@echo "> Fetching dependencies..."
+	@${BIN}/pip3 install -r requirements.txt
+
+## collectstatic: Collect assets into static folder
+collectstatic:
+	@echo
+	@echo "> Collecting static assets..."
+	@${BIN}/python3 manage.py collectstatic
+
+## run: Run webapp
+run:
+	@echo
+	@echo "> Running webapp..."
+	@${BIN}/gunicorn -b ${HOST}:${PORT} ${MODULE}.wsgi:application
+
+wait_for_db:
+	@echo
+	@echo "> Waiting for database..."
+	@${BIN}/python3 wait_for_db
+
+## shell: Run Django shell
+shell:
+	@echo
+	@echo "> Running shell..."
+	@${BIN}/python3 manage.py shell_plus
+
+## test: Run tests
+test: export DJANGO_SETTINGS_MODULE=${MODULE}.settings.test
+test: wait_for_db
+	@echo
+	@echo "> Running tests..."
+	@NAMED_TESTS="$(shell if [ -n "${TEST_NAME}" ]; then echo "-k ${TEST_NAME}" ; fi)" && \
+	${BIN}/pytest --color=yes ${MODULE} $$NAMED_TESTS
+
+## migrations: Apply database migrations
+migrations: wait_for_db
+	@echo
+	@echo "> Running database migrations..."
+	@${BIN}/python3 manage.py migrate
+
+createuser:
+	@echo "Creating user ${DB_USER}"
+	@createuser -d ${DB_USER}
+
+nocreateuser:
+	@echo User ${DB_USER} already exists
+
+createdb:
+	@echo "Creating database ${DB_NAME}"
+	@createdb -U ${DB_USER} ${DB_NAME}
+
+nocreatedb:
+	@echo Database ${DB_NAME} already exists
+
+## init-database: Setup database and user
+init-database:
+	@echo
+	@echo "> Initializing database..."
+	@make $(shell psql postgres -tAc "SELECT 'no' FROM pg_roles WHERE rolname='${DB_USER}'")createuser
+	@make $(shell psql postgres -tAc "SELECT 'no' FROM pg_database WHERE datname='${DB_NAME}'")createdb
+
+## docker-image: Build docker image
+docker-image:
+	@echo
+	@echo "> Building docker image..."
+	@docker build -t ${PROJECT} .
+
+install-helm:
+	@wget https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O helm.tgz && \
+		tar fxz helm.tgz && \
+		mv linux-amd64/helm /usr/local/bin && \
+		rm -rf helm.tgz linux-amd64
+
+## superuser: Create a superuser
+superuser:
+	@echo
+	@echo "> Creating superuser..."
+	@read -p "Username: " username; \
+	read -s -p "Password: " password; \
+	${BIN}/python3 manage.py shell -c "from control_panel_api.models import User; u = User(); u.username='$$username'; u.set_password('$$password'); u.is_superuser=True; u.save()"
+
+## docker-test: Run tests in Docker container
+docker-test:
+	@echo
+	@echo "> Running tests in Docker..."
+	@docker-compose -f docker-compose.test.yml run app make test TEST_NAME=$$TEST_NAME
+
+help: Makefile
+	@echo
+	@echo " Commands in "$(PROJECT)":"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' | sed -e 's/^/ /'
+	@echo

--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ Then browse to http://localhost:8000/
 make docker-test
 ```
 
-You can run a particular test using the `TEST_NAME` parameter:
-```sh
-make docker-test TEST_NAME=test_get_user_teams
-```
-
 ## Running directly on your machine
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker-compose up
 ```
 and then in a separate terminal window,
 ```sh
-docker-compose exec app make superuser
+docker-compose exec app python3 manage.py createsuperuser
 ```
 Then browse to http://localhost:8000/
 
@@ -37,13 +37,9 @@ The Control Panel app requires Python 3.6+
 
 Install dependencies with the following command:
 ```sh
-make dependencies
+python3 -m venv venv
 source venv/bin/activate
-```
-
-This will automatically use a virtual environment to install python dependencies, but if you want to install into your system library, you can override this with the `USE_VENV` parameter:
-```sh
-make dependencies USE_VENV=false
+pip3 install -r requirements.txt
 ```
 
 ### Kubernetes setup
@@ -94,18 +90,19 @@ export DJANGO_SETTINGS_MODULE=control_panel_api.settings
 
 The Control Panel app connects to a PostgreSQL database, which should have a database with the expected name:
 ```sh
-make init-database
+createuser -d controlpanel
+createdb -U controlpanel controlpanel
 ```
 
 Then you can run migrations:
 ```sh
-make migrations
+python3 manage.py migrate
 ```
 
 ### Create superuser (on first run only)
 
 ```sh
-make superuser
+python3 manage.py createsuperuser
 ```
 NB `Username` needs to be your GitHub username
 
@@ -113,14 +110,18 @@ NB `Username` needs to be your GitHub username
 
 Before the first run (or after changes to static assets), you need to run
 ```sh
-make collectstatic
+python3 manage.py collectstatic
 ```
 
 ### Run the app
 
-You can run the app with
+You can run the app with the Django development server with
 ```sh
-make run
+python3 manage.py runserver
+```
+Or with Gunicorn WSGI server:
+```sh
+gunicorn -b 0.0.0.0:8000 control_panel_api.wsgi:application
 ```
 Go to http://localhost:8000/
 
@@ -128,6 +129,11 @@ Go to http://localhost:8000/
 
 ```sh
 make test
+```
+
+You can run a specific test class or function by passing the `TEST_NAME` parameter, eg:
+```sh
+make test TEST_NAME=test_something
 ```
 
 # Deployment

--- a/README.md
+++ b/README.md
@@ -9,24 +9,24 @@ https://github.com/ministryofjustice/analytics-platform-control-panel-frontend
 ## Running with Docker
 
 ```sh
-docker-compose build
+docker-compose build  # OR make docker-image
 docker-compose up
 ```
 and then in a separate terminal window,
 ```sh
-docker-compose exec app python3 manage.py createsuperuser
+docker-compose exec app make superuser
 ```
 Then browse to http://localhost:8000/
 
 ### Running tests with docker
 
 ```sh
-docker-compose -f docker-compose.test.yml up --build --abort-on-container-exit
+make docker-test
 ```
 
-You can run a particular test using the pytest '-k' parameter:
+You can run a particular test using the `TEST_NAME` parameter:
 ```sh
-docker-compose -f docker-compose.test.yml build && docker-compose -f docker-compose.test.yml run app ./run_tests -k TEST-NAME
+make docker-test TEST_NAME=test_get_user_teams
 ```
 
 ## Running directly on your machine
@@ -35,11 +35,15 @@ docker-compose -f docker-compose.test.yml build && docker-compose -f docker-comp
 
 The Control Panel app requires Python 3.6+
 
-It is best to use a virtual environment to install python dependencies, eg:
+Install dependencies with the following command:
 ```sh
-python -m venv venv
-. venv/bin/activate
-pip install -r requirements.txt
+make dependencies
+source venv/bin/activate
+```
+
+This will automatically use a virtual environment to install python dependencies, but if you want to install into your system library, you can override this with the `USE_VENV` parameter:
+```sh
+make dependencies USE_VENV=false
 ```
 
 ### Kubernetes setup
@@ -90,18 +94,18 @@ export DJANGO_SETTINGS_MODULE=control_panel_api.settings
 
 The Control Panel app connects to a PostgreSQL database, which should have a database with the expected name:
 ```sh
-createdb $DB_NAME
+make init-database
 ```
 
 Then you can run migrations:
 ```sh
-python manage.py migrate
+make migrations
 ```
 
 ### Create superuser (on first run only)
 
 ```sh
-python manage.py createsuperuser
+make superuser
 ```
 NB `Username` needs to be your GitHub username
 
@@ -109,21 +113,21 @@ NB `Username` needs to be your GitHub username
 
 Before the first run (or after changes to static assets), you need to run
 ```sh
-python manage.py collectstatic
+make collectstatic
 ```
 
 ### Run the app
 
 You can run the app with
 ```sh
-./run_api
+make run
 ```
 Go to http://localhost:8000/
 
 ### How to run the tests
 
 ```sh
-./run_tests
+make test
 ```
 
 # Deployment

--- a/control_panel_api/k8s_patch.py
+++ b/control_panel_api/k8s_patch.py
@@ -7,15 +7,8 @@ import kubernetes
 from kubernetes.config.kube_config import _is_expired
 
 
-def load_token(self):
-    if 'auth-provider' not in self._user:
-        return
-
-    provider = self._user['auth-provider']
-
-    if ('name' not in provider
-            or 'config' not in provider
-            or provider['name'] != 'oidc'):
+def load_token(self, provider):
+    if 'config' not in provider:
         return
 
     parts = provider['config']['id-token'].split('.')
@@ -23,8 +16,10 @@ def load_token(self):
     if len(parts) != 3:  # Not a valid JWT
         return None
 
+    padding = (4 - len(parts[1]) % 4) * '='
+
     jwt_attributes = json.loads(
-        base64.b64decode(parts[1] + '==').decode('utf-8')
+        base64.b64decode(parts[1] + padding).decode('utf-8')
     )
 
     expire = jwt_attributes.get('exp')

--- a/control_panel_api/pagination.py
+++ b/control_panel_api/pagination.py
@@ -17,7 +17,7 @@ class CustomPageNumberPagination(PageNumberPagination):
         if not self._page_size_is_all(page_size):
             return super().paginate_queryset(queryset, request, view)
 
-        paginator = self.django_paginator_class(queryset, queryset.count())
+        paginator = self.django_paginator_class(queryset, queryset.count() or 1)
         self.page = paginator.page(1)
 
         return list(self.page)

--- a/control_panel_api/serializers.py
+++ b/control_panel_api/serializers.py
@@ -295,7 +295,7 @@ class ESBucketHitsSerializer(serializers.BaseSerializer):
         return sorted(results, key=itemgetter('count'), reverse=True)
 
     def _get_accessed_by(self, key):
-        match = re.search(f"{settings.ENV}_(app|user)_([\w-]+)/", key)
+        match = re.search(rf"{settings.ENV}_(app|user)_([\w-]+)/", key)
 
         if match:
             return match.group(1), match.group(2)

--- a/control_panel_api/settings/base.py
+++ b/control_panel_api/settings/base.py
@@ -116,9 +116,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
-
-STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'static')
+STATIC_HOST = os.environ.get('DJANGO_STATIC_HOST', '')
+STATIC_URL = STATIC_HOST + '/static/'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [

--- a/control_panel_api/settings/test.py
+++ b/control_panel_api/settings/test.py
@@ -21,3 +21,7 @@ ELASTICSEARCH = {
 }
 
 LOGGING['handlers']['console']['level'] = 'CRITICAL'
+ENABLED = {
+    'k8s_rbac': False,
+    'write_to_cluster': True,
+}

--- a/control_panel_api/views.py
+++ b/control_panel_api/views.py
@@ -123,7 +123,7 @@ class AppViewSet(viewsets.ModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     permission_classes = (AppPermissions,)
 
-    filter_fields = ('name', 'repo_url', 'slug')
+    filterset_fields = ('name', 'repo_url', 'slug')
 
     @handle_external_exceptions
     @transaction.atomic
@@ -238,7 +238,7 @@ class S3BucketViewSet(viewsets.ModelViewSet):
     serializer_class = S3BucketSerializer
     filter_backends = (S3BucketFilter,)
     permission_classes = (S3BucketPermissions,)
-    filter_fields = ('is_data_warehouse',)
+    filterset_fields = ('is_data_warehouse',)
 
     @handle_external_exceptions
     @transaction.atomic

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,8 @@ services:
       DB_NAME: "controlpanel"
       DB_USER: "postgres"
       DEBUG: "True"
-    command: ["make", "test"]
+      DJANGO_SETTINGS_MODULE: "control_panel_api.settings.test"
+    command: sh -c "python3 wait_for_db && pytest --color=yes control_panel_api"
   db:
     image: "postgres:9.6.2"
     logging:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   app:
     build: .
-    image: "app"
+    image: "control-panel"
     ports:
       - "8000:8000"
     depends_on:
@@ -14,8 +14,7 @@ services:
       DB_NAME: "controlpanel"
       DB_USER: "postgres"
       DEBUG: "True"
-      DJANGO_SETTINGS_MODULE: "control_panel_api.settings.test"
-    command: ["./run_tests"]
+    command: ["make", "test"]
   db:
     image: "postgres:9.6.2"
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       POSTGRES_DB: "controlpanel"
   migration:
     image: control-panel
-    command: ["make", "migrations"]
+    command: sh -c "python3 wait_for_db && python3 manage.py migrate"
     environment:
       DB_HOST: "db"
       DB_NAME: "controlpanel"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   app:
     build: .
-    image: app
+    image: control-panel
     ports:
       - "8000:8000"
     depends_on:
@@ -22,8 +22,8 @@ services:
       POSTGRES_USER: "controlpanel"
       POSTGRES_DB: "controlpanel"
   migration:
-    image: app:latest
-    command: ["sh", "-c", "python3 wait_for_db && python3 manage.py migrate"]
+    image: control-panel
+    command: ["make", "migrations"]
     environment:
       DB_HOST: "db"
       DB_NAME: "controlpanel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ kubernetes==8.0.1
 MarkupSafe==1.1.0
 model-mommy==1.6.0
 openapi-codec==1.3.2
-psycopg2==2.7.7
+psycopg2-binary==2.7.7
 py==1.7.0
 pyasn1==0.4.4
 pyasn1-modules==0.2.2

--- a/run_api
+++ b/run_api
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e -o pipefail
-
-python3 wait_for_db && \
-    gunicorn -b 0.0.0.0:8000 control_panel_api.wsgi:application

--- a/run_tests
+++ b/run_tests
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -e -o pipefail
-
-export DJANGO_SETTINGS_MODULE="control_panel_api.settings.test"
-
-python3 wait_for_db && pytest --color=yes --spec control_panel_api $@


### PR DESCRIPTION
## What

* Tidy up
  * Removed scripts to run server and tests - moved into Makefile
  * ~~Moved scripts from Dockerfile into Makefile~~ removed to avoid docker image dependency on `make`
  * Updated README
  * Reduced Docker layers
  * Removed deprecated workaround for building `cryptography`
  * Moved static directory out of source code directory to avoid Docker image build issues
&nbsp;
* Fixed Kubernetes client patch for OIDC auth

* Fixed warnings
  * `psycopg2` now called `psycopg2-binary`
  * DRF `field_filter` now called `fieldset_filter`