### PR TITLE
Add back the link to the deployed App

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -213,7 +213,7 @@ class App:
         ).items
 
         if len(ingresses) != 1:
-            return ""
+            return None
 
         return f"https://{ingresses[0].spec.rules[0].host}"
 

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -202,10 +202,11 @@ class App:
             if not is_ignored_exception(e):
                 raise e
 
-    def url(self, id_token):
-        repo_name = github_repository_name(self.app.repo_url)
+    @property
+    def url(self):
+        k8s = KubernetesClient(use_cpanel_creds=True)
 
-        k8s = KubernetesClient(id_token=id_token)
+        repo_name = github_repository_name(self.app.repo_url)
         ingresses = k8s.ExtensionsV1beta1Api.list_namespaced_ingress(
             self.APPS_NS,
             label_selector=f"repo={repo_name}",

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -36,8 +36,7 @@ class KubernetesClient:
         load_kube_config()
         config = kubernetes.client.Configuration()
 
-        if settings.ENABLED['k8s_rbac']:
-
+        if settings.ENABLED["k8s_rbac"] and not use_cpanel_creds:
             if id_token is None:
                 request = CrequestMiddleware.get_request()
                 if request and request.user and request.user.is_authenticated:

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -9,10 +9,30 @@ from controlpanel.kubeapi.views import kubernetes, load_kube_config
 class KubernetesClient:
     """
     Wraps kubernetes.client default configuration with currently logged-in
-    user's credentials
+    user's credentials unless `use_cpanel_creds=True`, in that case the
+    in-cluster (or ~/.kube/config) credentials are used.
+
+    **IMPORTANT**: Do not pass `use_cpanel_creds=True` unless strictly
+    necessary. The CP `ServiceAccount` has more privileges than normal users.
+    For most operations performed by a user use their ID token to make requests
+    to the k8s API.
     """
 
-    def __init__(self, id_token=None):
+    def __init__(self, id_token=None, use_cpanel_creds=False):
+        if not use_cpanel_creds and not id_token:
+            raise ValueError(
+                "please provide an id_token (preferred) or pass use_cpanel_creds"
+                "=True (this would cause the use of the host credentials so "
+                "be careful when using it)"
+            )
+
+        if id_token and use_cpanel_creds:
+            raise ValueError(
+                "id_token and use_cpanel_creds can't be used together. "
+                "Remember: avoid using the Control Panel credentials to talk with "
+                "the k8s API unless stricly necessary."
+            )
+
         load_kube_config()
         config = kubernetes.client.Configuration()
 

--- a/controlpanel/api/models/app.py
+++ b/controlpanel/api/models/app.py
@@ -31,7 +31,7 @@ class App(TimeStampedModel):
 
     @property
     def iam_role_name(self):
-        return f"{settings.ENV}_app_{self.slug}"
+        return cluster.App(self).iam_role_name
 
     @property
     def _repo_name(self):
@@ -72,10 +72,10 @@ class App(TimeStampedModel):
         super().save(*args, **kwargs)
 
         if is_create:
-            cluster.create_app_role(self.iam_role_name)
+            cluster.App(self).create_iam_role()
 
         return self
 
     def delete(self, *args, **kwargs):
-        cluster.delete_app_role(self.iam_role_name)
+        cluster.App(self).delete_iam_role()
         super().delete(*args, **kwargs)

--- a/controlpanel/frontend/jinja2/webapp-detail.html
+++ b/controlpanel/frontend/jinja2/webapp-detail.html
@@ -35,10 +35,10 @@
   </p>
   {% endif %}
 
-  {% if app.is_deployed %}
+  {% if app_url %}
   <h2 class="govuk-heading-m">Deployed URL</h2>
   <p class="govuk-body">
-      <a href="https://{{ app.deployed_url }}">https://{{ app.deployed_url }}</a>
+      <a href="{{ app_url }}">{{ app_url }}</a>
   </p>
   {% endif %}
 

--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -66,9 +66,7 @@ class AppDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
         context = super().get_context_data(**kwargs)
         app = self.get_object()
 
-        id_token = self.request.user.get_id_token()
-        context["app_url"] = cluster.App(app).url(id_token)
-
+        context["app_url"] = cluster.App(app).url
         context["admin_options"] = User.objects.filter(
             auth0_id__isnull=False,
         ).exclude(

--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -18,6 +18,7 @@ from django.views.generic.list import ListView
 from rules.contrib.views import PermissionRequiredMixin
 
 from controlpanel.api.cluster import get_repositories
+from controlpanel.api import cluster
 from controlpanel.api.models import (
     App,
     AppS3Bucket,
@@ -64,6 +65,9 @@ class AppDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         app = self.get_object()
+
+        id_token = self.request.user.get_id_token()
+        context["app_url"] = cluster.App(app).url(id_token)
 
         context["admin_options"] = User.objects.filter(
             auth0_id__isnull=False,

--- a/doc/running.md
+++ b/doc/running.md
@@ -113,3 +113,13 @@ Go to http://localhost:8000/
 ```sh
 make test
 ```
+
+or directly using `pytest`:
+
+```sh
+DJANGO_SETTINGS_MODULE=controlpanel.settings.test pytest
+```
+
+**NOTE** Set the `DJANGO_SETTINGS_MODULE` is important or otherwise you
+may accidentally run the tests with the `development` settings with
+unpredictable results.

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -1,6 +1,5 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
-from model_mommy import mommy
 import pytest
 
 from controlpanel.api.cluster import (
@@ -46,7 +45,7 @@ def test_app_delete_iam_role(aws, app):
 def test_app_url_when_no_ingresses(k8s_client, app, app_model):
     k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = []
 
-    assert app.url(id_token="test") == ""
+    assert app.url == ""
     k8s_client \
         .ExtensionsV1beta1Api \
         .list_namespaced_ingress \
@@ -56,7 +55,7 @@ def test_app_url_when_no_ingresses(k8s_client, app, app_model):
 def test_app_url_when_multiple_ingresses_found(k8s_client, app, app_model):
     k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = ["ing_1", "ing_2"]
 
-    assert app.url(id_token="test") == ""
+    assert app.url == ""
     k8s_client \
         .ExtensionsV1beta1Api \
         .list_namespaced_ingress \
@@ -68,7 +67,7 @@ def test_app_url_when_single_ingress_found(k8s_client, app, app_model):
     ingress.spec.rules = [MagicMock(name="Rule", host="test-app.example.com")]
     k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = [ingress]
 
-    assert app.url(id_token="test") == "https://test-app.example.com"
+    assert app.url == "https://test-app.example.com"
     k8s_client \
         .ExtensionsV1beta1Api \
         .list_namespaced_ingress \

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -2,10 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from controlpanel.api.cluster import (
-    BASE_ROLE_POLICY,
-    App,
-)
+from controlpanel.api.cluster import BASE_ROLE_POLICY, App
 from controlpanel.api import models
 
 from django.conf import settings
@@ -13,10 +10,8 @@ from django.conf import settings
 
 @pytest.fixture
 def app_model():
-    return models.App(
-        slug = "slug",
-        repo_url = "https://gitpub.example.com/test-repo",
-    )
+    return models.App(slug="slug", repo_url="https://gitpub.example.com/test-repo")
+
 
 @pytest.fixture
 def app(app_model):
@@ -31,10 +26,7 @@ def test_app_iam_role_name(app, app_model):
 def test_app_create_iam_role(aws, app):
     app.create_iam_role()
 
-    aws.create_role.assert_called_with(
-        app.iam_role_name,
-        BASE_ROLE_POLICY,
-    )
+    aws.create_role.assert_called_with(app.iam_role_name, BASE_ROLE_POLICY)
 
 
 def test_app_delete_iam_role(aws, app):
@@ -46,29 +38,31 @@ def test_app_url_when_no_ingresses(k8s_client, app, app_model):
     k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = []
 
     assert app.url == None
-    k8s_client \
-        .ExtensionsV1beta1Api \
-        .list_namespaced_ingress \
-        .assert_called_once_with("apps-prod", label_selector="repo=test-repo")
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.assert_called_once_with(
+        "apps-prod", label_selector="repo=test-repo"
+    )
 
 
 def test_app_url_when_multiple_ingresses_found(k8s_client, app, app_model):
-    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = ["ing_1", "ing_2"]
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = [
+        "ing_1",
+        "ing_2",
+    ]
 
     assert app.url == None
-    k8s_client \
-        .ExtensionsV1beta1Api \
-        .list_namespaced_ingress \
-        .assert_called_once_with("apps-prod", label_selector="repo=test-repo")
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.assert_called_once_with(
+        "apps-prod", label_selector="repo=test-repo"
+    )
 
 
 def test_app_url_when_single_ingress_found(k8s_client, app, app_model):
     ingress = MagicMock(name="Ingress")
     ingress.spec.rules = [MagicMock(name="Rule", host="test-app.example.com")]
-    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = [ingress]
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = [
+        ingress
+    ]
 
     assert app.url == "https://test-app.example.com"
-    k8s_client \
-        .ExtensionsV1beta1Api \
-        .list_namespaced_ingress \
-        .assert_called_once_with("apps-prod", label_selector="repo=test-repo")
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.assert_called_once_with(
+        "apps-prod", label_selector="repo=test-repo"
+    )

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+from model_mommy import mommy
+import pytest
+
+from controlpanel.api.cluster import (
+    BASE_ROLE_POLICY,
+    App,
+)
+from controlpanel.api import models
+
+from django.conf import settings
+
+
+@pytest.fixture
+def app_model():
+    return models.App(slug = "slug")
+
+
+@pytest.fixture
+def app(app_model):
+    return App(app_model)
+
+
+def test_app_iam_role_name(app, app_model):
+    expected_iam_role_name = f"{settings.ENV}_app_{app_model.slug}"
+    assert app.iam_role_name == expected_iam_role_name
+
+
+def test_app_create_iam_role(aws, app):
+    app.create_iam_role()
+
+    aws.create_role.assert_called_with(
+        app.iam_role_name,
+        BASE_ROLE_POLICY,
+    )
+
+
+def test_app_delete_iam_role(aws, app):
+    app.delete_iam_role()
+    aws.delete_role.assert_called_with(app.iam_role_name)

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from model_mommy import mommy
 import pytest
@@ -14,8 +14,10 @@ from django.conf import settings
 
 @pytest.fixture
 def app_model():
-    return models.App(slug = "slug")
-
+    return models.App(
+        slug = "slug",
+        repo_url = "https://gitpub.example.com/test-repo",
+    )
 
 @pytest.fixture
 def app(app_model):
@@ -39,3 +41,35 @@ def test_app_create_iam_role(aws, app):
 def test_app_delete_iam_role(aws, app):
     app.delete_iam_role()
     aws.delete_role.assert_called_with(app.iam_role_name)
+
+
+def test_app_url_when_no_ingresses(k8s_client, app, app_model):
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = []
+
+    assert app.url(id_token="test") == ""
+    k8s_client \
+        .ExtensionsV1beta1Api \
+        .list_namespaced_ingress \
+        .assert_called_once_with("apps-prod", label_selector="repo=test-repo")
+
+
+def test_app_url_when_multiple_ingresses_found(k8s_client, app, app_model):
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = ["ing_1", "ing_2"]
+
+    assert app.url(id_token="test") == ""
+    k8s_client \
+        .ExtensionsV1beta1Api \
+        .list_namespaced_ingress \
+        .assert_called_once_with("apps-prod", label_selector="repo=test-repo")
+
+
+def test_app_url_when_single_ingress_found(k8s_client, app, app_model):
+    ingress = MagicMock(name="Ingress")
+    ingress.spec.rules = [MagicMock(name="Rule", host="test-app.example.com")]
+    k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = [ingress]
+
+    assert app.url(id_token="test") == "https://test-app.example.com"
+    k8s_client \
+        .ExtensionsV1beta1Api \
+        .list_namespaced_ingress \
+        .assert_called_once_with("apps-prod", label_selector="repo=test-repo")

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -45,7 +45,7 @@ def test_app_delete_iam_role(aws, app):
 def test_app_url_when_no_ingresses(k8s_client, app, app_model):
     k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = []
 
-    assert app.url == ""
+    assert app.url == None
     k8s_client \
         .ExtensionsV1beta1Api \
         .list_namespaced_ingress \
@@ -55,7 +55,7 @@ def test_app_url_when_no_ingresses(k8s_client, app, app_model):
 def test_app_url_when_multiple_ingresses_found(k8s_client, app, app_model):
     k8s_client.ExtensionsV1beta1Api.list_namespaced_ingress.return_value.items = ["ing_1", "ing_2"]
 
-    assert app.url == ""
+    assert app.url == None
     k8s_client \
         .ExtensionsV1beta1Api \
         .list_namespaced_ingress \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,15 @@ def aws():
 
 
 @pytest.yield_fixture(autouse=True)
+def k8s_client():
+    """
+    Mock calls to kubernetes
+    """
+    with patch('controlpanel.api.cluster.KubernetesClient') as k8s_client:
+        yield k8s_client.return_value
+
+
+@pytest.yield_fixture(autouse=True)
 def elasticsearch():
     """
     Mock calls to Elasticsearch


### PR DESCRIPTION
### What
This used to be part of the frontend but got lost in translation when removed node app.

This is adding it back:

[Imagine gif of Bender saying "I'm back, baby" here]

### How
The URL will be the host in the `Ingress` with the `repo` label set to the app repo (repo name without the URL).

As the `Ingress` resources don't live in the users' namespaces, users will not have sufficient permissions to list them, therefore this request is performed using the CP credentials (which can list Ingresses in that namespace). 
In order to do that I've tweaked the `api.kubernetes.KubernetesClient` class to receive a `use_cpanel_creds` argument (default is `False` as use of CP creds is discouraged and we should always aim at making requests to the k8s API using the user ID token).

### Small refactorings, etc...
- following conversation with @andyhd I've started to group the app-related operations performed on the "cluster" (k8s cluster but also AWS account) into the `api.cluster.App` class which wraps the `api.models.App`. Future plans include splitting this big module into smaller files (maybe rename it `external` to avoid further confusion with the k8s cluster?)
- `api.kubernetes.KubernetesClient` class now blows up if:
  - `id_token` is not provided (it optional) but `user_cpanel_creds=False` as this would cause the  up using the client to use the host (in-cluster or kube config) credentials
  - both `id_token` and `user_cpanel_creds=True` are provided as this is ambiguous

### Future refactorings
In the spirit of trying to keep PRs small and as focused as possible (and following @josh always wise advice), I've refrained myself from further simplifying the `api.kubernetes.KubernetesClient` class (by potentially removing logic to read session `id_token` and legacy RBAC flag) as it turned out to be more involved than expected - so I may do that separately

### Ticket
https://trello.com/c/eQqJ1FRw