### PR TITLE
Fix app logs Elasticsearch query

### DIFF
--- a/controlpanel/api/elasticsearch.py
+++ b/controlpanel/api/elasticsearch.py
@@ -33,9 +33,14 @@ def app_logs(app, num_hours=None):
     conn = Elasticsearch(hosts=settings.ELASTICSEARCH['hosts'])
     s = Search(using=conn, index=settings.ELASTICSEARCH['indices']['app-logs'])
 
-    s = s.query(
+    # limit fields returned
+    s = s.source(['@timestamp', 'message'])
+
+    s = s.filter(
         Q('exists', field='message')
-        & Q('match', app_name=f'{app.release_name}-webapp')
+        & Q('term', **{
+            "app_name.keyword": f'{app.release_name}-webapp',
+        })
     )
 
     s = s.filter(Range(**{

--- a/controlpanel/frontend/static/components/app-logs/macro.html
+++ b/controlpanel/frontend/static/components/app-logs/macro.html
@@ -1,11 +1,9 @@
 {% macro app_logs(app, kibana_base_url) %}
-  {# disable app logs temporarily
   <div class="app-logs">
     <pre>{% for entry in app.get_logs() -%}
 <span class="timestamp">{{ entry.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}:</span> <span class="message">{{ entry.message }}</span>
 {% endfor %}</pre>
   </div>
-  #}
   <p class="govuk-body">
     <a href="{{ kibana_link(app, kibana_base_url) }}">View full logs</a>
   </p>


### PR DESCRIPTION
The query was returning log entries for all apps, because the filter on the `app_name` field was an analyzed text search returning a score, rather than an exact binary filter. Changing to a `term` filter on the `app_name.keyword` field results in a binary filter and fixes the problem.
I've also restricted the fields returned for efficiency.