### PR TITLE
Fix for KubernetesClient error when no id_token provided

### DIFF
--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -19,12 +19,12 @@ class KubernetesClient:
     """
 
     def __init__(self, id_token=None, use_cpanel_creds=False):
-        if not use_cpanel_creds and not id_token:
-            raise ValueError(
-                "please provide an id_token (preferred) or pass use_cpanel_creds"
-                "=True (this would cause the use of the host credentials so "
-                "be careful when using it)"
-            )
+        # if not use_cpanel_creds and not id_token:
+        #     raise ValueError(
+        #         "please provide an id_token (preferred) or pass use_cpanel_creds"
+        #         "=True (this would cause the use of the host credentials so "
+        #         "be careful when using it)"
+        #     )
 
         if id_token and use_cpanel_creds:
             raise ValueError(


### PR DESCRIPTION
That check was in place for some refactoring I'm working on (which
should remove the code that reads the ID token from request when not
passed).

The problem is that currently some of the code don't pass the `id_token`
and let the class read from current request.

I'm commenting that check for now.