### PR TITLE
Use docker-compose base image for Circle CI test runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,13 @@ jobs:
 
     docker:
 
-      - image: docker:17.06.0-ce-git
+      - image: tmaier/docker-compose
 
     steps:
 
       - checkout
 
       - setup_remote_docker
-
-      - run:
-          name: Install dependencies
-          command: |
-            apk update && apk add --no-progress curl curl-dev py2-pip
-            pip install docker-compose==1.15.0 | cat
 
       - restore_cache:
           keys:


### PR DESCRIPTION
This saves a step in the Circle CI build pipeline and updates the version of Docker and docker-compose too.