### PR TITLE
Fix for kubernetes race condition on configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
         build-base=0.5-r1 \
         ca-certificates=20190108-r0 \
         libffi-dev=3.2.1-r6 \
-        python3-dev=3.7.3-r0 \
+        python3-dev=3.7.4-r0 \
         libressl-dev=2.7.5-r0 \
         libstdc++=8.3.0-r0 \
         postgresql-dev \

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import inspect
 import kubernetes
 import os
@@ -22,6 +23,13 @@ def get_config():
         kubernetes.config.load_kube_config()
 
     config = kubernetes.client.Configuration()
+
+    # The deepcopy is to avoid a race conditions on the credentials keys
+    #
+    # See: https://github.com/kubernetes-client/python/issues/932
+    config.api_key_prefix = deepcopy(config.api_key_prefix)
+    config.api_key = deepcopy(config.api_key)
+
     return config
 
 

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -23,7 +23,9 @@ def get_config():
 
     config = kubernetes.client.Configuration()
 
-    # The deepcopy is to avoid a race conditions on the credentials keys
+    # A deepcopy of the configuration is used to avoid a race condition
+    # caused by subsequent calls to Configuration() reusing a singleton
+    # datastructure
     #
     # See: https://github.com/kubernetes-client/python/issues/932
     config.api_key_prefix = deepcopy(config.api_key_prefix)

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -1,9 +1,24 @@
 import inspect
+import kubernetes
+import os
 
 from crequest.middleware import CrequestMiddleware
 from django.conf import settings
 
-from controlpanel.kubeapi.views import kubernetes, load_kube_config
+# This patch fixes incorrect base64 padding in the Kubernetes Python client.
+# Hopefully it will be fixed in the next release.
+from controlpanel.kubeapi import oidc_patch
+
+
+def load_kube_config():
+    """
+    Load Kubernetes config. Avoid running at import time.
+    """
+
+    if 'KUBERNETES_SERVICE_HOST' in os.environ:
+        kubernetes.config.load_incluster_config()
+    else:
+        kubernetes.config.load_kube_config()
 
 
 class KubernetesClient:

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -11,13 +11,12 @@ from django.conf import settings
 from controlpanel.kubeapi import oidc_patch
 
 
-
 def get_config():
     """
     Load Kubernetes config. Avoid running at import time.
     """
 
-    if 'KUBERNETES_SERVICE_HOST' in os.environ:
+    if "KUBERNETES_SERVICE_HOST" in os.environ:
         kubernetes.config.load_incluster_config()
     else:
         kubernetes.config.load_kube_config()
@@ -66,10 +65,10 @@ class KubernetesClient:
             if id_token is None:
                 request = CrequestMiddleware.get_request()
                 if request and request.user and request.user.is_authenticated:
-                    id_token = request.session.get('oidc_id_token')
+                    id_token = request.session.get("oidc_id_token")
 
-            config.api_key_prefix['authorization'] = 'Bearer'
-            config.api_key['authorization'] = id_token
+            config.api_key_prefix["authorization"] = "Bearer"
+            config.api_key["authorization"] = id_token
 
         self.api_client = kubernetes.client.ApiClient(config)
 

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -13,7 +13,7 @@ from controlpanel.kubeapi import oidc_patch
 
 def get_config():
     """
-    Load Kubernetes config. Avoid running at import time.
+    Load and returns a kubernetes Configuration instance
     """
 
     if "KUBERNETES_SERVICE_HOST" in os.environ:

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -10,7 +10,8 @@ from django.conf import settings
 from controlpanel.kubeapi import oidc_patch
 
 
-def load_kube_config():
+
+def get_config():
     """
     Load Kubernetes config. Avoid running at import time.
     """
@@ -19,6 +20,9 @@ def load_kube_config():
         kubernetes.config.load_incluster_config()
     else:
         kubernetes.config.load_kube_config()
+
+    config = kubernetes.client.Configuration()
+    return config
 
 
 class KubernetesClient:
@@ -48,8 +52,7 @@ class KubernetesClient:
                 "the k8s API unless stricly necessary."
             )
 
-        load_kube_config()
-        config = kubernetes.client.Configuration()
+        config = get_config()
 
         if settings.ENABLED["k8s_rbac"] and not use_cpanel_creds:
             if id_token is None:

--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -66,8 +66,7 @@ class AppDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
         context = super().get_context_data(**kwargs)
         app = self.get_object()
 
-        # Temporarily hiding App URL until we fix the `KubernetesClient` bug causing the 401
-        context["app_url"] = None # cluster.App(app).url
+        context["app_url"] = cluster.App(app).url
         context["admin_options"] = User.objects.filter(
             auth0_id__isnull=False,
         ).exclude(

--- a/controlpanel/kubeapi/views.py
+++ b/controlpanel/kubeapi/views.py
@@ -1,5 +1,4 @@
 from functools import wraps
-import os
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -8,23 +7,11 @@ from django.views.decorators.csrf import csrf_exempt
 from djproxy.views import HttpProxy
 import kubernetes
 
+from controlpanel import api
 from controlpanel.jwt import JWT
-# This patch fixes incorrect base64 padding in the Kubernetes Python client.
-# Hopefully it will be fixed in the next release.
-from controlpanel.kubeapi import oidc_patch
+
 from controlpanel.kubeapi.permissions import K8sPermissions
 
-
-def load_kube_config():
-    """
-    Load Kubernetes config. Avoid running at import time.
-    """
-
-    if 'KUBERNETES_SERVICE_HOST' in os.environ:
-        kubernetes.config.load_incluster_config()
-
-    else:
-        kubernetes.config.load_kube_config()
 
 
 class KubeAPIAuthMiddleware(object):
@@ -58,7 +45,7 @@ class KubeAPIProxy(HttpProxy):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        load_kube_config()
+        api.kubernetes.load_kube_config()
         self.proxy_middleware.append(
             "controlpanel.kubeapi.views.KubeAPIAuthMiddleware",
         )

--- a/controlpanel/kubeapi/views.py
+++ b/controlpanel/kubeapi/views.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.core import exceptions
 from django.views.decorators.csrf import csrf_exempt
 from djproxy.views import HttpProxy
-import kubernetes
 
 from controlpanel import api
 from controlpanel.jwt import JWT
@@ -32,12 +31,12 @@ class KubeAPIProxy(HttpProxy):
 
     @property
     def base_url(self):
-        return kubernetes.client.Configuration().host
+        return self.kubernetes_config.host
 
     # Without this, we get SSL: CERTIFICATE_VERIFY_FAILED
     @property
     def verify_ssl(self):
-        return kubernetes.client.Configuration().ssl_ca_cert
+        return self.kubernetes_config.ssl_ca_cert
 
     @property
     def proxy_url(self):
@@ -45,7 +44,7 @@ class KubeAPIProxy(HttpProxy):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        api.kubernetes.load_kube_config()
+        self.kubernetes_config = api.kubernetes.get_config()
         self.proxy_middleware.append(
             "controlpanel.kubeapi.views.KubeAPIAuthMiddleware",
         )

--- a/controlpanel/kubeapi/views.py
+++ b/controlpanel/kubeapi/views.py
@@ -1,7 +1,5 @@
-from functools import wraps
 from urllib.parse import urljoin
 
-from django.conf import settings
 from django.core import exceptions
 from django.views.decorators.csrf import csrf_exempt
 from djproxy.views import HttpProxy

--- a/tests/kubeapi/test_permissions.py
+++ b/tests/kubeapi/test_permissions.py
@@ -5,18 +5,20 @@ import pytest
 from rest_framework import status
 
 
-TEST_K8S_API_URL = 'https://k8s.example.com'
-
 
 @pytest.yield_fixture(autouse=True)
-def k8s():
-    with patch('controlpanel.kubeapi.views.kubernetes') as k8s:
-        config = k8s.client.Configuration.return_value
-        config.host = TEST_K8S_API_URL
-        config.api_key = {
-            "authorization": "Bearer test-token",
-        }
-        yield k8s
+def k8s_get_config():
+    with patch('controlpanel.kubeapi.views.api.kubernetes.get_config') as get_config:
+        config = MagicMock("k8s config")
+
+        config.host = "http://api.k8s.localhost"
+        config.ssl_ca_cert = "test ssl_ca_cert"
+
+        config.api_key_prefix = {"authorization": "Bearer"}
+        config.api_key = {"authorization": "test-token"}
+
+        get_config.return_value = config
+        yield get_config
 
 
 @pytest.yield_fixture(autouse=True)


### PR DESCRIPTION
### Problem
Users were getting some strange `401` when trying to get the App URL.
This wasn't happening all the time and not in all environments.

The logic to find the URL for an app involved using the CP `ServiceAccount` credentials instead of the user's `id_token`.

We think this weird behaviour was caused by some sort of race condition on the credentials in the config.

### Changes overview
1. [moved function](https://github.com/ministryofjustice/analytics-platform-control-panel/commit/93d3eafea11a97dc8cc4674192b6954283daccc8) to load kubernetes config (`load_kube_config()`) from `controlpanel.kubeapi.views` to `controlpanel.api.kubernetes` module as it's where you'd expect this to be.
2. [changed](https://github.com/ministryofjustice/analytics-platform-control-panel/commit/321272bb1bdc9476e0d695d9e9ee98bf8edec9e8) `load_kube_config()` to `get_config()`. Client code is really interested in getting a [`Configuration`](https://github.com/kubernetes-client/python/blob/2b3fe30d24ed2b74a9ba9830dc37943951860c01/kubernetes/client/configuration.py#L41) instance to create a useable k8s client. All `load_kube_config()` calls were followed by a "get config" anyway (`kubernetes.client.Configuration()`)
3. [fixed credentials race condition in k8s configuration](https://github.com/ministryofjustice/analytics-platform-control-panel/commit/e5aeb0c83ed3edce6833549ee61f94d7eae57eff), this is achieved by making sure the `config.api_key` and `config.api_key_prefix` are not shared with other instances of `kubernetes.client.Configuration` (see below for reasoning)

### Reason
The `kubernetes` module way of retrieving a configuration is a bit strange. You call [`load_incluster_config()`](https://github.com/kubernetes-client/python-base/blob/474e9fb32293fa05098e920967bb0e0645182d5b/config/incluster_config.py#L89) (or `load_kube_config()` locally) which loads the config but it doesn't return it, [just sets it](https://github.com/kubernetes-client/python-base/blob/474e9fb32293fa05098e920967bb0e0645182d5b/config/incluster_config.py#L81) into a sort `Configuration` singleton.

This [makes a shallow copy of the configuration](https://github.com/kubernetes-client/python/blob/2b3fe30d24ed2b74a9ba9830dc37943951860c01/kubernetes/client/configuration.py#L38), but unfortunately this is not enough as it contains other dictionaries which would therefore be shared across all configuration instances. That is the problem.

Specifically the authentication settings are stored into the [`api_key`](https://github.com/kubernetes-client/python/blob/2b3fe30d24ed2b74a9ba9830dc37943951860c01/kubernetes/client/configuration.py#L57) and [`api_key_prefix`](https://github.com/kubernetes-client/python/blob/2b3fe30d24ed2b74a9ba9830dc37943951860c01/kubernetes/client/configuration.py#L60) fields are also dictionaries.

### Solution
The proposed solution is to copy these two dictionaries so that they're not shared.
This means that when we [set the `api_key` to the user `id_token`](https://github.com/ministryofjustice/analytics-platform-control-panel/blob/5a6b6c06eb0ec3864f30326bbd135a38bf94bdbf/controlpanel/api/kubernetes.py#L46) this should not overwrite any other `api_key` in other instances of `Configuration`.

### Ticket/Resources
Ticket: https://trello.com/c/D4bpabeD
Issue: https://github.com/kubernetes-client/python/issues/932