### PR TITLE
Add missing serializers for Tools and ToolDeployments

### DIFF
--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -311,3 +311,22 @@ class ParameterSerializer(serializers.ModelSerializer):
         model = Parameter
         fields = ('id', 'name', 'role_name', 'value', 'key')
         read_only_fields = ('name', )
+
+
+class ToolSerializer(serializers.Serializer):
+    name = serializers.CharField()
+
+
+class ToolDeploymentSerializer(serializers.Serializer):
+
+    def to_representation(self, tool_deployment):
+        metadata = tool_deployment.deployment.metadata
+        return {
+            'metadata': {
+                'annotations': metadata.annotations,
+                'creation_timestamp': metadata.creation_timestamp.astimezone().isoformat(),
+                'labels': metadata.labels,
+                'name': metadata.name,
+                'namespace': metadata.namespace,
+            },
+        }


### PR DESCRIPTION
Accessing `/api/cpanel/v1/deployments/` [raises an exception](https://sentry.service.dsd.io/mojds/control-panel-api/issues/36532/)

This also restores the output of `/api/cpanel/v1/tools/` to the format that the old frontend expects.