### PR TITLE
Avoid overwriting existing resources in s3-access policy statements

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -106,19 +106,16 @@ BASE_S3_ACCESS_STATEMENT = {
             's3:ListBucket',
         ],
         'Effect': 'Allow',
-        'Resource': [],
     },
     'readonly': {
         'Sid': 'readonly',
         'Action': READ_ACTIONS,
         'Effect': 'Allow',
-        'Resource': [],
     },
     'readwrite': {
         'Sid': 'readwrite',
         'Action': READ_ACTIONS + WRITE_ACTIONS,
         'Effect': 'Allow',
-        'Resource': [],
     },
 }
 

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -308,6 +308,14 @@ def test_grant_bucket_access(iam, users, resources):
     else:
         assert bucket_arn in statements['list']['Resource']
 
+    aws.grant_bucket_access(user.iam_role_name, f'{bucket_arn}-2', 'readonly')
+    policy.reload()
+    statements = get_statements_by_sid(policy.policy_document)
+    expected_num_resources = 2
+    if path_arns:
+        expected_num_resources = len(path_arns) + 1
+    assert len(statements['readonly']['Resource']) == expected_num_resources
+
 
 @pytest.mark.parametrize(
     'resources',


### PR DESCRIPTION
Should have stuck to my original code - updating Statement dicts with empty Resource list removes all resources :man_facepalming: