### PR TITLE
IAM role creation works in cross-account setup

### DIFF
--- a/controlpanel/api/models/iam_managed_policy.py
+++ b/controlpanel/api/models/iam_managed_policy.py
@@ -1,11 +1,9 @@
 import re
 
-from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
 
-from controlpanel.api.aws import iam_arn
 from controlpanel.api import cluster
 
 

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -538,7 +538,8 @@ KIBANA_BASE_URL = os.environ.get(
 
 
 # -- AWS
-AWS_ACCOUNT_ID = os.environ.get('AWS_ACCOUNT_ID')
+AWS_COMPUTE_ACCOUNT_ID = os.environ.get("AWS_COMPUTE_ACCOUNT_ID")
+AWS_DATA_ACCOUNT_ID = os.environ.get("AWS_DATA_ACCOUNT_ID")
 K8S_WORKER_ROLE_NAME = os.environ.get('K8S_WORKER_ROLE_NAME')
 
 BUCKET_REGION = os.environ.get('BUCKET_REGION', 'eu-west-1')

--- a/controlpanel/settings/test.py
+++ b/controlpanel/settings/test.py
@@ -3,7 +3,8 @@ from controlpanel.settings.common import *
 
 ENV = 'test'
 
-AWS_ACCOUNT_ID = '123456789012'  # XXX DO NOT CHANGE - it will break moto tests
+AWS_COMPUTE_ACCOUNT_ID = "test_compute_account_id"
+AWS_DATA_ACCOUNT_ID = "123456789012"  # XXX DO NOT CHANGE - it will break moto tests
 K8S_WORKER_ROLE_NAME = "nodes.example.com"
 SAML_PROVIDER = "test-saml"
 

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -3,7 +3,8 @@
 | Name | Description | Default |
 | ---- | ----------- | ------- |
 | `ALLOWED_HOSTS` | Space separated. Must be set if DEBUG is False | `[]` |
-| `AWS_ACCOUNT_ID` | Your AWS account ID. You can find this by running `aws sts get-caller-identity --query Account --output text` | |
+| `AWS_COMPUTE_ACCOUNT_ID` | ID of the AWS account where tools and apps run | |
+| `AWS_DATA_ACCOUNT_ID` | ID of the AWS account where data sits | |
 | `BUCKET_REGION` | AWS region | `eu-west-1` |
 | `DB_HOST` | Hostname of postgres server | `127.0.0.1` |
 | `DB_NAME` | Postgres database name | `controlpanel` |

--- a/tests/api/cluster/test_group.py
+++ b/tests/api/cluster/test_group.py
@@ -16,7 +16,7 @@ def iam_managed_policy():
 
 def test_arn(settings, iam_managed_policy):
     assert cluster.RoleGroup(iam_managed_policy).arn == (
-        f'arn:aws:iam::{settings.AWS_ACCOUNT_ID}:policy/{settings.ENV}/group/test'
+        f"arn:aws:iam::{settings.AWS_DATA_ACCOUNT_ID}:policy/{settings.ENV}/group/test"
     )
 
 


### PR DESCRIPTION
A quirk of AWS cross-account setup is that the IAM role trust relationship
(AKA `AssumeRolePolicyDocument`)'s `Principal` is not the full ARN of the
assuming IAM role but only the ID of the account where the assumimg IAM
role is.

Once we have both data and compute AWS account IDs we can then tell
if everything is in the same AWS account or not (e.g. different IDs means
we have a cross-account setup).

In practice this means that CP would work as before in `alpha` (as long
as `AWS_COMPUTE_ACCOUNT_ID` and `AWS_COMPUTE_ACCOUNT_ID` as set correctly
to the same account ID where everything sits).

**IMPORTANT**: Removed now-ambiguous `AWS_ACCOUNT_ID` and added
`AWS_COMPUTE_ACCOUNT_ID` and `AWS_COMPUTE_ACCOUNT_ID` configuration.
We need to distinguish between the AWS account where the data/IAM roles
are and the AWS account k8s nodes (tools and apps) are.

**AWS delegate access example**: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_policy-examples.html#example-delegate-xaccount-S3

**Part of ticket**: https://trello.com/c/1DrJ8TN1
