### PR TITLE
Set public access block on created buckets

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -78,6 +78,24 @@ class AWSClient(object):
                 'TagSet': [{'Key': str(k), 'Value': str(v)} for k, v in tags.items()]
             })
 
+    def put_public_access_block(
+        self,
+        bucket_name,
+        block_public_acls=True,
+        ignore_public_acls=True,
+        block_public_policy=True,
+        restrict_public_buckets=True,
+    ):
+        self._do('s3', 'put_public_access_block',
+            Bucket=bucket_name,
+            PublicAccessBlockConfiguration={
+                'BlockPublicAcls': block_public_acls,
+                'IgnorePublicAcls': ignore_public_acls,
+                'BlockPublicPolicy': block_public_policy,
+                'RestrictPublicBuckets': restrict_public_buckets,
+            }
+        )
+
     def get_inline_policy_document(self, role_name, policy_name):
         if not self.enabled:
             return None

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -299,7 +299,7 @@ def create_bucket(bucket_name, is_data_warehouse=False):
             target_prefix=f"{bucket_name}/",
         )
         aws.put_bucket_encryption(bucket_name)
-
+        aws.put_public_access_block(bucket_name)
         if is_data_warehouse:
             aws.put_bucket_tagging(
                 bucket_name,


### PR DESCRIPTION
Turn on public access blocking on S3 buckets created in the Control Panel by default.

We have an AWS Lambda function which checks buckets block public access every day at 9AM UTC as a backup, but it's better to do it up front.