### PR TITLE
On app delete, uninstall helm release and delete Auth0 resources

### DIFF
--- a/controlpanel/api/auth0.py
+++ b/controlpanel/api/auth0.py
@@ -127,6 +127,13 @@ class AuthorizationAPI(APIClient):
 
         return groups[0]
 
+    def delete_group(self, group_name):
+        """Deletes a group from the authorization API"""
+
+        group = self.get_group(group_name)
+        if group:
+            self.request("DELETE", f'groups/{group["_id"]}')
+
     def get_group_members(self, group_name):
         group = self.get_group(group_name)
         if group:

--- a/controlpanel/api/auth0.py
+++ b/controlpanel/api/auth0.py
@@ -181,6 +181,9 @@ class AuthorizationAPI(APIClient):
 
     def add_group_members(self, group_name, emails, user_options={}):
         group_id = self.get_group_id(group_name)
+        if not group_id:
+            raise Auth0Error("Group for the app not found, was the app released?")
+
         mgmt = ManagementAPI()
         users = self.get_users()
         user_lookup = {user["email"]: user for user in users if "email" in user}

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from github import Github, GithubException
 
-from controlpanel.api import aws
+from controlpanel.api import auth0, aws
 from controlpanel.api.aws import iam_arn, s3_arn  # keep for tests
 from controlpanel.api.helm import HelmError, helm
 from controlpanel.api.kubernetes import KubernetesClient
@@ -97,6 +97,11 @@ class App:
 
     def revoke_bucket_access(self, bucket_arn):
         aws.revoke_bucket_access(self.iam_role_name, bucket_arn)
+
+    def delete_authz_group(self):
+        """Deletes the Auth0 authorization group for the app"""
+
+        auth0.AuthorizationAPI().delete_group(group_name=self.app.slug)
 
     @property
     def url(self):

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -89,18 +89,14 @@ class App:
     def create_iam_role(self):
         aws.create_app_role(self.app)
 
-    def delete_iam_role(self):
-        aws.delete_role(self.iam_role_name)
-
     def grant_bucket_access(self, bucket_arn, access_level, path_arns):
         aws.grant_bucket_access(self.iam_role_name, bucket_arn, access_level, path_arns)
 
     def revoke_bucket_access(self, bucket_arn):
         aws.revoke_bucket_access(self.iam_role_name, bucket_arn)
 
-    def delete_authz_group(self):
-        """Deletes the Auth0 authorization group for the app"""
-
+    def delete(self):
+        aws.delete_role(self.iam_role_name)
         auth0.AuthorizationAPI().delete_group(group_name=self.app.slug)
 
     @property

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -98,6 +98,7 @@ class App:
     def delete(self):
         aws.delete_role(self.iam_role_name)
         auth0.AuthorizationAPI().delete_group(group_name=self.app.slug)
+        helm.delete(True, self.app.release_name)
 
     @property
     def url(self):

--- a/controlpanel/api/models/app.py
+++ b/controlpanel/api/models/app.py
@@ -84,7 +84,10 @@ class App(TimeStampedModel):
         return self
 
     def delete(self, *args, **kwargs):
-        cluster.App(self).delete_iam_role()
+        cluster_app = cluster.App(self)
+        cluster_app.delete_iam_role()
+        cluster_app.delete_authz_group()
+
         super().delete(*args, **kwargs)
 
 

--- a/controlpanel/api/models/app.py
+++ b/controlpanel/api/models/app.py
@@ -84,9 +84,7 @@ class App(TimeStampedModel):
         return self
 
     def delete(self, *args, **kwargs):
-        cluster_app = cluster.App(self)
-        cluster_app.delete_iam_role()
-        cluster_app.delete_authz_group()
+        cluster.App(self).delete()
 
         super().delete(*args, **kwargs)
 

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -10,6 +10,12 @@ def app():
     return models.App(slug="slug", repo_url="https://gitpub.example.com/test-repo")
 
 
+@pytest.yield_fixture
+def authz():
+    with patch("controlpanel.api.cluster.auth0") as auth0:
+        yield auth0.AuthorizationAPI.return_value
+
+
 def test_app_create_iam_role(aws, app):
     cluster.App(app).create_iam_role()
     aws.create_app_role.assert_called_with(app)
@@ -18,6 +24,12 @@ def test_app_create_iam_role(aws, app):
 def test_app_delete_iam_role(aws, app):
     cluster.App(app).delete_iam_role()
     aws.delete_role.assert_called_with(app.iam_role_name)
+
+
+def test_app_delete_authz_group(app, authz):
+    cluster.App(app).delete_authz_group()
+
+    authz.delete_group.assert_called_with(group_name=app.slug)
 
 
 mock_ingress = MagicMock(name="Ingress")

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -21,14 +21,10 @@ def test_app_create_iam_role(aws, app):
     aws.create_app_role.assert_called_with(app)
 
 
-def test_app_delete_iam_role(aws, app):
-    cluster.App(app).delete_iam_role()
+def test_app_delete(aws, app, authz):
+    cluster.App(app).delete()
+
     aws.delete_role.assert_called_with(app.iam_role_name)
-
-
-def test_app_delete_authz_group(app, authz):
-    cluster.App(app).delete_authz_group()
-
     authz.delete_group.assert_called_with(group_name=app.slug)
 
 

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -21,11 +21,12 @@ def test_app_create_iam_role(aws, app):
     aws.create_app_role.assert_called_with(app)
 
 
-def test_app_delete(aws, app, authz):
+def test_app_delete(aws, app, authz, helm):
     cluster.App(app).delete()
 
     aws.delete_role.assert_called_with(app.iam_role_name)
     authz.delete_group.assert_called_with(group_name=app.slug)
+    helm.delete.assert_called_with(True, app.release_name)
 
 
 mock_ingress = MagicMock(name="Ingress")

--- a/tests/api/models/test_app.py
+++ b/tests/api/models/test_app.py
@@ -35,12 +35,16 @@ def test_aws_create_role_calls_service(aws):
 
 
 @pytest.mark.django_db
-def test_aws_delete_role_calls_service(aws):
+def test_delete_also_deletes_app_artifacts(aws):
     app = App.objects.create(repo_url="https://example.com/repo_name")
 
-    app.delete()
+    with patch("controlpanel.api.cluster.auth0") as auth0:
+        app.delete()
 
-    aws.delete_role.assert_called_with(app.iam_role_name)
+        aws.delete_role.assert_called_with(app.iam_role_name)
+
+        authz = auth0.AuthorizationAPI.return_value
+        authz.delete_group.assert_called_with(group_name=app.slug)
 
 
 @pytest.mark.django_db

--- a/tests/api/models/test_app.py
+++ b/tests/api/models/test_app.py
@@ -35,16 +35,14 @@ def test_aws_create_role_calls_service(aws):
 
 
 @pytest.mark.django_db
-def test_delete_also_deletes_app_artifacts(aws):
+def test_delete_also_deletes_app_artifacts():
     app = App.objects.create(repo_url="https://example.com/repo_name")
 
-    with patch("controlpanel.api.cluster.auth0") as auth0:
+    with patch("controlpanel.api.models.app.cluster") as cluster:
         app.delete()
 
-        aws.delete_role.assert_called_with(app.iam_role_name)
-
-        authz = auth0.AuthorizationAPI.return_value
-        authz.delete_group.assert_called_with(group_name=app.slug)
+        cluster.App.assert_called_with(app)
+        cluster.App.return_value.delete.assert_called()
 
 
 @pytest.mark.django_db

--- a/tests/api/permissions/test_app_permissions.py
+++ b/tests/api/permissions/test_app_permissions.py
@@ -98,6 +98,6 @@ def test_permission(client, app, users, view, user, expected_status):
     u = users[user]
     client.force_login(u)
 
-    with patch("controlpanel.api.views.models.App.delete") as _:
+    with patch("controlpanel.api.views.models.App.delete"):
         response = view(client, app)
         assert response.status_code == expected_status

--- a/tests/api/permissions/test_app_permissions.py
+++ b/tests/api/permissions/test_app_permissions.py
@@ -9,6 +9,7 @@ import pytest
 from rest_framework.reverse import reverse
 from rest_framework import status
 from rules import perm_exists, has_perm
+from unittest.mock import patch
 
 import controlpanel.api.rules
 
@@ -96,5 +97,7 @@ def test_authenticated_user_has_basic_perms(client, users):
 def test_permission(client, app, users, view, user, expected_status):
     u = users[user]
     client.force_login(u)
-    response = view(client, app)
-    assert response.status_code == expected_status
+
+    with patch("controlpanel.api.views.models.App.delete") as _:
+        response = view(client, app)
+        assert response.status_code == expected_status

--- a/tests/api/test_auth0.py
+++ b/tests/api/test_auth0.py
@@ -37,8 +37,8 @@ def groups(AuthorizationAPI):
             {
                 "total": 2,
                 "groups": [
-                    {"name": "foo"},
-                    {"name": "bar"},
+                    {"name": "foo", "_id": "foo-id"},
+                    {"name": "bar", "_id": "bar-id"},
                 ],
             },
         ]
@@ -55,10 +55,11 @@ def test_get_group_by_name(AuthorizationAPI, groups):
     AuthorizationAPI.request.assert_called_with("GET", "groups", params={})
     assert group["name"] == "foo"
 
+
 def test_get_group_id(AuthorizationAPI, groups):
-    group = AuthorizationAPI.get_group("foo")
+    group_id = AuthorizationAPI.get_group_id("foo")
     AuthorizationAPI.request.assert_called_with("GET", "groups", params={})
-    assert group["name"] == "foo"
+    assert group_id == "foo-id"
 
 @pytest.yield_fixture
 def get_group(AuthorizationAPI):

--- a/tests/api/test_auth0.py
+++ b/tests/api/test_auth0.py
@@ -55,16 +55,44 @@ def test_get_group_by_name(AuthorizationAPI, groups):
     AuthorizationAPI.request.assert_called_with("GET", "groups", params={})
     assert group["name"] == "foo"
 
+def test_get_group_id(AuthorizationAPI, groups):
+    group = AuthorizationAPI.get_group("foo")
+    AuthorizationAPI.request.assert_called_with("GET", "groups", params={})
+    assert group["name"] == "foo"
+
 @pytest.yield_fixture
 def get_group(AuthorizationAPI):
     with patch.object(AuthorizationAPI, "get_group") as get_group:
-        get_group.return_value = {"name": "foo", "_id": "foo_id"}
+        get_group.return_value = {
+            "_id": "foo_id",
+            "name": "foo",
+            "roles": ["role_1", "role_2"],
+        }
         yield get_group
 
 
-def test_delete_group(AuthorizationAPI, get_group):
+@pytest.yield_fixture
+def _delete_group_roles(AuthorizationAPI):
+    with patch.object(AuthorizationAPI, "_delete_group_roles") as _delete_group_roles:
+        yield _delete_group_roles
+
+
+def test_delete_group(AuthorizationAPI, get_group, _delete_group_roles):
     with patch.object(AuthorizationAPI, "request") as request:
         AuthorizationAPI.delete_group(group_name="foo")
 
         get_group.assert_called_with("foo")
+        _delete_group_roles.assert_called_with("foo_id", ["role_1", "role_2"])
         request.assert_called_with("DELETE", f"groups/foo_id")
+
+def test_delete_group_roles(AuthorizationAPI):
+    with patch.object(AuthorizationAPI, "request") as request:
+        group_id = "group_id_1"
+        role_ids = ["role_id_1", "role_id_2"]
+        AuthorizationAPI._delete_group_roles(group_id, role_ids)
+
+        request.assert_called_with(
+            "DELETE",
+            f"groups/{group_id}/roles",
+            json=role_ids,
+        )

--- a/tests/api/test_auth0.py
+++ b/tests/api/test_auth0.py
@@ -54,3 +54,17 @@ def test_get_group_by_name(AuthorizationAPI, groups):
     group = AuthorizationAPI.get_group("foo")
     AuthorizationAPI.request.assert_called_with("GET", "groups", params={})
     assert group["name"] == "foo"
+
+@pytest.yield_fixture
+def get_group(AuthorizationAPI):
+    with patch.object(AuthorizationAPI, "get_group") as get_group:
+        get_group.return_value = {"name": "foo", "_id": "foo_id"}
+        yield get_group
+
+
+def test_delete_group(AuthorizationAPI, get_group):
+    with patch.object(AuthorizationAPI, "request") as request:
+        AuthorizationAPI.delete_group(group_name="foo")
+
+        get_group.assert_called_with("foo")
+        request.assert_called_with("DELETE", f"groups/foo_id")

--- a/tests/api/views/test_app.py
+++ b/tests/api/views/test_app.py
@@ -3,6 +3,7 @@ from model_mommy import mommy
 import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
+from unittest.mock import patch
 
 from controlpanel.api.models import App
 
@@ -87,10 +88,17 @@ def test_detail(client, app):
     assert set(userapp['user']) == expected_fields
 
 
-def test_delete(client, app, aws):
+@pytest.yield_fixture
+def authz():
+    with patch("controlpanel.api.cluster.auth0.AuthorizationAPI") as authz:
+        yield authz.return_value
+
+
+def test_delete(client, app, aws, authz):
     response = client.delete(reverse('app-detail', (app.id,)))
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
+    authz.delete_group.assert_called_with(group_name=app.slug)
     aws.delete_role.assert_called_with(app.iam_role_name)
 
     response = client.get(reverse('app-detail', (app.id,)))

--- a/tests/api/views/test_app.py
+++ b/tests/api/views/test_app.py
@@ -91,7 +91,7 @@ def test_detail(client, app):
 @pytest.yield_fixture
 def authz():
     with patch("controlpanel.api.cluster.auth0.AuthorizationAPI") as authz:
-        yield authz.return_value
+        yield authz()
 
 
 def test_delete(client, app, aws, authz):


### PR DESCRIPTION
### What

Currently, when an app is deleted, in addition to deleting its record in the DB we also delete its IAM role (which means any running pod for the app will no longer have any permissions).

In addition to this we now also delete its Auth0 Authorization group/roles/permissions (see below) and also the helm release (see below)


### Why
As the number of applications grows there may be applications that are no more needed and these can be deleted. Free up these related resources not only reduces clutter but also helps with the load on the k8s cluster. 


### Auth0 Authorization
We're using Auth0's Authorization extension to keep track of which customers can access an app (our users' users).
Each application has its own Auth0 group (roughly named after the repository name), each group has a role (`app-viewer`) and each role has a permission (`view:app`). 

This groups/roles/permissions relationships are very flexible and potentially a group may have more than one role associated with it - and similarly a role may have multiple permissions (the usual RBAC stuff)

However in our use-case each app has only a single group/role/permission so it's safe to delete these roles/permissions are they're not shared among several apps' groups.

These Auth0 resources are now deleted.

One important thing I've noticed while developing/testing this is that delete a role or permission would fail with a `400 BAD REQUEST` when there are groups/roles associated with this role/permission (unfortunately this was not documented which made building this more "fun").
This is the reason why deletion starts with the group, continues with the roles and finally deletes the permissions (basically try to delete the role before the group or try to delete the permission before the role would fail).

FYI: There is some documentation on this extension's API here: https://auth0.com/docs/api/authorization-extension


### helm release
When a release for an app is created Concourse will deploy an app by releasing the [`webapp`](https://github.com/ministryofjustice/analytics-platform-helm-charts/tree/master/charts/webapp) helm chart. 
As part of this PR the helm release is now uninstalled (which means the app will not be 
available anymore)


### Ticket
https://trello.com/c/nAIlHeAO