### PR TITLE
Don't render navigation on error pages

### DIFF
--- a/controlpanel/frontend/jinja2/404.html
+++ b/controlpanel/frontend/jinja2/404.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% set page_title = "Page not found" %}
+{% set hide_nav = True %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>

--- a/controlpanel/frontend/jinja2/503.html
+++ b/controlpanel/frontend/jinja2/503.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% set page_title = "Sorry, the service is unavailable" %}
+{% set hide_nav = True %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -2,6 +2,7 @@
 {% from "footer/macro.html" import govukFooter %}
 {% from "navbar/macro.html" import navbar %}
 {% from "alerts/macro.html" import alerts with context %}
+{% from "sign-out/macro.html" import sign_out_link with context %}
 
 {% extends "govuk-frontend.html" %}
 
@@ -36,17 +37,27 @@
 {% endblock %}
 
 {% block header %}
-  {{ govukHeader({
-    'serviceName': service_name,
-    'serviceUrl': '#',
-    'navigation': [
-      {
-        'href': url('index'),
-        'text': "Signed in as " ~ request.user.name | default(request.user.email),
-        'active': True
-      }
-    ]
-  }) }}
+  {% if request.user.is_authenticated -%}
+    {{ govukHeader({
+      'serviceName': service_name,
+      'serviceUrl': '#',
+      'navigation': [
+        {
+          'href': url('index'),
+          'text': "Signed in as " ~ request.user.name | default(request.user.email),
+          'active': True
+        },
+        {
+          'html': sign_out_link(),
+        }
+      ]
+    }) }}
+  {%- else -%}
+    {{ govukHeader({
+      'serviceName': service_name,
+      'serviceUrl': '#',
+    }) }}
+  {%- endif %}
 {% endblock %}
 
 {% block beforeContent %}

--- a/controlpanel/frontend/static/components/header/macro.html
+++ b/controlpanel/frontend/static/components/header/macro.html
@@ -1,4 +1,3 @@
-{% from "sign-out/macro.html" import sign_out_link with context %}
 {% from "whats-new/macro.html" import whats_new_notification %}
 
 {% macro govukHeader(params) %}
@@ -81,11 +80,12 @@
               {{ item.text }}
             </a>
           </li>
+          {% elif item.html %}
+          <li class="govuk-header__navigation-item {% if item.active %}govuk-header__navigation-item--active{% endif %}">
+            {{ item.html|safe }}
+          </li>
           {% endif %}
         {% endfor %}
-          <li class="govuk-header__navigation-item">
-            {{ sign_out_link() }}
-          </li>
         </ul>
         {{ whats_new_notification() }}
       </nav>


### PR DESCRIPTION
And don't show "Signed in as" and "Sign out" header items if user is not
authenticated.

This should fix [https://sentry.service.dsd.io/mojds/control-panel-api/issues/37125/](this error)