### PR TITLE
Security fixes for OWASP

### DIFF
--- a/controlpanel/middleware/__init__.py
+++ b/controlpanel/middleware/__init__.py
@@ -1,1 +1,2 @@
+from controlpanel.middleware.never_cache import DisableClientSideCachingMiddleware
 from controlpanel.middleware.legacy_api_redirect import LegacyAPIRedirectMiddleware

--- a/controlpanel/middleware/never_cache.py
+++ b/controlpanel/middleware/never_cache.py
@@ -1,0 +1,14 @@
+from django.utils.cache import add_never_cache_headers
+
+
+class DisableClientSideCachingMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        add_never_cache_headers(response)
+        response['Pragma'] = 'no-cache'
+        return response
+

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "controlpanel.middleware.DisableClientSideCachingMiddleware",
     "controlpanel.middleware.LegacyAPIRedirectMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -214,6 +215,20 @@ MANAGERS = []
 
 # Whitelist values for the HTTP Host header, to prevent certain attacks
 ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split() if host]
+
+# Sets the X-XSS-Protection: 1; mode=block header
+SECURE_BROWSER_XSS_FILTER = True
+
+# Sets the X-Content-Type-Options: nosniff header
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+# Secure the CSRF cookie
+CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
+
+# Secure the session cookie
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = True
 
 
 # -- Running Django

--- a/controlpanel/settings/development.py
+++ b/controlpanel/settings/development.py
@@ -34,3 +34,6 @@ if os.environ.get('ENABLE_DJANGO_DEBUG_TOOLBAR'):
     ]
 
 INTERNAL_IPS = ['127.0.0.1']
+
+CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = False

--- a/controlpanel/settings/test.py
+++ b/controlpanel/settings/test.py
@@ -27,3 +27,6 @@ TOOLS["testtool"] = {
     "client_id": "42",
     "client_secret": "secret",
 }
+
+CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = False


### PR DESCRIPTION
* Ensure CSRF and session cookies are HTTP only and sent over HTTPS
* Disable client-side caching (static files are served by Nginx with caching allowed)
* Enable XSS protection
* Disable content-type sniffing