### PR TITLE
Updated dependencies to get new ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10 AS base
+FROM alpine:3.11.2 AS base
 
 LABEL maintainer="andy.driver@digital.justice.gov.uk"
 
@@ -17,12 +17,12 @@ WORKDIR /home/controlpanel
 
 # install build dependencies
 RUN apk add --no-cache \
-        build-base=0.5-r1 \
-        ca-certificates=20190108-r0 \
-        libffi-dev=3.2.1-r6 \
-        python3-dev=3.7.5-r1 \
-        libressl-dev=2.7.5-r0 \
-        libstdc++=8.3.0-r0 \
+        build-base \
+        ca-certificates \
+        libffi-dev \
+        python3-dev=3.8.1-r0 \
+        libressl-dev \
+        libstdc++ \
         postgresql-dev \
         postgresql-client
 


### PR DESCRIPTION
This will be required soon as Amazon RDS CA certificates will
expire on on March 5, 2020 (see link below) - AWS published new CA certificates on 19 Sep 2019 - I imagine they should be included in alpine's `ca-certificates=20191127-r0` (Nov 2019)

I've unpinned the version of `ca-certificates`, we should really be
interested in the latest we can get ideally (latest version is `20191127-r0`) - although as I've learned
this is linked to the alpine tag so it's not guaranteed we'll always
get the latest version of `ca-certificates` just by re-building the
docker image.

To satisfy the dependencies I had to:
- update the alpine base image tag to `3.11.2` (was `3.10`)
- update Python to `3.8.1-r0` (from `3.7.5-r1`)
- unpin some of the dependencies, to be fair we shouldn't really care
  about specific versions of `build-base`, `libffi-dev`, `libressl-dev`,
  `libstdc++` anyway

See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html

Part of ticket: https://trello.com/c/SZCNhWm4