### PR TITLE
Prevent Helm debug output

### DIFF
--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+import os
 import re
 import subprocess
 
@@ -26,11 +27,16 @@ class Helm(object):
 
         try:
             log.debug(' '.join(['helm', *args]))
+            env = os.environ.copy()
+            # helm checks for existence of DEBUG env var
+            if 'DEBUG' in env:
+                del env['DEBUG']
             proc = subprocess.Popen(
                 ["helm", *args],
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 encoding='utf8',
+                env=env,
                 **kwargs,
             )
 


### PR DESCRIPTION
We're getting a lot of Sentry issues with output like
```
2019/12/05 10:55:53 (0xc0007fc000) (0xc0006a2140) Create stream
2019/12/05 10:55:53 (0xc0007fc000) (0xc0006a2140) Stream added, broadcasting: 1
2019/12/05 10:55:53 (0xc0007fc000) Reply frame received for 1
2019/12/05 10:55:53 (0xc0006a2140) (1) Writing data frame
2019/12/05 10:55:53 (0xc0007fc000) (0xc000640000) Create stream
2019/12/05 10:55:53 (0xc0007fc000) (0xc000640000) Stream added, broadcasting: 3
2019/12/05 10:55:53 (0xc0007fc000) Reply frame received for 3
2019/12/05 10:55:53 (0xc000640000) (3) ...
```
which is possibly obscuring real errors.

This change removes the `DEBUG` variable from the environment when running `helm`, which should prevent it from dumping this debug output.