### PR TITLE
Make sure users know that the paths in the access form is optional.

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -116,8 +116,9 @@ class GrantAccessForm(forms.Form):
             ],
             required=True,
         ),
-        label="Paths",
-        help_text="Add specific paths for this user or group to access",
+        label="Paths (optional)",
+        help_text="Add specific paths for this user or group to access or leave blank "
+                  "for whole bucket access",
         required=False,
         delimiter="\n",
     )


### PR DESCRIPTION
Adding more descriptive text to let users know that paths is optional on user access form