### PR TITLE
Disable app logs viewing

### DIFF
--- a/controlpanel/api/elasticsearch.py
+++ b/controlpanel/api/elasticsearch.py
@@ -27,6 +27,11 @@ def bucket_hits_aggregation(bucket_name, num_days=None):
 
 
 def app_logs(app, num_hours=None):
+    # Disable logs for noisy app ("covid19-early-release")
+    # to prevent its App details page to timeout
+    if app.id == 171:
+        return []
+
     if not num_hours:
         num_hours = 1
 

--- a/controlpanel/frontend/static/components/app-logs/macro.html
+++ b/controlpanel/frontend/static/components/app-logs/macro.html
@@ -1,8 +1,11 @@
 {% macro app_logs(app, kibana_base_url) %}
   <div class="app-logs">
-    <pre>{% for entry in app.get_logs() -%}
+    <pre>{# for entry in app.get_logs() #}
+         {% for entry in [] -%}
 <span class="timestamp">{{ entry.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}:</span> <span class="message">{{ entry.message }}</span>
-{% endfor %}</pre>
+{% endfor %}
+Logs viewing currently disabled in Control Panel. See logs by following link below.
+</pre>
   </div>
   <p class="govuk-body">
     <a href="{{ kibana_link(app, kibana_base_url) }}">View full logs</a>

--- a/controlpanel/frontend/static/components/app-logs/macro.html
+++ b/controlpanel/frontend/static/components/app-logs/macro.html
@@ -1,11 +1,8 @@
 {% macro app_logs(app, kibana_base_url) %}
   <div class="app-logs">
-    <pre>{# for entry in app.get_logs() #}
-         {% for entry in [] -%}
+    <pre>{% for entry in app.get_logs() -%}
 <span class="timestamp">{{ entry.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}:</span> <span class="message">{{ entry.message }}</span>
-{% endfor %}
-Logs viewing currently disabled in Control Panel. See logs by following link below.
-</pre>
+{% endfor %}</pre>
   </div>
   <p class="govuk-body">
     <a href="{{ kibana_link(app, kibana_base_url) }}">View full logs</a>


### PR DESCRIPTION
### Why
View an app details was timing out because of the big amount of
logs produced.

### What
This is a temporary/short-term workaround which disable the printing
of these ElasticSearch logs.

Instead the following message is shown to try avoid confusing the user:

> Logs viewing currently disabled in Control Panel. See logs by following link below.

### Ticket
https://trello.com/c/cNoHc6pf