### PR TITLE
Ensure bucket names are correctly prefixed

### DIFF
--- a/controlpanel/api/models/s3bucket.py
+++ b/controlpanel/api/models/s3bucket.py
@@ -52,6 +52,12 @@ class S3Bucket(TimeStampedModel):
         db_table = "control_panel_api_s3bucket"
         ordering = ('name',)
 
+    def __repr__(self):
+        warehouse = ""
+        if self.is_data_warehouse:
+            warehouse = " (warehouse)"
+        return f"<{self.__class__.__name__}: {self.name}{warehouse}>"
+
     @property
     def arn(self):
         return s3_arn(self.name)

--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -81,10 +81,20 @@ class CreateAppForm(forms.Form):
         return value
 
 
+def has_env_prefix(value):
+    if not value.startswith(f'{settings.ENV}-'):
+        raise ValidationError(
+            f"Bucket name must be prefixed with {settings.ENV}-"
+        )
+
+
 class CreateDatasourceForm(forms.Form):
     name = forms.CharField(
         max_length=60,
-        validators=[RegexValidator(r'[a-z0-9.-]{1,60}')],
+        validators=[
+            has_env_prefix,
+            RegexValidator(r'[a-z0-9.-]{1,60}'),
+        ],
     )
 
 

--- a/controlpanel/frontend/jinja2/datasource-create.html
+++ b/controlpanel/frontend/jinja2/datasource-create.html
@@ -30,11 +30,11 @@
       },
       "classes": "govuk-!-width-two-thirds",
       "hint": {
-        "text": '60 chars max, only lowercase letters, numbers, periods and hyphens, auto-prefixed with "' + env + '"'
+        "text": '60 chars max, only lowercase letters, numbers, periods and hyphens, auto-prefixed with "' + env + '-"'
       },
       "name": "name",
       "attributes": {
-        "data-bucket-prefix": env,
+        "data-bucket-prefix": env + "-",
         "pattern": "[a-z0-9.-]{1,60}",
         "maxlength": "60",
       },

--- a/controlpanel/frontend/static/javascripts/modules/bucket-name.js
+++ b/controlpanel/frontend/static/javascripts/modules/bucket-name.js
@@ -1,29 +1,23 @@
 moj.Modules.bucketName = {
-  inputName: 'new-datasource-name',
+  selector: '[data-bucket-prefix]',
 
   init() {
-    this.$input = $(`#${this.inputName}`);
-
-    if (this.$input.length) {
-      this.prefix = this.$input.data('bucket-prefix');
-      this.bindEvents();
+    const input = document.querySelector(this.selector);
+    if (input) {
+      this.bindEvents(input);
     }
   },
 
-  bindEvents() {
-    this.$input.on('keypress blur', () => {
-      this.formatBucketName();
-    });
+  bindEvents(input) {
+    input.addEventListener('keypress', this.ensurePrefix.bind(input));
+    input.addEventListener('blur', this.ensurePrefix.bind(input));
   },
 
-  formatBucketName() {
-    let val = this.$input.val();
-
-    if (val.length < this.prefix.length) {
-      val = this.prefix;
+  ensurePrefix(e) {
+    let val = this.value;
+    if (val.length < this.dataset.bucketPrefix.length) {
+      val = this.dataset.bucketPrefix;
     }
-
-    val = val.toLowerCase().replace(/ /gi, '-');
-    this.$input.val(val);
+    this.value = val.toLowerCase().replace(/ /gi, '-');
   },
 };

--- a/tests/frontend/views/test_datasource.py
+++ b/tests/frontend/views/test_datasource.py
@@ -99,7 +99,7 @@ def detail(client, buckets, *args):
 
 def create(client, *args):
     data = {
-        'name': 'new_bucket',
+        'name': 'test-new-bucket',
     }
     return client.post(reverse('create-datasource') + '?type=warehouse', data)
 


### PR DESCRIPTION
The Javascript to automatically prefix a new bucket name with the `env` name was not updated.

This change fixes the Javascript and adds a Django form field validator to raise an error if the prefix is missing (if Javascript is disabled).