### PR TITLE
Fixed revoke access when IAM role doesn't exist

### DIFF
--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -359,6 +359,18 @@ def test_revoke_bucket_access(iam, users, resources):
     assert 'list' not in statements
 
 
+def test_revoke_bucket_access_when_no_role(iam):
+    role_name = "test_role_non_existent"
+    bucket_arn = "arn:aws:s3:::test-bucket"
+
+    # be sure role doesn't exist before calling revoke_bucket_access()
+    with pytest.raises(iam.meta.client.exceptions.NoSuchEntityException):
+        role = iam.Role(role_name)
+        role.load()
+
+    aws.revoke_bucket_access(role_name, bucket_arn, [])
+
+
 def test_create_group(iam, settings):
     aws.create_group('test', '/group/test/')
 


### PR DESCRIPTION
When trying to revoke access to a bucket the code tries to load the
corresponsing IAM role's `s3-access` inline policy but if the IAM role
doesn't exist this would of course fail.

It's not clear what's causing this but this shouldn't prevent the operaion
to succeed as if there is no IAM role effectively the provided IAM role
(which doesn't exist) already doesn't have access to the bucket and hence
there is nothing to revoke.

Also, as when deleting a user/app role all the associated `AppS3Bucket`
and `UserS3Bucket` records are deleted this exception mean you can't
delete a user/app when it has access to something but no IAM role for
whatever reason.

Ticket: https://trello.com/c/vwgmnhBX