### PR TITLE
Get deployment status with request user's id token

### DIFF
--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -74,6 +74,7 @@ class ToolDeployment:
     objects = ToolDeploymentManager()
 
     def __init__(self, tool, user):
+        self._id_token = None
         self._subprocess = None
         self.tool = tool
         self.user = user
@@ -95,6 +96,7 @@ class ToolDeployment:
         """
         Deploy the tool to the cluster (asynchronous)
         """
+        self._id_token = kwargs.get('id_token')
         self._subprocess = cluster.deploy_tool(self.tool, self.user)
 
     @property
@@ -109,7 +111,10 @@ class ToolDeployment:
             if status:
                 return status
 
-        return cluster.get_tool_deployment_status(self)
+        return cluster.get_tool_deployment_status(
+            self,
+            id_token=self._id_token,
+        )
 
     def _poll(self):
         """
@@ -129,9 +134,13 @@ class ToolDeployment:
     def url(self):
         return f"https://{self.host}/"
 
-    def restart(self):
+    def restart(self, **kwargs):
         """
         Restart the tool deployment
         """
-        cluster.restart_tool_deployment(self)
+        self._id_token = kwargs.get('id_token')
+        cluster.restart_tool_deployment(
+            self,
+            id_token=self._id_token,
+        )
 

--- a/controlpanel/frontend/static/javascripts/modules/tool-status.js
+++ b/controlpanel/frontend/static/javascripts/modules/tool-status.js
@@ -38,10 +38,10 @@ moj.Modules.toolStatus = {
           break;
         case 'READY':
         case 'IDLED':
-          this.showActions(listener, ['open', 'remove']);
+          this.showActions(listener, ['open', 'restart', 'remove']);
           break;
         case 'FAILED':
-          this.showActions(listener, ['reset', 'remove']);
+          this.showActions(listener, ['restart', 'remove']);
           break;
       }
     };

--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -46,6 +46,7 @@ class DeployTool(LoginRequiredMixin, RedirectView):
             'tool_name': name,
             # 'version': self.request.POST['version'],
             'user_id': self.request.user.id,
+            'id_token': self.request.user.get_id_token(),
         })
 
         messages.success(
@@ -64,6 +65,7 @@ class RestartTool(LoginRequiredMixin, RedirectView):
         start_background_task('tool.restart', {
             'tool_name': name,
             'user_id': self.request.user.id,
+            'id_token': self.request.user.get_id_token(),
         })
 
         messages.success(


### PR DESCRIPTION
When deploying a tool, the deployment status updates are pushed to the client via SSE. The updates should go `Deploying` > `Ready` / `Failed`, but the `Ready` or `Failed` events are never sent in dev and alpha.
This is because the method of checking the status of the deployment in the background task queries the Kubernetes API with the credentials of the `cpanel` service account and it doesn't seem to have permission to read deployments in users' namespaces.
This change passes the request user's id token through to the background deployment task when it is started, to be used as a credential when accessing the Kubernetes API.