### PR TITLE
Extend the time range for Kibana deep links

### DIFF
--- a/controlpanel/frontend/jinja2/includes/app-logs.html
+++ b/controlpanel/frontend/jinja2/includes/app-logs.html
@@ -1,8 +1,13 @@
 {% macro app_logs(app) -%}
 {% filter replace(" ", "") -%}
 {% filter replace("\n", "") -%}
-https://kibana.services.{{env}}.mojanalytics.xyz/app/kibana#/discover?_g=()&_a=
-(
+https://kibana.services.{{env}}.mojanalytics.xyz/app/kibana#/discover?_g=(
+time:(
+  from:now-24h,
+  mode:quick,
+  to:now
+)
+)&_a=(
 columns:!(message),
 filters:!(
   (


### PR DESCRIPTION
From default (last 15 mins) to last 24 hours

Trello ticket: https://trello.com/c/ISMdyqzz