### PR TITLE
When an S3 bucket is deleted, it's tagged for archival

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -207,10 +207,7 @@ def create_bucket(bucket_name, is_data_warehouse=False):
             },
         )
         if is_data_warehouse:
-            bucket.Tagging().put(Tagging={'TagSet': [{
-                'Key': 'buckettype',
-                'Value': 'datawarehouse',
-            }]})
+            _tag_bucket(bucket, {"buckettype": "datawarehouse"})
 
     except bucket.meta.client.exceptions.BucketAlreadyOwnedByYou:
         log.warning(f'Skipping creating Bucket {bucket_name}: Already exists')
@@ -238,6 +235,11 @@ def create_bucket(bucket_name, is_data_warehouse=False):
         },
     )
     return bucket
+
+
+def _tag_bucket(boto_bucket, tags):
+    tag_set = [{"Key": k, "Value": v} for k, v in tags.items()]
+    boto_bucket.Tagging().put(Tagging={"TagSet": tag_set})
 
 
 class S3AccessPolicy:

--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -237,6 +237,13 @@ def create_bucket(bucket_name, is_data_warehouse=False):
     return bucket
 
 
+def tag_bucket(bucket_name, tags):
+    """Add the given `tags` to the S3 bucket called `bucket_name`"""
+
+    bucket = boto3.resource("s3").Bucket(bucket_name)
+    _tag_bucket(bucket, tags)
+
+
 def _tag_bucket(boto_bucket, tags):
     """
     Tags the bucket with the given tags

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -126,6 +126,9 @@ class S3Bucket:
     def create(self):
         return aws.create_bucket(self.bucket.name, self.bucket.is_data_warehouse)
 
+    def mark_for_archival(self):
+        aws.tag_bucket(self.bucket.name, {"to-archive": "true"})
+
 
 class RoleGroup:
     """

--- a/controlpanel/api/models/s3bucket.py
+++ b/controlpanel/api/models/s3bucket.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
+from django.db.transaction import atomic
 from django_extensions.db.models import TimeStampedModel
 
 from controlpanel.api import cluster, validators
@@ -110,3 +111,8 @@ class S3Bucket(TimeStampedModel):
                 )
 
         return self
+
+    @atomic
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        cluster.S3Bucket(self).mark_for_archival()

--- a/tests/api/cluster/test_bucket.py
+++ b/tests/api/cluster/test_bucket.py
@@ -21,3 +21,7 @@ def test_arn(bucket):
 def test_create(aws, bucket):
     cluster.S3Bucket(bucket).create()
     aws.create_bucket.assert_called_with(bucket.name, False)
+
+def test_mark_for_archival(aws, bucket):
+    cluster.S3Bucket(bucket).mark_for_archival()
+    aws.tag_bucket.assert_called_with(bucket.name, {"to-archive": "true"})

--- a/tests/api/models/test_s3bucket.py
+++ b/tests/api/models/test_s3bucket.py
@@ -1,5 +1,6 @@
 from unittest.mock import call, patch
 
+from botocore.exceptions import ClientError
 from django.conf import settings
 from model_mommy import mommy
 import pytest
@@ -27,6 +28,20 @@ def test_delete_revokes_permissions(bucket, aws):
         call(apps3bucket.iam_role_name, bucket.arn),
         call(users3bucket.iam_role_name, bucket.arn),
     ])
+
+
+def test_delete_marks_bucket_for_archival(bucket, aws):
+    bucket.delete()
+    aws.tag_bucket.assert_called_once_with(bucket.name, {"to-archive": "true"})
+
+
+def test_delete_marks_bucket_for_archival_when_tag_bucket_fails(bucket, aws):
+    aws.tag_bucket.side_effect = ClientError({"error": "true"}, "TagFailed")
+    with pytest.raises(ClientError):
+        bucket.delete()
+
+    # The S3 bucket record is not deleted from the DB
+    assert S3Bucket.objects.filter(name=bucket.name).exists()
 
 
 def test_bucket_create(aws):

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -254,12 +254,16 @@ def test_create_bucket(logs_bucket, s3):
     aws.create_bucket(bucket_name, is_data_warehouse=True)
 
     bucket.load()
+    # Check logging
     assert bucket.Logging().logging_enabled['TargetBucket'] == settings.LOGS_BUCKET_NAME
+    # Check tagging
+    tags = { tag["Key"]: tag["Value"] for tag in bucket.Tagging().tag_set }
+    assert tags == {"buckettype": "datawarehouse"}
+
     # XXX moto 1.3.10 doesn't provide get_bucket_encryption(),
     # get_public_access_block() or get_bucket_tagging() yet
     # assert encrypted(bucket, alg='AES256')
     # assert public_access_blocked(bucket)
-    # assert tagged(bucket, buckettype=datawarehouse)
 
 
 def test_create_parameter(ssm):

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -258,7 +258,7 @@ def test_create_bucket(logs_bucket, s3):
     assert bucket.Logging().logging_enabled['TargetBucket'] == settings.LOGS_BUCKET_NAME
     # Check tagging
     tags = { tag["Key"]: tag["Value"] for tag in bucket.Tagging().tag_set }
-    assert tags == {"buckettype": "datawarehouse"}
+    assert tags["buckettype"] == "datawarehouse"
 
     # XXX moto 1.3.10 doesn't provide get_bucket_encryption(),
     # get_public_access_block() or get_bucket_tagging() yet

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -253,7 +253,6 @@ def test_create_bucket(logs_bucket, s3):
 
     aws.create_bucket(bucket_name, is_data_warehouse=True)
 
-    bucket.load()
     # Check logging
     assert bucket.Logging().logging_enabled['TargetBucket'] == settings.LOGS_BUCKET_NAME
     # Check tagging
@@ -264,6 +263,22 @@ def test_create_bucket(logs_bucket, s3):
     # get_public_access_block() or get_bucket_tagging() yet
     # assert encrypted(bucket, alg='AES256')
     # assert public_access_blocked(bucket)
+
+
+def test_tag_bucket(s3):
+    bucket_name = f"bucket-{id(MagicMock())}"
+    bucket = s3.Bucket(bucket_name)
+    bucket.create()
+
+    aws.tag_bucket(bucket_name, {"env": "test", "test-update": "old-value"})
+    aws.tag_bucket(bucket_name, {"test-update": "new-value", "to-archive": "true"})
+
+    tags = { tag["Key"]: tag["Value"] for tag in bucket.Tagging().tag_set }
+    assert tags == {
+        "env": "test",
+        "test-update": "new-value",
+        "to-archive": "true",
+    }
 
 
 def test_create_parameter(ssm):


### PR DESCRIPTION
### What

#### Before
When a bucket was deleted from the Control Panel only the record in the DB and IAM permissions to access it, was deleted. The S3 bucket and its data were left alone in AWS.

#### Now
Now when a bucket is deleted from the Control Panel is tagged as `to-archive=true` and also removed from the CP database.

The bucket's data will be archived/moved (by the [`buckets-archiver`](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/418) job) to a separate bucket and once the data is moved, the S3 bucket will be deleted.

### Why
Leaving "deleted" data behind forever is not great from a data retention perspective and also poses potential security problem if the same bucket is re-created in Control Panel by a separate user.

### How
Few things to note regarding the code changes:
- (in the `api.aws` module) we used to tag buckets on creation with the `buckettype=datawarehouse` tag (if they were datawarehouse buckets)
- this logic was moved into an helper function to be reused to tag on archival as well
- `api.aws.tag_bucket()` is part of the "public" interface of `api.aws` and it's higher level and receving the name of the bucket to tag and the tags
- `api.aws._tag_bucket()` is "private" and lower level, it receives a boto resource and performs the heavy lifting of translating the dictionary into the weird list of `{"Key": k, "Value": v}` format used by the AWS/boto Tagging API
- I've improved the existing tagging logic to merge new tags with existing ones to avoid losing old tags when tagging again. This makes `tag_bucket()` more predictable, it also means potentially we could write a migration to tag existing buckets with the standard buckets without losing the `buckettype` tag.
- the other noteworthy thing to notice is that the `controlpanel.api.models.s3bucket.S3Bucket#delete()` method is overridden to mark the bucket for archival on delete. This method is atomic as we want to rollback the DB transaction if for whatever reason the AWS request to tag the bucket failed - e.g. we don't want the bucket to be deleted from the DB but its data still hanging around because the bucket was not tagged as expected.
- existing tagging logic on creation wasn't tested, I've added a test for it

#### On the `cluster`/`models`/`aws` modules separation
The code affected by this PR is structured into 3 main modules with distinct responsibilities:
- `models` is responsible for persistence of data into the DB
- `cluster` is a more higher level module with the logic to propagate the CP changes into external systems (e.g. AWS/IAM/Kubernetes) - for example, when a bucket is created in the DB it also needs to be created in the AWS account
- `aws` is where the lower level logic to interact with AWS is, for example functions to create IAM roles, S3 buckets, tag buckets, etc...

### AWS permissions
[CP already has permissions to tag buckets](https://github.com/ministryofjustice/analytics-platform-ops/blob/master/infra/terraform/modules/control_panel_api/role.tf#L43) so this shouldn't require any additional permission.

**UPDATE**: ⚠️ I was testing this in `dev` and I actually need to add the `GetBucketTagging` permission as we were only able to update tags but we now read existing tags (error I'm getting: `An error occurred (AccessDenied) when calling the GetBucketTagging operation: Access Denied`)

### Related PRs/repositories
- `buckets-archiver`: https://github.com/ministryofjustice/analytics-platform-buckets-archiver
- `buckets-archiver` helm chart: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/418
- `buckets-archiver` helm chart config: https://github.com/ministryofjustice/analytics-platform-config/pull/190
- `buckets-archiver` S3 bucket/permissions: https://github.com/ministryofjustice/analytics-platform-ops/pull/311

### Ticket

Part of ticket: https://trello.com/c/6VdNPbzz