### PR TITLE
Don't get App URL until we fix the `KubernetesClient` bug

### DIFF
--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -66,7 +66,8 @@ class AppDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
         context = super().get_context_data(**kwargs)
         app = self.get_object()
 
-        context["app_url"] = cluster.App(app).url
+        # Temporarily hiding App URL until we fix the `KubernetesClient` bug causing the 401
+        context["app_url"] = None # cluster.App(app).url
         context["admin_options"] = User.objects.filter(
             auth0_id__isnull=False,
         ).exclude(


### PR DESCRIPTION
Sometimes users get a `401` from the Kubernetes API. This seems
to be caused by a bug/race condition in the way the `kubernetes` module
loads the configuration (this is our best theory so far)

It's annoying for users so avoiding this until we fix the problem.


Part of ticket: https://trello.com/c/D4bpabeD