### PR TITLE
Removed legacy `ENABLE_K8S_RBAC` flag

### DIFF
--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -63,7 +63,7 @@ class KubernetesClient:
 
         config = get_config()
 
-        if settings.ENABLED["k8s_rbac"] and not use_cpanel_creds:
+        if not use_cpanel_creds:
             if id_token is None:
                 request = CrequestMiddleware.get_request()
                 if request and request.user and request.user.is_authenticated:

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -30,6 +30,12 @@ class User(AbstractUser):
         Retrieve the user's Id token if they are the logged in user
         """
         request = CrequestMiddleware.get_request()
+        if not request:
+            raise Exception(
+                "request not found: have you called get_id_token() in a "
+                "background worker?"
+            )
+
         if request.user == self:
             return request.session.get('oidc_id_token')
 

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -9,10 +9,6 @@ from controlpanel.utils import is_truthy
 # -- Feature flags
 
 ENABLED = {
-
-    # Enable Kubernetes Role-based Access Control
-    "k8s_rbac": is_truthy(os.environ.get("ENABLE_K8S_RBAC", False)),
-
     # Enable writes to Kubernetes cluster
     "write_to_cluster": is_truthy(os.environ.get("ENABLE_WRITE_TO_CLUSTER", True)),
 

--- a/doc/feature-flags.md
+++ b/doc/feature-flags.md
@@ -7,5 +7,4 @@ Current flags are:
 
 | Name | Description | Default |
 | ---- | ----------- | ------- |
-| `ENABLE_K8S_RBAC` | Enable Kubernetes Role-based Access Control | `False` |
 | `ENABLE_WRITE_TO_CLUSTER` | Enables writing changes to the Kubernetes cluster | `True` |


### PR DESCRIPTION
This was useful when we enabled RBAC in the k8s cluster and we
transitioned to it but it's not necessary anymore as this is always
enabled now.

It also works fine when running the app locally and tests pass so no
reason to keep this.

The main reason to remove this is that it will enable us to simplify
the `KubernetesClient` class and make it more testable (as we'd not
need to care about testing cases when this flag is enabled or disabled)

Part of ticket: https://trello.com/c/OXWwaZua