### PR TITLE
Add nginx reverse proxy for deployment in production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,13 @@ jobs:
       - run:
           name: Build application Docker image
           command: |
-            docker build --cache-from=app -t app .
+            docker build --cache-from=controlpanel -t controlpanel .
 
       - run:
           name: Save Docker image layer cache
           command: |
             mkdir -p /caches
-            docker save -o /caches/app.tar app
+            docker save -o /caches/app.tar controlpanel
 
       - save_cache:
           key: v1-{{ .Branch }}-{{ epoch }}
@@ -50,14 +50,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            docker-compose run -e DJANGO_SETTINGS_MODULE=controlpanel.settings.test -e KUBECONFIG=tests/kubeconfig app sh -c "until pg_isready -h db; do sleep 2; done; pytest tests --color=yes"
+            touch .env  # empty .env file to avoid error
+            docker-compose run -e DJANGO_SETTINGS_MODULE=controlpanel.settings.test -e KUBECONFIG=tests/kubeconfig cpanel sh -c "until pg_isready -h db; do sleep 2; done; pytest tests --color=yes"
 
       - deploy:
           name: Push application Docker image
           command: |
             BRANCH=$(echo -n $CIRCLE_BRANCH | tr '/' '-')
             docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} quay.io
-            docker tag app "quay.io/mojanalytics/control-panel:${CIRCLE_SHA1}"
-            docker tag app "quay.io/mojanalytics/control-panel:${BRANCH}"
+            docker tag controlpanel "quay.io/mojanalytics/control-panel:${CIRCLE_SHA1}"
+            docker tag controlpanel "quay.io/mojanalytics/control-panel:${BRANCH}"
             docker push "quay.io/mojanalytics/control-panel:${CIRCLE_SHA1}"
             docker push "quay.io/mojanalytics/control-panel:${BRANCH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN pip3 install django-debug-toolbar
 
 USER controlpanel
 COPY controlpanel controlpanel
+COPY docker docker
 COPY tests tests
 
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DEV=false
 -include .env
 export
 
-.PHONY: clean clean-bytecode clean-static collectstatic dependencies docker-image docker-test help node_modules run test
+.PHONY: clean clean-bytecode clean-static collectstatic compilescss dependencies docker-image docker-test help node_modules run test transpile
 
 
 clean-static:
@@ -88,7 +88,6 @@ docker-image:
 	@echo
 	@echo "> Building docker image..."
 	@docker build -t ${PROJECT} .
-
 
 ## docker-run: Run app in a Docker container
 docker-run:

--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -16,7 +16,7 @@ class OIDCSubAuthenticationBackend(OIDCAuthenticationBackend):
         return User.objects.create(
             pk=claims.get("sub"),
             username=claims.get(settings.OIDC_FIELD_USERNAME),
-            email=claims.get(settings.OIDC_FIELD_EMAIL),
+            email=claims.get(settings.OIDC_FIELD_EMAIL, ''),
             name=claims.get(settings.OIDC_FIELD_NAME),
         )
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  app:
+  cpanel:
     build: .
     image: controlpanel
     ports:
@@ -9,13 +9,15 @@ services:
       - db
     links:
       - db
+    env_file: .env
     environment:
       DB_HOST: "db"
       DB_NAME: "controlpanel"
       DB_USER: "controlpanel"
       DEBUG: "True"
+      ALLOWED_HOSTS: "*"
     volumes:
-      - ~/.kube/config:/root/.kube/config
+      - ~/.kube/config:/home/controlpanel/.kube/config
   db:
     image: "circleci/postgres:9.6.2"
     logging:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,28 @@
+upstream django {
+    server localhost:8000;
+}
+
+server {
+    listen 80;
+
+    location /static/ {
+        root /usr/share/nginx/html;
+    }
+
+    location / {
+        try_files $uri @proxy_to_django;
+    }
+
+    location @proxy_to_django {
+        proxy_pass http://django;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $server_name;
+    }
+}


### PR DESCRIPTION
⚠️ **REWRITTEN**

* Running Django with `DEBUG=False` means static files are not served, so we need to come up with alternative arrangements
* I've added a configuration for a simple Nginx reverse proxy which sits in front of the Django app and serves static files

**AFTER REWRITE**
* I've used the official nginx docker image and mount the configuration file and static assets as volumes - see the [Helm chart](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/356)