### PR TITLE
Fallback to email username if no nickname

### DIFF
--- a/controlpanel/api/auth0.py
+++ b/controlpanel/api/auth0.py
@@ -187,6 +187,9 @@ class ManagementAPI(APIClient):
     audience = base_url
 
     def create_user(self, email, email_verified=False, **kwargs):
+        if "nickname" not in kwargs:
+            kwargs["nickname"], _, _ = email.partition('@')
+
         response = self.request(
             "POST",
             "users",


### PR DESCRIPTION
If the user has no nickname from userinfo, default to the username portion of their email address.

See https://github.com/ministryofjustice/analytics-platform/issues/98
Also https://github.com/ministryofjustice/analytics-platform-control-panel/issues/717