### PR TITLE
Fix delete bucket access

### DIFF
--- a/controlpanel/api/models/access_to_s3bucket.py
+++ b/controlpanel/api/models/access_to_s3bucket.py
@@ -42,9 +42,9 @@ class AccessToS3Bucket(TimeStampedModel):
 
         return self
 
+    def delete(self, *args, **kwargs):
+        with S3AccessPolicy.load(self.aws_role_name()) as policy:
+            policy.revoke_access(self.s3bucket.arn)
 
-def _access_to_bucket_deleted(sender, **kwargs):
-    access_to_bucket = kwargs['instance']
+        super().delete(*args, **kwargs)
 
-    with S3AccessPolicy.load(access_to_bucket.aws_role_name()) as policy:
-        policy.revoke_access(access_to_bucket.s3bucket.arn)


### PR DESCRIPTION
Revoking access to a bucket in the Control Panel did not update the relevant IAM policy.

This was due to a missing `Signal.connect` call attaching the signal handler function to the `pre_` or `post_delete` signals.

Signals are not needed here anyway, so the code is moved into the `delete` method instead.