### PR TITLE
Remove clear SECRET_KEY (rotated) from source code

### DIFF
--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -207,9 +207,7 @@ OIDC_DRF_AUTH_BACKEND = "controlpanel.oidc.OIDCSubAuthenticationBackend"
 
 # -- Security
 
-SECRET_KEY = os.environ.get(
-    "SECRET_KEY", "(2gbfi1uc1llww251t00s7$^luuzvivf7l+(snj=sbt#s8h!wu"
-)
+SECRET_KEY = os.environ.get("SECRET_KEY", "")
 
 # A list of people who get code error notifications when DEBUG=False
 ADMINS = []

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -207,7 +207,7 @@ OIDC_DRF_AUTH_BACKEND = "controlpanel.oidc.OIDCSubAuthenticationBackend"
 
 # -- Security
 
-SECRET_KEY = os.environ.get("SECRET_KEY", "")
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")
 
 # A list of people who get code error notifications when DEBUG=False
 ADMINS = []


### PR DESCRIPTION
We don't use [`SECRET_KEY`](https://docs.djangoproject.com/en/dev/ref/settings/#secret-key) for anything special (at the moment) but nevertheless this shouldn't be in clear in the source code.

**NOTE**: I've added/changed this in the [config files](https://github.com/ministryofjustice/analytics-platform-config/pull/157) and updated the [helm chart](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/375).