### PR TITLE
Fix links to app logs

### DIFF
--- a/controlpanel/api/models/app.py
+++ b/controlpanel/api/models/app.py
@@ -4,7 +4,11 @@ from django_extensions.db.fields import AutoSlugField
 from django_extensions.db.models import TimeStampedModel
 
 from controlpanel.api import auth0, cluster
-from controlpanel.utils import github_repository_name, s3_slugify
+from controlpanel.utils import (
+    github_repository_name,
+    s3_slugify,
+    webapp_release_name,
+)
 
 
 class App(TimeStampedModel):
@@ -29,6 +33,10 @@ class App(TimeStampedModel):
     @property
     def _repo_name(self):
         return github_repository_name(self.repo_url)
+
+    @property
+    def release_name(self):
+        return webapp_release_name(self._repo_name)
 
     @property
     def customers(self):
@@ -59,7 +67,6 @@ class App(TimeStampedModel):
             cluster.create_app_role(self.iam_role_name)
 
         return self
-
 
     def delete(self, *args, **kwargs):
         cluster.delete_app_role(self.iam_role_name)

--- a/controlpanel/frontend/jinja2/includes/app-logs.html
+++ b/controlpanel/frontend/jinja2/includes/app-logs.html
@@ -65,16 +65,16 @@ filters:!(
       key:app_name,
       negate:!f,
       params:(
-        query:{{object.name}}-webapp,
+        query:{{app.release_name}}-webapp,
         type:phrase
       ),
       type:phrase,
-      value:{{object.name}}-webapp
+      value:{{app.release_name}}-webapp
     ),
     query:(
       match:(
         app_name:(
-          query:{{object.name}}-webapp,
+          query:{{app.release_name}}-webapp,
           type:phrase
         )
       )

--- a/controlpanel/utils.py
+++ b/controlpanel/utils.py
@@ -5,6 +5,10 @@ from channels.generic.http import AsyncHttpConsumer
 from django.template.defaultfilters import slugify
 
 
+INVALID_CHARS = re.compile(r"[^-a-z0-9]")
+SURROUNDING_HYPHENS = re.compile(r"^-*|-*$")
+
+
 def github_repository_name(url):
     """
     Get the repository name from a Github URL
@@ -51,6 +55,12 @@ def sanitize_dns_label(label):
 
 def sanitize_environment_variable(s):
     return name.upper().replace("-", "_")
+
+
+def webapp_release_name(repo_name):
+    name = repo_name.lower()
+    name = SURROUNDING_HYPHENS.sub("", INVALID_CHARS.sub("-", name))
+    return name[:50]
 
 
 class PatchedAsyncHttpConsumer(AsyncHttpConsumer):


### PR DESCRIPTION
Kibana app logs are labelled with `app_name: {helm_release_name}`, where the release name is [generated by the Github org Concourse resource](https://github.com/ministryofjustice/analytics-platform-concourse-github-org-resource/blob/fbbdd516384f048517d1cecca4cd30f8c54a3dba/resource/out#L89) but the Control Panel was linking into Kibana with `app_name: {github_repo_name}-webapp`.