### PR TITLE
Fix bugs with path-specific bucket access

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -291,10 +291,7 @@ class S3AccessPolicy:
                     resources.remove(resource)
 
     def grant_object_access(self, arn, access_level):
-        other_level = 'readwrite' if access_level == 'readonly' else 'readonly'
-
         self.add_resource(f'{arn}/*', access_level)
-        self.remove_resource(arn, other_level)
 
     def grant_list_access(self, arn):
         self.add_resource(arn, 'list')
@@ -357,8 +354,8 @@ def grant_bucket_access(role_name, bucket_arn, access_level, path_arns=[]):
     policy.put()
 
 
-def revoke_bucket_access(role_name, bucket_arn=None, path_arns=[]):
-    if not bucket_arn and not path_arns:
+def revoke_bucket_access(role_name, bucket_arn=None):
+    if not bucket_arn:
         log.warning(f'Asked to revoke {role_name} role access to nothing')
         return
 
@@ -426,8 +423,8 @@ def grant_group_bucket_access(group_policy_arn, bucket_arn, access_level, path_a
     policy.put()
 
 
-def revoke_group_bucket_access(group_policy_arn, bucket_arn=None, path_arns=[]):
-    if not bucket_arn and not path_arns:
+def revoke_group_bucket_access(group_policy_arn, bucket_arn=None):
+    if not bucket_arn:
         log.warning(f'Asked to revoke {group_policy_arn} group access to nothing')
         return
 

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -68,8 +68,8 @@ class User:
     def grant_bucket_access(self, bucket_arn, access_level, path_arns=[]):
         aws.grant_bucket_access(self.iam_role_name, bucket_arn, access_level, path_arns)
 
-    def revoke_bucket_access(self, bucket_arn, path_arns=[]):
-        aws.revoke_bucket_access(self.iam_role_name, bucket_arn, path_arns)
+    def revoke_bucket_access(self, bucket_arn):
+        aws.revoke_bucket_access(self.iam_role_name, bucket_arn)
 
 
 class App:
@@ -95,8 +95,8 @@ class App:
     def grant_bucket_access(self, bucket_arn, access_level, path_arns):
         aws.grant_bucket_access(self.iam_role_name, bucket_arn, access_level, path_arns)
 
-    def revoke_bucket_access(self, bucket_arn, path_arns=[]):
-        aws.revoke_bucket_access(self.iam_role_name, bucket_arn, path_arns)
+    def revoke_bucket_access(self, bucket_arn):
+        aws.revoke_bucket_access(self.iam_role_name, bucket_arn)
 
     @property
     def url(self):
@@ -164,8 +164,8 @@ class RoleGroup:
     def grant_bucket_access(self, bucket_arn, access_level, path_arns):
         aws.grant_group_bucket_access(self.arn, bucket_arn, access_level, path_arns)
 
-    def revoke_bucket_access(self, bucket_arn, path_arns=[]):
-        aws.revoke_group_bucket_access(self.arn, bucket_arn, path_arns)
+    def revoke_bucket_access(self, bucket_arn):
+        aws.revoke_group_bucket_access(self.arn, bucket_arn)
 
 
 def create_parameter(name, value, role, description):

--- a/controlpanel/api/models/apps3bucket.py
+++ b/controlpanel/api/models/apps3bucket.py
@@ -37,5 +37,5 @@ class AppS3Bucket(AccessToS3Bucket):
         )
 
     def revoke_bucket_access(self):
-        cluster.App(self.app).revoke_bucket_access(self.s3bucket.arn, self.resources)
+        cluster.App(self.app).revoke_bucket_access(self.s3bucket.arn)
 

--- a/controlpanel/api/models/policys3bucket.py
+++ b/controlpanel/api/models/policys3bucket.py
@@ -29,4 +29,3 @@ class PolicyS3Bucket(AccessToS3Bucket):
 
     def revoke_bucket_access(self):
         cluster.RoleGroup(self.policy).revoke_bucket_access(self.s3bucket.arn)
-

--- a/controlpanel/api/models/users3bucket.py
+++ b/controlpanel/api/models/users3bucket.py
@@ -43,5 +43,5 @@ class UserS3Bucket(AccessToS3Bucket):
         )
 
     def revoke_bucket_access(self):
-        cluster.User(self.user).revoke_bucket_access(self.s3bucket.arn, self.resources)
+        cluster.User(self.user).revoke_bucket_access(self.s3bucket.arn)
 

--- a/tests/api/models/test_apps3bucket.py
+++ b/tests/api/models/test_apps3bucket.py
@@ -84,5 +84,4 @@ def test_delete_revoke_permissions(app, aws, bucket):
     aws.revoke_bucket_access.assert_called_with(
         apps3bucket.iam_role_name,
         bucket.arn,
-        apps3bucket.resources,
     )

--- a/tests/api/models/test_s3bucket.py
+++ b/tests/api/models/test_s3bucket.py
@@ -24,8 +24,8 @@ def test_delete_revokes_permissions(bucket, aws):
     bucket.delete()
 
     aws.revoke_bucket_access.assert_has_calls([
-        call(apps3bucket.iam_role_name, bucket.arn, apps3bucket.resources),
-        call(users3bucket.iam_role_name, bucket.arn, users3bucket.resources),
+        call(apps3bucket.iam_role_name, bucket.arn),
+        call(users3bucket.iam_role_name, bucket.arn),
     ])
 
 

--- a/tests/api/models/test_users3bucket.py
+++ b/tests/api/models/test_users3bucket.py
@@ -59,6 +59,5 @@ def test_delete_revoke_permissions(user, bucket, users3bucket, aws):
     aws.revoke_bucket_access.assert_called_with(
         user.iam_role_name,
         bucket.arn,
-        users3bucket.resources,
     )
     # TODO get policy from call and assert bucket ARN removed

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -293,8 +293,8 @@ def get_statements_by_sid(policy_document):
 @pytest.mark.parametrize(
     'resources',
     [
-        ([]),
-        (['/foo/bar', '/foo/baz']),
+        ([],),
+        (['/foo/bar', '/foo/baz'],),
     ],
     ids=[
         'no-paths',
@@ -303,11 +303,8 @@ def get_statements_by_sid(policy_document):
 )
 def test_grant_bucket_access(iam, users, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
-    path_arns_list = []
-    path_arns_object = []
-    if resources:
-        path_arns_list = [f'{bucket_arn}{resource}' for resource in resources]
-        path_arns_object = [f'{bucket_arn}{resource}/*' for resource in resources]
+    path_arns_list = [f'{bucket_arn}{resource}' for resource in resources]
+    path_arns_object = [f'{bucket_arn}{resource}/*' for resource in resources]
     user = users['normal_user']
     aws.create_user_role(user)
 
@@ -337,7 +334,7 @@ def test_grant_bucket_access(iam, users, resources):
 @pytest.mark.parametrize(
     'resources',
     [
-        (['/foo/bar', '/foo/baz'])
+        (['/foo/bar', '/foo/baz'],)
     ],
     ids=[
         'paths'
@@ -405,8 +402,8 @@ def test_update_bucket_path_access(iam, users, resources_1, resources_2):
 @pytest.mark.parametrize(
     'resources',
     [
-        ([]),
-        (['/foo/bar', '/foo/baz']),
+        ([],),
+        (['/foo/bar', '/foo/baz'],),
     ],
     ids=[
         'no-paths',
@@ -415,14 +412,12 @@ def test_update_bucket_path_access(iam, users, resources_1, resources_2):
 )
 def test_revoke_bucket_access(iam, users, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
-    path_arns = []
-    if resources:
-        path_arns = [f'{bucket_arn}{resource}' for resource in resources]
+    path_arns = [f'{bucket_arn}{resource}' for resource in resources]
     user = users['normal_user']
     aws.create_user_role(user)
     aws.grant_bucket_access(user.iam_role_name, bucket_arn, 'readonly', path_arns)
 
-    aws.revoke_bucket_access(user.iam_role_name, bucket_arn, path_arns)
+    aws.revoke_bucket_access(user.iam_role_name, bucket_arn)
 
     policy = iam.RolePolicy(user.iam_role_name, 's3-access')
     statements = get_statements_by_sid(policy.policy_document)
@@ -509,8 +504,8 @@ def test_delete_group(iam, group, user_roles):
 @pytest.mark.parametrize(
     'resources',
     [
-        ([]),
-        (['/foo/bar', '/foo/baz']),
+        ([],),
+        (['/foo/bar', '/foo/baz'],),
     ],
     ids=[
         'no-paths',
@@ -519,11 +514,8 @@ def test_delete_group(iam, group, user_roles):
 )
 def test_grant_group_bucket_access(iam, group, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
-    path_arns_list = []
-    path_arns_object = []
-    if resources:
-        path_arns_list = [f'{bucket_arn}{resource}' for resource in resources]
-        path_arns_object = [f'{bucket_arn}{resource}/*' for resource in resources]
+    path_arns_list = [f'{bucket_arn}{resource}' for resource in resources]
+    path_arns_object = [f'{bucket_arn}{resource}/*' for resource in resources]
 
     aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns_list)
 
@@ -551,7 +543,7 @@ def test_grant_group_bucket_access(iam, group, resources):
 @pytest.mark.parametrize(
     'resources',
     [
-        (['/foo/bar', '/foo/baz'])
+        (['/foo/bar', '/foo/baz'],)
     ],
     ids=[
         'paths'
@@ -608,8 +600,8 @@ def test_update_group_bucket_path_access(iam, group, resources_1, resources_2):
 @pytest.mark.parametrize(
     'resources',
     [
-        ([]),
-        (['/foo/bar', '/foo/baz']),
+        ([],),
+        (['/foo/bar', '/foo/baz'],),
     ],
     ids=[
         'no-paths',
@@ -618,12 +610,10 @@ def test_update_group_bucket_path_access(iam, group, resources_1, resources_2):
 )
 def test_revoke_group_bucket_access(iam, group, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
-    path_arns = []
-    if resources:
-        path_arns = [f'{bucket_arn}{resource}' for resource in resources]
+    path_arns = [f'{bucket_arn}{resource}' for resource in resources]
     aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns)
 
-    aws.revoke_group_bucket_access(group.arn, bucket_arn, path_arns)
+    aws.revoke_group_bucket_access(group.arn, bucket_arn)
 
     group.reload()
     statements = get_statements_by_sid(group.default_version.document)

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -293,7 +293,7 @@ def get_statements_by_sid(policy_document):
 @pytest.mark.parametrize(
     'resources',
     [
-        ([],),
+        ([]),
         (['/foo/bar', '/foo/baz']),
     ],
     ids=[
@@ -303,6 +303,48 @@ def get_statements_by_sid(policy_document):
 )
 def test_grant_bucket_access(iam, users, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
+    path_arns_list = []
+    path_arns_object = []
+    if resources:
+        path_arns_list = [f'{bucket_arn}{resource}' for resource in resources]
+        path_arns_object = [f'{bucket_arn}{resource}/*' for resource in resources]
+    user = users['normal_user']
+    aws.create_user_role(user)
+
+    aws.grant_bucket_access(user.iam_role_name, bucket_arn, 'readonly', path_arns_list)
+
+    policy = iam.RolePolicy(user.iam_role_name, 's3-access')
+    statements = get_statements_by_sid(policy.policy_document)
+
+    if path_arns_object:
+        assert set(path_arns_object) == set(statements['readonly']['Resource'])
+        assert f'{bucket_arn}/*' not in statements['readonly']['Resource']
+    else:
+        assert set([f'{bucket_arn}/*']) == set(statements['readonly']['Resource'])
+    # no readwrite statement because no readwrite access granted
+    assert 'readwrite' not in statements
+    assert set([bucket_arn]) == set(statements['list']['Resource'])
+
+    aws.grant_bucket_access(user.iam_role_name, f'{bucket_arn}-2', 'readonly')
+    policy.reload()
+    statements = get_statements_by_sid(policy.policy_document)
+    expected_num_resources = 2
+    if path_arns_list:
+        expected_num_resources = len(path_arns_list) + 1
+    assert len(statements['readonly']['Resource']) == expected_num_resources
+
+
+@pytest.mark.parametrize(
+    'resources',
+    [
+        (['/foo/bar', '/foo/baz'])
+    ],
+    ids=[
+        'paths'
+    ]
+)
+def test_revoke_bucket_path_access(iam, users, resources):
+    bucket_arn = 'arn:aws:s3:::test-bucket'
     path_arns = [f'{bucket_arn}{resource}' for resource in resources]
     user = users['normal_user']
     aws.create_user_role(user)
@@ -310,32 +352,60 @@ def test_grant_bucket_access(iam, users, resources):
     aws.grant_bucket_access(user.iam_role_name, bucket_arn, 'readonly', path_arns)
 
     policy = iam.RolePolicy(user.iam_role_name, 's3-access')
-    statements = get_statements_by_sid(policy.policy_document)
 
-    if path_arns:
-        assert f'{bucket_arn}/*' not in statements['readonly']['Resource']
-    else:
-        assert f'{bucket_arn}/*' in statements['readonly']['Resource']
-    # no readwrite statement because no readwrite access granted
-    assert 'readwrite' not in statements
-    if path_arns:
-        assert set(path_arns) == set(statements['list']['Resource'])
-    else:
-        assert bucket_arn in statements['list']['Resource']
-
-    aws.grant_bucket_access(user.iam_role_name, f'{bucket_arn}-2', 'readonly')
+    aws.grant_bucket_access(user.iam_role_name, bucket_arn, 'readonly')
     policy.reload()
     statements = get_statements_by_sid(policy.policy_document)
-    expected_num_resources = 2
-    if path_arns:
-        expected_num_resources = len(path_arns) + 1
-    assert len(statements['readonly']['Resource']) == expected_num_resources
+
+    assert set([f'{bucket_arn}/*']) == set(statements['readonly']['Resource'])
+    assert set([f'{bucket_arn}']) == set(statements['list']['Resource'])
+
+
+@pytest.mark.parametrize(
+    'resources_1,resources_2',
+    [
+        (['/foo/bar', '/foo/baz'], ['/foo/bar', '/bar/baz']),
+        (['/foo/bar', '/foo/baz'], ['/bar/foo', '/bar/baz']),
+        (['/foo/bar'], ['/foo/bar', '/foo/baz']),
+    ],
+    ids=[
+        'change-some-paths',
+        'change-all-paths',
+        'add-new-paths',
+    ]
+)
+def test_update_bucket_path_access(iam, users, resources_1, resources_2):
+    bucket_arn = 'arn:aws:s3:::test-bucket'
+    path_arns_list_1 = [f'{bucket_arn}{resource}' for resource in resources_1]
+    path_arns_list_2 = [f'{bucket_arn}{resource}' for resource in resources_2]
+    path_arns_object_1 = [f'{bucket_arn}{resource}/*' for resource in resources_1]
+    path_arns_object_2 = [f'{bucket_arn}{resource}/*' for resource in resources_2]
+    user = users['normal_user']
+    aws.create_user_role(user)
+
+    aws.grant_bucket_access(
+        user.iam_role_name, bucket_arn, 'readonly', path_arns_list_1
+    )
+
+    policy = iam.RolePolicy(user.iam_role_name, 's3-access')
+    statements = get_statements_by_sid(policy.policy_document)
+
+    assert set(path_arns_object_1) == set(statements['readonly']['Resource'])
+
+    aws.grant_bucket_access(
+        user.iam_role_name, bucket_arn, 'readonly', path_arns_list_2
+    )
+
+    policy.reload()
+    statements = get_statements_by_sid(policy.policy_document)
+
+    assert set(path_arns_object_2) == set(statements['readonly']['Resource'])
 
 
 @pytest.mark.parametrize(
     'resources',
     [
-        ([],),
+        ([]),
         (['/foo/bar', '/foo/baz']),
     ],
     ids=[
@@ -345,7 +415,9 @@ def test_grant_bucket_access(iam, users, resources):
 )
 def test_revoke_bucket_access(iam, users, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
-    path_arns = [f'{bucket_arn}{resource}' for resource in resources]
+    path_arns = []
+    if resources:
+        path_arns = [f'{bucket_arn}{resource}' for resource in resources]
     user = users['normal_user']
     aws.create_user_role(user)
     aws.grant_bucket_access(user.iam_role_name, bucket_arn, 'readonly', path_arns)
@@ -437,7 +509,7 @@ def test_delete_group(iam, group, user_roles):
 @pytest.mark.parametrize(
     'resources',
     [
-        ([],),
+        ([]),
         (['/foo/bar', '/foo/baz']),
     ],
     ids=[
@@ -447,28 +519,96 @@ def test_delete_group(iam, group, user_roles):
 )
 def test_grant_group_bucket_access(iam, group, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
-    path_arns = [f'{bucket_arn}{resource}' for resource in resources]
+    path_arns_list = []
+    path_arns_object = []
+    if resources:
+        path_arns_list = [f'{bucket_arn}{resource}' for resource in resources]
+        path_arns_object = [f'{bucket_arn}{resource}/*' for resource in resources]
 
-    aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns)
+    aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns_list)
 
     group.reload()
     statements = get_statements_by_sid(group.default_version.document)
 
-    if path_arns:
+    if path_arns_object:
+        assert set(path_arns_object) == set(statements['readonly']['Resource'])
         assert f'{bucket_arn}/*' not in statements['readonly']['Resource']
     else:
-        assert f'{bucket_arn}/*' in statements['readonly']['Resource']
+        assert set([f'{bucket_arn}/*']) == set(statements['readonly']['Resource'])
+    # no readwrite statement because no readwrite access granted
     assert 'readwrite' not in statements
-    if path_arns:
-        assert set(path_arns) == set(statements['list']['Resource'])
-    else:
-        assert bucket_arn in statements['list']['Resource']
+    assert set([bucket_arn]) == set(statements['list']['Resource'])
+
+    aws.grant_group_bucket_access(group.arn, f'{bucket_arn}-2', 'readonly')
+    group.reload()
+    statements = get_statements_by_sid(group.default_version.document)
+    expected_num_resources = 2
+    if path_arns_list:
+        expected_num_resources = len(path_arns_list) + 1
+    assert len(statements['readonly']['Resource']) == expected_num_resources
 
 
 @pytest.mark.parametrize(
     'resources',
     [
-        ([],),
+        (['/foo/bar', '/foo/baz'])
+    ],
+    ids=[
+        'paths'
+    ],
+)
+def test_revoke_group_bucket_path_access(iam, group, resources):
+    bucket_arn = 'arn:aws:s3:::test-bucket'
+    path_arns = [f'{bucket_arn}{resource}' for resource in resources]
+    aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns)
+
+    aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly')
+    group.reload()
+    statements = get_statements_by_sid(group.default_version.document)
+
+    assert set([f'{bucket_arn}/*']) == set(statements['readonly']['Resource'])
+    assert set([f'{bucket_arn}']) == set(statements['list']['Resource'])
+
+
+@pytest.mark.parametrize(
+    'resources_1,resources_2',
+    [
+        (['/foo/bar', '/foo/baz'], ['/foo/bar', '/bar/baz']),
+        (['/foo/bar', '/foo/baz'], ['/bar/foo', '/bar/baz']),
+        (['/foo/bar'], ['/foo/bar', '/foo/baz']),
+    ],
+    ids=[
+        'change-some-paths',
+        'change-all-paths',
+        'add-new-paths',
+    ],
+)
+def test_update_group_bucket_path_access(iam, group, resources_1, resources_2):
+    bucket_arn = 'arn:aws:s3:::test-bucket'
+    path_arns_list_1 = [f'{bucket_arn}{resource}' for resource in resources_1]
+    path_arns_list_2 = [f'{bucket_arn}{resource}' for resource in resources_2]
+    path_arns_object_1 = [f'{bucket_arn}{resource}/*' for resource in resources_1]
+    path_arns_object_2 = [f'{bucket_arn}{resource}/*' for resource in resources_2]
+
+    aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns_list_1)
+
+    group.reload()
+    statements = get_statements_by_sid(group.default_version.document)
+
+    assert set(path_arns_object_1) == set(statements['readonly']['Resource'])
+
+    aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns_list_2)
+
+    group.reload()
+    statements = get_statements_by_sid(group.default_version.document)
+
+    assert set(path_arns_object_2) == set(statements['readonly']['Resource'])
+
+
+@pytest.mark.parametrize(
+    'resources',
+    [
+        ([]),
         (['/foo/bar', '/foo/baz']),
     ],
     ids=[
@@ -478,10 +618,9 @@ def test_grant_group_bucket_access(iam, group, resources):
 )
 def test_revoke_group_bucket_access(iam, group, resources):
     bucket_arn = 'arn:aws:s3:::test-bucket'
-    path_arns = [
-        f'{bucket_arn}{resource}'
-        for resource in resources
-    ]
+    path_arns = []
+    if resources:
+        path_arns = [f'{bucket_arn}{resource}' for resource in resources]
     aws.grant_group_bucket_access(group.arn, bucket_arn, 'readonly', path_arns)
 
     aws.revoke_group_bucket_access(group.arn, bucket_arn, path_arns)

--- a/tests/api/views/test_apps3bucket.py
+++ b/tests/api/views/test_apps3bucket.py
@@ -69,7 +69,6 @@ def test_delete(client, apps3buckets, aws):
     aws.revoke_bucket_access.assert_called_with(
         apps3buckets[1].iam_role_name,
         apps3buckets[1].s3bucket.arn,
-        apps3buckets[1].resources,
     )
     # TODO get policy document JSON from call and assert bucket ARN not present
 

--- a/tests/api/views/test_users3bucket.py
+++ b/tests/api/views/test_users3bucket.py
@@ -78,7 +78,6 @@ def test_delete(client, users3buckets, aws):
     aws.revoke_bucket_access.assert_called_with(
         users3buckets[1].user.iam_role_name,
         users3buckets[1].s3bucket.arn,
-        users3buckets[1].resources,
     )
     # TODO get policy from call and assert bucket ARN not contained
 


### PR DESCRIPTION
This PR:
- fixes #785: Path-specific access is not removed from IAM policy
- fixes #786: Path-specific access is not applied correctly
- fixes #787: Users cannot access objects in the S3 console when given path-specific access
- updates existing tests
- adds new tests

Linked to https://github.com/moj-analytical-services/user-guidance/pull/11.