### PR TITLE
Ensure readwrite and admin on created bucket

### DIFF
--- a/controlpanel/frontend/views/datasource.py
+++ b/controlpanel/frontend/views/datasource.py
@@ -140,12 +140,8 @@ class CreateDatasource(
         datasource_type = self.request.GET.get("type")
         self.object = S3Bucket.objects.create(
             name=name,
+            created_by=self.request.user,
             is_data_warehouse=datasource_type == "warehouse",
-        )
-        UserS3Bucket.objects.create(
-            s3bucket=self.object,
-            user=self.request.user,
-            is_admin=True,
         )
         messages.success(
             self.request,

--- a/tests/frontend/views/test_datasource.py
+++ b/tests/frontend/views/test_datasource.py
@@ -226,3 +226,13 @@ def test_list(client, buckets, users, view, user, expected_count):
     response = view(client, buckets, users)
     assert len(response.context_data['object_list']) == expected_count
 
+
+def test_bucket_creator_has_readwrite_and_admin_access(client, users):
+    user = users['normal_user']
+    client.force_login(user)
+    response = create(client)
+    assert user.users3buckets.count() == 1
+    ub = user.users3buckets.all()[0]
+    assert ub.access_level == UserS3Bucket.READWRITE
+    assert ub.is_admin
+


### PR DESCRIPTION
Creating a bucket in the frontend was granting readonly access to the creator,
not readwrite
