### PR TITLE
Fix bug in creating app role

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -87,7 +87,7 @@ class App:
         return f"{settings.ENV}_app_{self.app.slug}"
 
     def create_iam_role(self):
-        aws.create_app_role(self.iam_role_name)
+        aws.create_app_role(self.app)
 
     def delete_iam_role(self):
         aws.delete_role(self.iam_role_name)

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -12,7 +12,7 @@ def app():
 
 def test_app_create_iam_role(aws, app):
     cluster.App(app).create_iam_role()
-    aws.create_app_role.assert_called_with(app.iam_role_name)
+    aws.create_app_role.assert_called_with(app)
 
 
 def test_app_delete_iam_role(aws, app):

--- a/tests/api/models/test_app.py
+++ b/tests/api/models/test_app.py
@@ -31,7 +31,7 @@ def test_slug_collisions_increments():
 @pytest.mark.django_db
 def test_aws_create_role_calls_service(aws):
     app = App.objects.create(repo_url="https://example.com/repo_name")
-    aws.create_app_role.assert_called_with(app.iam_role_name)
+    aws.create_app_role.assert_called_with(app)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Was passing the role name instead of the app. This meant app roles were not being created successfully, as seen with `prison-performance-dashboard`.