### PR TITLE
KubernetesClient related refactorings

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -496,7 +496,7 @@ def deploy_tool(tool, user, **kwargs):
         raise ToolDeploymentError(error)
 
 
-def list_tool_deployments(user, id_token=None, search_name=None, search_version=None):
+def list_tool_deployments(user, id_token, search_name=None, search_version=None):
     deployments = []
     k8s = KubernetesClient(id_token=id_token)
     results = k8s.AppsV1Api.list_namespaced_deployment(user.k8s_namespace)
@@ -511,12 +511,12 @@ def list_tool_deployments(user, id_token=None, search_name=None, search_version=
     return deployments
 
 
-def get_tool_deployment(tool_deployment, **kwargs):
+def get_tool_deployment(tool_deployment, id_token):
     deployments = list_tool_deployments(
         tool_deployment.user,
+        id_token,
         search_name=tool_deployment.tool.chart_name,
         # search_version=tool_deployment.tool.version,
-        **kwargs,
     )
 
     if not deployments:
@@ -529,17 +529,17 @@ def get_tool_deployment(tool_deployment, **kwargs):
     return deployments[0]
 
 
-def delete_tool_deployment(tool_deployment, **kwargs):
-    deployment = get_tool_deployment(tool_deployment, **kwargs)
+def delete_tool_deployment(tool_deployment, id_token):
+    deployment = get_tool_deployment(tool_deployment, id_token)
     helm.delete(
         deployment.metadata.name,
         f"--namespace={tool_deployment.user.k8s_namespace}",
     )
 
 
-def get_tool_deployment_status(tool_deployment, **kwargs):
+def get_tool_deployment_status(tool_deployment, id_token):
     try:
-        deployment = get_tool_deployment(tool_deployment, **kwargs)
+        deployment = get_tool_deployment(tool_deployment, id_token)
 
     except ObjectDoesNotExist:
         log.warning(f"{tool_deployment} not found")

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -492,7 +492,7 @@ def deploy_tool(tool, user, **kwargs):
             *set_values,
         )
 
-    except HelmError as error:
+    except helm.HelmError as error:
         raise ToolDeploymentError(error)
 
 

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -572,7 +572,7 @@ def get_tool_deployment_status(tool_deployment, **kwargs):
     )
     return TOOL_STATUS_UNKNOWN
 
-def restart_tool_deployment(tool_deployment, id_token=None):
+def restart_tool_deployment(tool_deployment, id_token):
     k8s = KubernetesClient(id_token=id_token)
     return k8s.AppsV1Api.delete_collection_namespaced_replica_set(
         tool_deployment.user.k8s_namespace,

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -47,12 +47,12 @@ class KubernetesClient:
     """
 
     def __init__(self, id_token=None, use_cpanel_creds=False):
-        # if not use_cpanel_creds and not id_token:
-        #     raise ValueError(
-        #         "please provide an id_token (preferred) or pass use_cpanel_creds"
-        #         "=True (this would cause the use of the host credentials so "
-        #         "be careful when using it)"
-        #     )
+        if not use_cpanel_creds and not id_token:
+            raise ValueError(
+                "please provide an id_token (preferred) or pass use_cpanel_creds"
+                "=True (this would cause the use of the host credentials so "
+                "be careful when using it)"
+            )
 
         if id_token and use_cpanel_creds:
             raise ValueError(

--- a/controlpanel/api/kubernetes.py
+++ b/controlpanel/api/kubernetes.py
@@ -3,7 +3,6 @@ import inspect
 import kubernetes
 import os
 
-from crequest.middleware import CrequestMiddleware
 from django.conf import settings
 
 # This patch fixes incorrect base64 padding in the Kubernetes Python client.
@@ -63,12 +62,7 @@ class KubernetesClient:
 
         config = get_config()
 
-        if not use_cpanel_creds:
-            if id_token is None:
-                request = CrequestMiddleware.get_request()
-                if request and request.user and request.user.is_authenticated:
-                    id_token = request.session.get("oidc_id_token")
-
+        if id_token:
             config.api_key_prefix["authorization"] = "Bearer"
             config.api_key["authorization"] = id_token
 

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -50,9 +50,10 @@ class ToolDeploymentManager:
 
     def filter(self, **kwargs):
         deployed_versions = {}
-        user = kwargs.get('user')
+        user = kwargs["user"]
+        id_token = kwargs["id_token"]
         filter = Q(chart_name=None)  # Always False
-        for deployment in cluster.list_tool_deployments(user):
+        for deployment in cluster.list_tool_deployments(user, id_token):
             chart_name, version = deployment.metadata.labels["chart"].rsplit("-", 1)
             deployed_versions[chart_name] = version
             filter = filter | (
@@ -81,7 +82,6 @@ class ToolDeployment:
     objects = ToolDeploymentManager()
 
     def __init__(self, tool, user, outdated=False):
-        self._id_token = None
         self._subprocess = None
         self.tool = tool
         self.user = user
@@ -90,11 +90,11 @@ class ToolDeployment:
     def __repr__(self):
         return f'<ToolDeployment: {self.tool!r} {self.user!r}>'
 
-    def delete(self):
+    def delete(self, id_token):
         """
         Remove the release from the cluster
         """
-        cluster.delete_tool_deployment(self)
+        cluster.delete_tool_deployment(self, id_token)
 
     @property
     def host(self):
@@ -104,11 +104,10 @@ class ToolDeployment:
         """
         Deploy the tool to the cluster (asynchronous)
         """
-        self._id_token = kwargs.get('id_token')
+
         self._subprocess = cluster.deploy_tool(self.tool, self.user)
 
-    @property
-    def status(self):
+    def get_status(self, id_token):
         """
         Get the current status of the deployment.
         Polls the subprocess if running, otherwise returns idled status.
@@ -119,10 +118,7 @@ class ToolDeployment:
             if status:
                 return status
 
-        return cluster.get_tool_deployment_status(
-            self,
-            id_token=self._id_token,
-        )
+        return cluster.get_tool_deployment_status(self, id_token)
 
     def _poll(self):
         """
@@ -147,5 +143,4 @@ class ToolDeployment:
         Restart the tool deployment
         """
 
-        self._id_token = id_token
         cluster.restart_tool_deployment(self, id_token)

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -142,13 +142,10 @@ class ToolDeployment:
     def url(self):
         return f"https://{self.host}/"
 
-    def restart(self, **kwargs):
+    def restart(self, id_token):
         """
         Restart the tool deployment
         """
-        self._id_token = kwargs.get('id_token')
-        cluster.restart_tool_deployment(
-            self,
-            id_token=self._id_token,
-        )
 
+        self._id_token = id_token
+        cluster.restart_tool_deployment(self, id_token)

--- a/controlpanel/api/views/tools.py
+++ b/controlpanel/api/views/tools.py
@@ -36,4 +36,9 @@ class ToolDeploymentViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         return Response({}, status=status.HTTP_201_CREATED)
 
     def get_queryset(self):
-        return ToolDeployment.objects.filter(user=self.request.user)
+        user = self.request.user
+        id_token = user.get_id_token()
+        return ToolDeployment.objects.filter(
+            user=user,
+            id_token=id_token,
+        )

--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -142,11 +142,12 @@ class BackgroundTaskConsumer(SyncConsumer):
         Restart the named tool for the specified user
         """
         tool, user = self.get_tool_and_user(message)
+        id_token = message.get("id_token")
 
         update_tool_status(user, tool, "Restarting")
 
         deployment = ToolDeployment(tool, user)
-        deployment.restart(id_token=message.get('id_token'))
+        deployment.restart(id_token=id_token)
 
         status = wait_for_deployment(user, tool, deployment)
 

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -27,7 +27,7 @@
       </td>
       <td class="govuk-table__cell">
         <div class="tool-status-label">
-          {{ deployment.status | default("") }}
+          {{ deployment and deployment.get_status(id_token) | default("") }}
         </div>
       </td>
       <td class="govuk-table__cell align-right no-wrap">

--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -26,9 +26,17 @@ class ToolList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     template_name = "tool-list.html"
 
     def get_context_data(self, *args, **kwargs):
-        deployments = ToolDeployment.objects.filter(user=self.request.user)
+        user = self.request.user
+        id_token = user.get_id_token()
+
+        deployments = ToolDeployment.objects.filter(
+            user=user,
+            id_token=id_token,
+        )
+
         context = super().get_context_data(*args, **kwargs)
-        context['deployed_tools'] = {
+        context["id_token"] = id_token
+        context["deployed_tools"] = {
             deployment.tool: deployment
             for deployment in deployments
         }

--- a/tests/api/test_kubernetes.py
+++ b/tests/api/test_kubernetes.py
@@ -50,3 +50,18 @@ def test_kubernetes_client_constructor_when_use_cpanel_creds_true(k8s_config):
     assert config.api_key_prefix["authorization"] == "Bearer"
     assert config.api_key["authorization"] == SERVICE_ACCOUNT_TEST_TOKEN
 
+
+def test_kubernetes_client__getattr__(k8s_config):
+    id_token = "test-user-id-token"
+
+    client = KubernetesClient(id_token=id_token)
+    api_client = client.api_client
+
+    # These are just two examples of k8s APIs
+    k8s_api_1 = client.ExtensionsV1beta1Api
+    k8s_api_2 = client.AppsV1Api
+
+    assert type(k8s_api_1) == kubernetes.client.apis.ExtensionsV1beta1Api
+    assert k8s_api_1.api_client == api_client
+    assert type(k8s_api_2) == kubernetes.client.apis.AppsV1Api
+    assert k8s_api_2.api_client == api_client

--- a/tests/api/test_kubernetes.py
+++ b/tests/api/test_kubernetes.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+import kubernetes
+import pytest
+
+from controlpanel.api.kubernetes import KubernetesClient
+
+
+
+SERVICE_ACCOUNT_TEST_TOKEN = "test-service-account-token"
+
+
+
+@pytest.yield_fixture()
+def k8s_config():
+    config = kubernetes.client.Configuration()
+    with patch("controlpanel.api.kubernetes.kubernetes.client.Configuration") as Configuration:
+        config.host = "https://api.k8s.localhost"
+        config.api_key_prefix = {"authorization": "Bearer"}
+        config.api_key = {"authorization": SERVICE_ACCOUNT_TEST_TOKEN}
+        Configuration.return_value = config
+        yield Configuration
+
+
+def test_kubernetes_client_constructor_when_no_creds_passed():
+    with pytest.raises(ValueError):
+        KubernetesClient()
+
+
+def test_kubernetes_client_constructor_when_use_cpanel_creds_and_id_token_passed():
+    with pytest.raises(ValueError):
+        KubernetesClient(id_token="test-token", use_cpanel_creds=True)
+
+
+def test_kubernetes_client_constructor_when_id_token_passed(k8s_config):
+    id_token = "test-user-id-token"
+
+    client = KubernetesClient(id_token=id_token)
+
+    config = client.api_client.configuration
+    assert config.api_key_prefix["authorization"] == "Bearer"
+    assert config.api_key["authorization"] == id_token
+
+
+def test_kubernetes_client_constructor_when_use_cpanel_creds_true(k8s_config):
+    client = KubernetesClient(use_cpanel_creds=True)
+
+    config = client.api_client.configuration
+
+    assert config.api_key_prefix["authorization"] == "Bearer"
+    assert config.api_key["authorization"] == SERVICE_ACCOUNT_TEST_TOKEN
+


### PR DESCRIPTION
### What

- Simplified `KubernetesClient` [to not read the user `id_token` from HTTP request](https://github.com/ministryofjustice/analytics-platform-control-panel/commit/5b8fd7b17c2c6975c405744a12d1332b0283d0ee) (this can't be always done, e.g. if in the context of a background worker)
- Above allowed me to write some tests [[1]](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/761/files#diff-7195327eb3862074d88addee3f580b5bR1) [[2]](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/761/commits/5b97d498f23d1d6120c5d6c385969f5404fa9208) for this class
- Remove the implicit read of the `id_token` required me to be sure that all places where a `KubernetesClient` is instantiated (and their client code) always pass the `id_token` when performing an operation against the kubernetes API. This is done in this two commits:
  - [change to `cluster. restart_tool_deployment()`](https://github.com/ministryofjustice/analytics-platform-control-panel/commit/9a5921184c15d244ed80891a9e28101ccdeea2aa)
  - [change to the rest of `cluster` functions](https://github.com/ministryofjustice/analytics-platform-control-panel/commit/e4f4c1cf3604cc73db7c46d1f714baef4ef28699) (functions using `cluster. list_tool_deployments()` directly or indirectly)
- also fixed use of [unimported `helm.HelmError` in `cluster` module](https://github.com/ministryofjustice/analytics-platform-control-panel/commit/ed00f9be2d9bee0ec3fc17af5ae0146e93a1d61f)

### Design rationale
I've avoided moving too much around to keep this PR focused on simplifying/testing the `KubernetesClient` class.

One key design decision I've taken is to always explicitly passing the `id_token` when performing an operation against the k8s cluster. 
Potentially we could move this in the state (e.g. in an instance attribute) - I preferred to be explicit here. Plus this is not possible in the case of `list_tool_deployments()` or `ToolDeployment.objects.filter()` which would have to be "special" and require the client code to pass the `id_token` anyway.

Potential future changes could involve grouping the functions related to a tool deployment into a `cluster.ToolDeployment` class:

```python
class ToolDeployment():
  @classmethod
  def get_deployments()

  def deploy()
  def get_status()
  def get_deployment()
  def restart()
  def delete()
```

(or something like that)

Arguably the "fake" model `ToolDeployment` is really responsible for interacting with the k8s cluster and could be removed/moved into `cluster` but I've avoided this for the time being.


### How to review

1. Run tests, they should pass
2. Run CP locally (both HTTP server and worker)
3. You should be able to see the list of tools, and perform operations on them


### Ticket
Part of ticket: https://trello.com/c/OXWwaZua