### PR TITLE
Enable deploying a tool without push status updates

### DIFF
--- a/controlpanel/frontend/jinja2/tools.html
+++ b/controlpanel/frontend/jinja2/tools.html
@@ -7,13 +7,14 @@
 
 <h1 class="govuk-heading-xl">Your tools</h1>
 
-<p class="govuk-body">The status of your tools will update automatically.</p>
+{# <p class="govuk-body">The status of your tools will update automatically.</p>
+#}
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Name</th>
-      <th class="govuk-table__header">Status</th>
+      <th class="govuk-table__header">{# Status #}</th>
       <th class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
     </tr>
   </thead>
@@ -23,6 +24,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ tool.name }}</td>
       <td class="govuk-table__cell">
+        {#
         <div class="sse-listener tool-status" data-tool-name="{{ tool.name }}">
         {% if deployed %}
           {% if tool.idled %}
@@ -43,6 +45,7 @@
           {% endif %}
         {% endif %}
         </div>
+        #}
       </td>
       <td class="govuk-table__cell align-right no-wrap">
       {% if deployed %}


### PR DESCRIPTION
In the interest of expediting the deployment of the new Control Panel frontend to alpha, this drops any attempts to use SSE or websockets to update tool status in favour of simply executing the tool deployment in the background and returning immediately.