### PR TITLE
Update helm to 2.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
-ENV HELM_VERSION 2.9.1
+ENV HELM_VERSION 2.13.0
 ENV HELM_HOME /tmp/helm
 ENV DJANGO_SETTINGS_MODULE "control_panel_api.settings"
 


### PR DESCRIPTION
## What

Update helm to 2.13.0 as we are updating tiller

## How to review

1. Helm updated to 2.13.0
