### PR TITLE
Add email scope to get email claim

### DIFF
--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -23,7 +23,7 @@ class OIDCSubAuthenticationBackend(OIDCAuthenticationBackend):
         return User.objects.create(
             pk=claims.get("sub"),
             username=claims.get(settings.OIDC_FIELD_USERNAME),
-            email=claims.get(settings.OIDC_FIELD_EMAIL, ''),
+            email=claims.get(settings.OIDC_FIELD_EMAIL),
             name=claims.get(settings.OIDC_FIELD_NAME),
         )
 

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -185,7 +185,7 @@ OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET")
 # OIDC JWT signing algorithm
 OIDC_RP_SIGN_ALGO = os.environ.get("OIDC_RP_SIGN_ALGO", "RS256")
 
-OIDC_RP_SCOPES = "openid profile offline-access"
+OIDC_RP_SCOPES = "openid email profile offline-access"
 
 # OIDC claims
 OIDC_FIELD_EMAIL = "email"


### PR DESCRIPTION
Missing `email` scope meant we didn't get the `email` and `email_verified` claims from Auth0 on user login, which in turn meant that new users were created with an empty email address, which causes the `config-user` chart job to fail to complete