### PR TITLE
Show admin access in datasource lists

### DIFF
--- a/controlpanel/frontend/jinja2/includes/datasource-list.html
+++ b/controlpanel/frontend/jinja2/includes/datasource-list.html
@@ -36,11 +36,15 @@
           Webapp
         {%- endif -%}
       {%- else -%}
-        {% if datasource.access_level(user).lower() == 'readwrite' -%}
-          Read/write
-        {%- else -%}
-          Read only
-        {%- endif %}
+        {% with access_level = datasource.access_level(user).lower() -%}
+          {% if access_level == 'admin' -%}
+            Admin
+          {%- elif access_level == 'readwrite' -%}
+            Read/write
+          {%- else -%}
+            Read only
+          {%- endif %}
+        {%- endwith %}
       {%- endif -%}
       </td>
       <td class="govuk-table__cell align-right no-wrap">


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/analytics-platform/issues/102 where datasource lists only showed read/write or read-only access levels, even if the user has admin access.