### PR TITLE
Remove integer-indexed users fixture

### DIFF
--- a/tests/api/views/conftest.py
+++ b/tests/api/views/conftest.py
@@ -1,31 +1,9 @@
-from unittest.mock import patch
-
-from model_mommy import mommy
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def enable_django_db_for_all_tests(transactional_db):
     pass
-
-
-@pytest.fixture
-def users(superuser):
-    return {
-        'superuser': superuser,
-        1: mommy.make(
-            'api.User',
-            auth0_id='github|1',
-            is_superuser=False,
-            username='bob',
-        ),
-        2: mommy.make(
-            'api.User',
-            auth0_id='github|2',
-            is_superuser=False,
-            username='carol',
-        ),
-    }
 
 
 @pytest.fixture(autouse=True)

--- a/tests/api/views/test_tool_deployment.py
+++ b/tests/api/views/test_tool_deployment.py
@@ -7,12 +7,6 @@ from rest_framework.reverse import reverse
 from controlpanel.api.tools import Tool
 
 
-@pytest.fixture(autouse=True)
-def logged_in_normal_user(client, users):
-    client.force_login(users[1])
-    return users[1]
-
-
 @pytest.yield_fixture(autouse=True)
 def tool_deploy():
     with patch.object(Tool, 'deploy_for') as deploy:
@@ -25,9 +19,11 @@ def test_create_when_invalid_tool_name(client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_create_when_valid_tool_name(client, tool_deploy, logged_in_normal_user):
+def test_create_when_valid_tool_name(client, tool_deploy, users):
     tool_name = 'rstudio'
+    user = users['normal_user']
+    client.force_login(user)
     response = client.post(reverse('deployment-list'), {"name": tool_name})
     assert response.status_code == status.HTTP_201_CREATED
 
-    tool_deploy.assert_called_with(logged_in_normal_user)
+    tool_deploy.assert_called_with(user)

--- a/tests/api/views/test_user.py
+++ b/tests/api/views/test_user.py
@@ -12,8 +12,8 @@ from controlpanel.api.models import User
 
 @pytest.fixture(autouse=True)
 def models(users):
-    mommy.make('api.UserS3Bucket', user=users[1])
-    mommy.make('api.UserApp', user=users[1])
+    mommy.make('api.UserS3Bucket', user=users['normal_user'])
+    mommy.make('api.UserApp', user=users['normal_user'])
 
 
 def test_list(client, users):
@@ -23,7 +23,7 @@ def test_list(client, users):
 
 
 def test_detail(client, users):
-    response = client.get(reverse('user-detail', (users[1].auth0_id,)))
+    response = client.get(reverse('user-detail', (users['normal_user'].auth0_id,)))
     assert response.status_code == status.HTTP_200_OK
 
     expected_fields = {
@@ -72,13 +72,13 @@ def test_detail(client, users):
 
 
 def test_delete(client, helm, aws, users):
-    response = client.delete(reverse('user-detail', (users[1].auth0_id,)))
+    response = client.delete(reverse('user-detail', (users['normal_user'].auth0_id,)))
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
     aws.delete_role.assert_called()
     helm.delete.assert_called()
 
-    response = client.get(reverse('user-detail', (users[1].auth0_id,)))
+    response = client.get(reverse('user-detail', (users['normal_user'].auth0_id,)))
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -97,7 +97,7 @@ def test_create(client, helm, aws):
 def test_update(client, users):
     data = {'username': 'foo', 'auth0_id': 'github|888'}
     response = client.put(
-        reverse('user-detail', (users[1].auth0_id,)),
+        reverse('user-detail', (users['normal_user'].auth0_id,)),
         json.dumps(data),
         content_type="application/json",
     )

--- a/tests/api/views/test_userapp.py
+++ b/tests/api/views/test_userapp.py
@@ -25,7 +25,7 @@ def userapps(apps, users):
             is_admin=True,
         ),
         2: UserApp.objects.create(
-            user=users[1],
+            user=users['normal_user'],
             app=apps[1],
             is_admin=True,
         ),
@@ -51,7 +51,7 @@ def test_detail(client, userapps):
 def test_create(client, apps, users):
     data = {
         'app': apps[2].id,
-        'user': users[1].auth0_id,
+        'user': users['normal_user'].auth0_id,
         'is_admin': False,
     }
     response = client.post(reverse('userapp-list'), data)
@@ -61,7 +61,7 @@ def test_create(client, apps, users):
 def test_update(client, apps, users, userapps):
     data = {
         'app': apps[1].id,
-        'user': users[1].auth0_id,
+        'user': users['normal_user'].auth0_id,
         'is_admin': False,
     }
     response = client.put(
@@ -84,7 +84,7 @@ def test_delete(client, userapps):
 @pytest.mark.parametrize(
     "app, user, is_admin",
     [
-        (2, 1, True),
+        (2, "normal_user", True),
         (1, "superuser", True),
     ],
     ids=[

--- a/tests/api/views/test_users3bucket.py
+++ b/tests/api/views/test_users3bucket.py
@@ -22,7 +22,7 @@ def buckets():
 @pytest.fixture
 def users3buckets(users, buckets):
     return {
-        1: users[1].users3buckets.create(
+        1: users['normal_user'].users3buckets.create(
             s3bucket=buckets[1],
             access_level=AppS3Bucket.READONLY,
         ),
@@ -53,7 +53,7 @@ def test_detail(client, users3buckets):
 
 def test_create(client, buckets, users, aws):
     data = {
-        'user': users[2].auth0_id,
+        'user': users['other_user'].auth0_id,
         's3bucket': buckets[1].id,
         'access_level': AppS3Bucket.READONLY,
     }
@@ -77,7 +77,7 @@ def test_delete(client, users3buckets, aws):
 
 def test_update(client, buckets, users, users3buckets, aws):
     data = {
-        'user': users[1].auth0_id,
+        'user': users['normal_user'].auth0_id,
         's3bucket': buckets[1].id,
         'access_level': UserS3Bucket.READWRITE,
     }
@@ -96,8 +96,8 @@ def test_update(client, buckets, users, users3buckets, aws):
 @pytest.mark.parametrize(
     "user, s3bucket, access_level",
     [
-        (2, 1, UserS3Bucket.READWRITE),
-        (1, 2, UserS3Bucket.READWRITE),
+        ('other_user', 1, UserS3Bucket.READWRITE),
+        ('normal_user', 2, UserS3Bucket.READWRITE),
     ],
     ids=[
         'app-changed',


### PR DESCRIPTION
Tidy up API view tests by using the `users` dict fixture defined in `tests/conftest.py` (which allows accessing user fixtures by names like `users['normal_user']`) and removing the integer-indexed fixture (which had `users[1]`).