### PR TITLE
Added ability to "Upgrade" a tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ transpile:
 		controlpanel/frontend/static/javascripts \
 		-o static/app.js -s
 
-redis: /usr/local/var/run/redis.pid
+redis:
 	@echo
 	@echo "> Running Redis server..."
 	@if [ -z "$$REDIS_PASSWORD" ]; then REQUIREPASS="--requirepass=$$REDIS_PASSWORD"; fi

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -72,6 +72,7 @@ TOOL_DEPLOY_FAILED = 'Failed'
 TOOL_IDLED = 'Idled'
 TOOL_NOT_DEPLOYED = 'Not deployed'
 TOOL_READY = 'Ready'
+TOOL_UPGRADED = 'Upgraded'
 TOOL_STATUS_UNKNOWN = 'Unknown'
 
 

--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -126,6 +126,12 @@ class BackgroundTaskConsumer(SyncConsumer):
         else:
             log.debug(f"Deployed {tool.name} for {user}")
 
+    def tool_upgrade(self, message):
+        """
+        Upgrade simply means re-installing the helm chart for the tool
+        """
+        self.tool_deploy(message)
+
     def tool_restart(self, message):
         """
         Restart the named tool for the specified user

--- a/controlpanel/frontend/jinja2/includes/forms.html
+++ b/controlpanel/frontend/jinja2/includes/forms.html
@@ -56,8 +56,3 @@
     {{ caller() }}
   </fieldset>
 {%- endmacro %}
-
-{% macro delete_button(label, confirm="") -%}
-  <input type="submit" class="button button-warning right js-confirm" value="{{
-  label }}" data-confirm-message="{{ confirm | default("Are you sure?") }}">
-{%- endmacro %}

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -44,7 +44,7 @@
               method="post">
           {{ csrf_input }}
           {# <input type="hidden" value="{{ tool.version }}" name="version"> #}
-          <button class="govuk-button hmcts-button--secondary">Restart</button>
+          <button class="govuk-button hmcts-button--secondary right">Restart</button>
         </form>
         <form action="{{ url('deploy-tool', kwargs={"name": tool.chart_name}) }}"
               class="background-submit tool-action {% if deployment %} govuk-visually-hidden {% endif %}"

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -32,12 +32,12 @@
       </td>
       <td class="govuk-table__cell align-right no-wrap">
         <a class="govuk-button hmcts-button--secondary tool-action {% if not deployment %} govuk-visually-hidden {% endif %}"
-           data-action-name="open"
-           href="{{ tool.url(request.user) }}"
-           rel="noopener"
-           target="_blank">
-          Open
-        </a>
+          data-action-name="open"
+          href="{{ tool.url(request.user) }}"
+          rel="noopener"
+          target="_blank">
+         Open
+       </a>
         <form action="{{ url('restart-tool', kwargs={'name': tool.chart_name}) }}"
               class="background-submit tool-action {% if not deployment %} govuk-visually-hidden {% endif %}"
               data-action-name="restart"
@@ -53,6 +53,13 @@
           {{ csrf_input }}
           {# <input type="hidden" value="{{ tool.version }}" name="version"> #}
           <button class="govuk-button hmcts-button--secondary right">Deploy</button>
+        </form>
+        <form action="{{ url('upgrade-tool', kwargs={"name": tool.chart_name}) }}"
+              class="background-submit tool-action {% if not deployment %} govuk-visually-hidden {% endif %}"
+              data-action-name="upgrade"
+              method="post">
+          {{ csrf_input }}
+          <button class="govuk-button hmcts-button--secondary right">Upgrade</button>
         </form>
       </td>
     </tr>

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -54,13 +54,15 @@
           {# <input type="hidden" value="{{ tool.version }}" name="version"> #}
           <button class="govuk-button hmcts-button--secondary right">Deploy</button>
         </form>
-        <form action="{{ url('upgrade-tool', kwargs={"name": tool.chart_name}) }}"
-              class="background-submit tool-action {% if not deployment %} govuk-visually-hidden {% endif %}"
-              data-action-name="upgrade"
-              method="post">
-          {{ csrf_input }}
-          <button class="govuk-button hmcts-button--secondary right">Upgrade</button>
-        </form>
+        {% if deployment.outdated %}
+          <form action="{{ url('upgrade-tool', kwargs={"name": tool.chart_name}) }}"
+                class="background-submit tool-action {% if not deployment %} govuk-visually-hidden {% endif %}"
+                data-action-name="upgrade"
+                method="post">
+            {{ csrf_input }}
+            <button class="govuk-button hmcts-button--secondary right">Upgrade</button>
+          </form>
+        {% endif %}
       </td>
     </tr>
     {% endfor %}

--- a/controlpanel/frontend/static/javascripts/modules/confirm.js
+++ b/controlpanel/frontend/static/javascripts/modules/confirm.js
@@ -16,7 +16,9 @@ moj.Modules.jsConfirm = {
       }
     });
 
-    $(document).on('click', `input[type="submit"].${this.confirmClass}`, (e) => {
+    // works on any children of a `<form>` with `confirmClass` but it's
+    // usually used on `<input type="submit">` or `<button>`
+    $(document).on('click', `form > .${this.confirmClass}`, (e) => {
       const $el = $(e.target);
       e.preventDefault();
 

--- a/controlpanel/frontend/static/javascripts/modules/tool-status.js
+++ b/controlpanel/frontend/static/javascripts/modules/tool-status.js
@@ -38,7 +38,7 @@ moj.Modules.toolStatus = {
           break;
         case 'READY':
         case 'IDLED':
-          this.showActions(listener, ['open', 'restart', 'remove']);
+          this.showActions(listener, ['open', 'restart', 'upgrade', 'remove']);
           break;
         case 'FAILED':
           this.showActions(listener, ['restart', 'remove']);

--- a/controlpanel/frontend/static/javascripts/modules/tool-status.js
+++ b/controlpanel/frontend/static/javascripts/modules/tool-status.js
@@ -40,8 +40,11 @@ moj.Modules.toolStatus = {
         case 'IDLED':
           this.showActions(listener, ['open', 'restart', 'upgrade', 'remove']);
           break;
+        case 'UPGRADED':
+          this.showActions(listener, ['open']);
+          break;
         case 'FAILED':
-          this.showActions(listener, ['restart', 'remove']);
+          this.showActions(listener, ['restart', 'upgrade', 'remove']);
           break;
       }
     };

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path("parameters/<int:pk>/delete/", views.ParameterDelete.as_view(), name="delete-parameter"),
     path("tools/", views.ToolList.as_view(), name="list-tools"),
     path("tools/<str:name>/deploy/", views.DeployTool.as_view(), name="deploy-tool"),
+    path("tools/<str:name>/upgrade/", views.UpgradeTool.as_view(), name="upgrade-tool"),
     path("tools/<str:name>/restart/", views.RestartTool.as_view(), name="restart-tool"),
     path("users/", views.UserList.as_view(), name="list-users"),
     path("users/<str:pk>/", views.UserDetail.as_view(), name="manage-user"),

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -36,6 +36,7 @@ from controlpanel.frontend.views.parameter import (
 from controlpanel.frontend.views.tool import (
     ToolList,
     DeployTool,
+    UpgradeTool,
     RestartTool,
 )
 from controlpanel.frontend.views.user import (

--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -55,6 +55,25 @@ class DeployTool(LoginRequiredMixin, RedirectView):
         return super().get_redirect_url(*args, **kwargs)
 
 
+class UpgradeTool(LoginRequiredMixin, RedirectView):
+    http_method_names = ['post']
+    url = reverse_lazy("list-tools")
+
+    def get_redirect_url(self, *args, **kwargs):
+        name = kwargs['name']
+
+        start_background_task('tool.upgrade', {
+            'tool_name': name,
+            'user_id': self.request.user.id,
+            'id_token': self.request.user.get_id_token(),
+        })
+
+        messages.success(
+            self.request, f"Upgrading {name}... this may take several minutes",
+        )
+        return super().get_redirect_url(*args, **kwargs)
+
+
 class RestartTool(LoginRequiredMixin, RedirectView):
     http_method_names = ["post"]
     url = reverse_lazy("list-tools")


### PR DESCRIPTION
Similarly to how a user can deploy an instance of a tool, this will allow users to upgrade a tool (the `helm` command is the same).

We only show the "Upgrade" button when a user's deployed tool version differs from the version in the DB (which is the version we consider stable and supported).

Also:
- fixed "Restart" button style/layout
- fixed `jsConfirm` module to work with buttons too (e.g. the "delete data source" button was a `<button>` with `.js-confirm` class but it didn't ask for confirmation)
- removed unused `delete_button` jinja macro
- commented redis server pidfile dependency as it doesn't seem to work on my machine (and probably on other platforms too)

**Ticket**: https://trello.com/c/rz6o5bug/101-users-can-upgrade-their-tools

