### PR TITLE
Fix creation of superusers

### DIFF
--- a/controlpanel/api/slack.py
+++ b/controlpanel/api/slack.py
@@ -17,9 +17,8 @@ def notify_superuser_created(username, by_username=None):
 
 
 def send_notification(message):
-    slack.WebClient(token=settings.SLACK['api_token']).chat_postMessage(
-        as_user=False,
-        username=f"Control Panel [{settings.ENV}]",
+    client = slack.WebClient(token=settings.SLACK['api_token'])
+    client.chat_postMessage(
         channel=settings.SLACK["channel"],
-        text=message,
+        text=f"{message} [{settings.ENV}]",
     )

--- a/tests/api/test_slack.py
+++ b/tests/api/test_slack.py
@@ -10,10 +10,8 @@ def message_sent(settings, slack_WebClient):
     def check_sent(message):
         slack_WebClient.assert_called_with(token=settings.SLACK["api_token"])
         slack_WebClient.return_value.chat_postMessage.assert_called_with(
-            as_user=False,
-            username=f"Control Panel [{settings.ENV}]",
             channel=settings.SLACK["channel"],
-            text=message,
+            text=f"{message} [{settings.ENV}]",
         )
         return True
     return check_sent


### PR DESCRIPTION
The old slack `access_token` stopped working and prevented the update
of the users' `is_superuser` flag.

This fixes the problem.

✅ Wait for [config PR](https://github.com/ministryofjustice/analytics-platform-config/pull/189) to be merged before releasing this

Context/Technicalities
======================

The old Slack application' `access_token` stopped working causing the
Control Panel to raise the following error:

```
{'ok': False, 'error': 'account_inactive'}
```

This may have been caused by the person setting up the corresponding
app being deactivated in Slack (because they left).

We tried to tweak the old app - required some approval - but we couldn't
make it work.

I've now created a new application in Slack but when testing its new
`access_token` I was getting another error:

```
{'ok': False, 'error': 'invalid_arguments', 'deprecated_argument': 'as_user'}
```

This is caused by the change in new Slack Applications behaviour.
According to [Slack's `chat.postMessage` documentation](https://api.slack.com/methods/chat.postMessage#authorship):

> The `as_user` parameter may not be used by new Slack apps (i.e., apps
> installed using our V2 of Oauth 2.0). New Slack apps act on their own
> behalf, rather than a user's.

Remove the `as_user` argument worked but the `user` argument was completely
ignored (again, because of the change in behaviour above).
This is the reason why I've moved the environment name at the end of the
message - as we still want to distinguish between `dev` and `alpha`
messages to avoid confusion.

Ticket
======
Part of ticket: https://trello.com/c/GrJPGKxm