### PR TITLE
docker-compose: Set redis-server password

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
 
   redis:
     image: "redis"
+    command: sh -c "exec redis-server --requirepass \"$${REDIS_PASSWORD}\""
     environment:
       REDIS_PASSWORD: "controlpanel"
 


### PR DESCRIPTION
Surprisingly the `redis` image doesn't have a nicer way of setting
the `redis-server` password and ignores the `REDIS_PASSWORD`
environment variable.

This was causing the `ERR Client sent AUTH, but no password is set`
error (as the client still passed the password correctly).

This change overrides the image command and set the password.

See open issue and solution: https://github.com/docker-library/redis/issues/46#issuecomment-211598784