### PR TITLE
Moved `cluster` functions into `ToolDeployment` class

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -572,12 +572,29 @@ def get_tool_deployment_status(tool_deployment, id_token):
     )
     return TOOL_STATUS_UNKNOWN
 
-def restart_tool_deployment(tool_deployment, id_token):
-    k8s = KubernetesClient(id_token=id_token)
-    return k8s.AppsV1Api.delete_collection_namespaced_replica_set(
-        tool_deployment.user.k8s_namespace,
-        label_selector=(
-            f'app={tool_deployment.tool.chart_name}'
-            # f'-{tool_deployment.tool.version}'
-        ),
-    )
+
+
+
+class ToolDeployment():
+
+    def __init__(self, user, tool):
+        self.user = user
+        self.tool = tool
+
+    @property
+    def chart_name(self):
+        return self.tool.chart_name
+
+    @property
+    def k8s_namespace(self):
+        return self.user.k8s_namespace
+
+    def restart(self, id_token):
+        k8s = KubernetesClient(id_token=id_token)
+        return k8s.AppsV1Api.delete_collection_namespaced_replica_set(
+            self.k8s_namespace,
+            label_selector=(
+                f"app={self.chart_name}"
+                # f'-{tool_deployment.tool.version}'
+            ),
+        )

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -105,7 +105,7 @@ class ToolDeployment:
         Deploy the tool to the cluster (asynchronous)
         """
 
-        self._subprocess = cluster.deploy_tool(self.tool, self.user)
+        self._subprocess = cluster.ToolDeployment(self.user, self.tool).install()
 
     def get_status(self, id_token):
         """

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -143,4 +143,4 @@ class ToolDeployment:
         Restart the tool deployment
         """
 
-        cluster.restart_tool_deployment(self, id_token)
+        cluster.ToolDeployment(self.user, self.tool).restart(id_token)

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -53,7 +53,8 @@ class ToolDeploymentManager:
         user = kwargs["user"]
         id_token = kwargs["id_token"]
         filter = Q(chart_name=None)  # Always False
-        for deployment in cluster.list_tool_deployments(user, id_token):
+        deployments = cluster.ToolDeployment.get_deployments(user, id_token)
+        for deployment in deployments:
             chart_name, version = deployment.metadata.labels["chart"].rsplit("-", 1)
             deployed_versions[chart_name] = version
             filter = filter | (
@@ -94,7 +95,8 @@ class ToolDeployment:
         """
         Remove the release from the cluster
         """
-        cluster.delete_tool_deployment(self, id_token)
+
+        cluster.ToolDeployment(self.user, self.tool).uninstall(id_token)
 
     @property
     def host(self):
@@ -118,7 +120,7 @@ class ToolDeployment:
             if status:
                 return status
 
-        return cluster.get_tool_deployment_status(self, id_token)
+        return cluster.ToolDeployment(self.user, self.tool).get_status(id_token)
 
     def _poll(self):
         """

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -18,6 +18,9 @@ class User(AbstractUser):
         db_table = 'control_panel_api_user'
         ordering = ('username',)
 
+    def __repr__(self):
+        return f"<User: {self.username} ({self.auth0_id})>"
+
     def get_full_name(self):
         return self.name
 

--- a/tests/api/views/test_tool_deployment.py
+++ b/tests/api/views/test_tool_deployment.py
@@ -6,12 +6,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 
-@pytest.yield_fixture(autouse=True)
-def deploy_tool():
-    with patch('controlpanel.api.models.tool.cluster.deploy_tool') as deploy:
-        yield deploy
-
-
 @pytest.fixture
 def tool(db):
     return mommy.make('api.Tool')
@@ -24,9 +18,11 @@ def test_create_when_invalid_tool_name(client, users):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_create_when_valid_tool_name(client, deploy_tool, tool, users):
-    client.force_login(users['normal_user'])
-    response = client.post(reverse('deployment-list'), {"name": tool.chart_name})
-    assert response.status_code == status.HTTP_201_CREATED
+def test_create_when_valid_tool_name(client, tool, users):
+    with patch("controlpanel.api.models.tool.cluster.ToolDeployment") as ToolDeployment:
+        client.force_login(users["normal_user"])
+        response = client.post(reverse("deployment-list"), {"name": tool.chart_name})
+        assert response.status_code == status.HTTP_201_CREATED
 
-    deploy_tool.assert_called_with(tool, users['normal_user'])
+        ToolDeployment.assert_called_once_with(users["normal_user"], tool)
+        ToolDeployment.return_value.install.assert_called()


### PR DESCRIPTION
This logically groups together the functions that operate on a tool deployment.

(also fixed `HelmError` import in `cluster` module)

Part of ticket: https://trello.com/c/OXWwaZua