### PR TITLE
Fix redirect on deleting a datasource

### DIFF
--- a/controlpanel/frontend/jinja2/datasource-detail.html
+++ b/controlpanel/frontend/jinja2/datasource-detail.html
@@ -190,7 +190,7 @@
 </section>
 {% endif %}
 
-{% if request.user.has_perm('api.destroy_s3bucket') %}
+{% if request.user.has_perm('api.destroy_s3bucket', bucket) %}
 <section class="cpanel-section">
   <form action="{{ url('delete-datasource', kwargs={ "pk": bucket.id }) }}" method="post">
     {{ csrf_input }}

--- a/controlpanel/frontend/views/datasource.py
+++ b/controlpanel/frontend/views/datasource.py
@@ -161,10 +161,21 @@ class DeleteDatasource(
 ):
     model = S3Bucket
     permission_required = 'api.destroy_s3bucket'
+    success_url = reverse_lazy('list-warehouse-datasources')
 
-    def get_success_url(self):
-        messages.success(self.request, "Successfully delete data source")
-        return reverse_lazy("list-all-datasources")
+    def delete(self, *args, **kwargs):
+        bucket = self.get_object()
+        session = self.request.session
+        user = self.request.user
+
+        if not bucket.is_data_warehouse:
+            self.success_url = reverse_lazy('list-webapp-datasources')
+
+        response = super().delete(*args, **kwargs)
+
+        messages.success(self.request, "Successfully deleted data source")
+
+        return response
 
 
 class UpdateAccessLevel(


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/analytics-platform/issues/111

After deleting a datasource (S3 bucket), the user was redirected to `list-all-datasources`, which requires superuser access, so they got a 403.

This change updates the view to redirect to either the user's list of warehouse buckets, if the deleted bucket was a warehouse bucket, or their list of webapp buckets otherwise.

Also, the datasource delete button was visible to users who did not have permission to delete the datasource, and has now been removed.