### PR TITLE
Merging this PR will allow app admins to grant and remove app admin permission to other users.

### DIFF
--- a/controlpanel/api/rules.py
+++ b/controlpanel/api/rules.py
@@ -29,6 +29,9 @@ def is_app_admin(user, obj):
     if obj is None:
         return True
 
+    if is_superuser(user):
+        return True
+
     if isinstance(obj, App):
         return user in obj.admins
 
@@ -49,8 +52,8 @@ add_perm('api.update_app', is_authenticated & is_superuser)
 add_perm('api.destroy_app', is_authenticated & is_superuser)
 add_perm('api.add_app_customer', is_authenticated & is_app_admin)
 add_perm('api.remove_app_customer', is_authenticated & is_app_admin)
-add_perm('api.add_app_admin', is_authenticated & is_superuser)
-add_perm('api.revoke_app_admin', is_authenticated & is_superuser)
+add_perm('api.add_app_admin', is_authenticated & is_app_admin)
+add_perm('api.revoke_app_admin', is_authenticated & is_app_admin)
 add_perm('api.add_app_bucket', is_authenticated & is_superuser)
 add_perm('api.remove_app_bucket', is_authenticated & is_superuser)
 add_perm('api.view_app_logs', is_authenticated & is_app_admin)

--- a/controlpanel/frontend/static/components/app-logs/macro.html
+++ b/controlpanel/frontend/static/components/app-logs/macro.html
@@ -1,8 +1,11 @@
 {% macro app_logs(app, kibana_base_url) %}
   <div class="app-logs">
-    <pre>{% for entry in app.get_logs() -%}
+    <pre>{# for entry in app.get_logs() #}
+         {% for entry in [] -%}
 <span class="timestamp">{{ entry.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}:</span> <span class="message">{{ entry.message }}</span>
-{% endfor %}</pre>
+{% endfor %}
+Logs viewing currently disabled in Control Panel. See logs by following link below.
+</pre>
   </div>
   <p class="govuk-body">
     <a href="{{ kibana_link(app, kibana_base_url) }}">View full logs</a>

--- a/controlpanel/frontend/static/components/app-logs/macro.html
+++ b/controlpanel/frontend/static/components/app-logs/macro.html
@@ -1,11 +1,8 @@
 {% macro app_logs(app, kibana_base_url) %}
   <div class="app-logs">
-    <pre>{# for entry in app.get_logs() #}
-         {% for entry in [] -%}
+    <pre>{% for entry in app.get_logs() -%}
 <span class="timestamp">{{ entry.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}:</span> <span class="message">{{ entry.message }}</span>
-{% endfor %}
-Logs viewing currently disabled in Control Panel. See logs by following link below.
-</pre>
+{% endfor %}</pre>
   </div>
   <p class="govuk-body">
     <a href="{{ kibana_link(app, kibana_base_url) }}">View full logs</a>

--- a/tests/frontend/views/test_app.py
+++ b/tests/frontend/views/test_app.py
@@ -166,11 +166,11 @@ def connect_bucket(client, app, _, s3buckets, *args):
         (delete, 'normal_user', status.HTTP_403_FORBIDDEN),
 
         (add_admin, 'superuser', status.HTTP_302_FOUND),
-        (add_admin, 'app_admin', status.HTTP_403_FORBIDDEN),
+        (add_admin, 'app_admin', status.HTTP_302_FOUND),
         (add_admin, 'normal_user', status.HTTP_403_FORBIDDEN),
 
         (revoke_admin, 'superuser', status.HTTP_302_FOUND),
-        (revoke_admin, 'app_admin', status.HTTP_403_FORBIDDEN),
+        (revoke_admin, 'app_admin', status.HTTP_302_FOUND),
         (revoke_admin, 'normal_user', status.HTTP_403_FORBIDDEN),
 
         (add_customers, 'superuser', status.HTTP_302_FOUND),


### PR DESCRIPTION
## What

Describe what you have changed and *why*.

This is an initial fix for [this Trello ticket](https://trello.com/c/jxUgm3IP/570-app-admins-cant-grant-admin-permissions-to-other-users). Please see my questions on that ticket for more context, pasted below for convenience:

> Do we really want App admins to have this power? Imagine the following situation:
>
>  *  Alice is an app admin of project X.
>  *  Bob wants to become an app admin of project Y.
>  *  Alice, who has nothing to do with project Y, gives Bob the permission he needs because they're buddies. Bob is elevated to the "app admin" set of users.
>  *  Bob, for accidental or other reasons, gives Eve admin privileges to project X.
>  *  Alice wonders who on earth Eve is and what she's doing with her app.
>
> How can Alice stop Bob from giving accidental privileges to Eve..? By having the superuser group
> sitting above the level of app admins, with only super users able to elevate regular users to the 
> role of app admins, you avoid the (perhaps inevitable) result of everyone just elevating everyone 
> else to the role of app admin because it's just more convenient to work with those sets of privileges.
>
> Does this make sense? Also, I'm painfully aware that I'm probably missing something here. :-)

I've ensured that app-admins can also undo their action, by giving them the additional permission to remove app admin from a user. Please shout if I've assume the wrong thing here.

Finally, if the object passed into the  predicate function is None then the user was assumed to be a member of the `app_admin` group for any app (the default was to return `True`). While I realise the `obj` probably won't be `None`, this felt like the wrong default behaviour. We're essentially saying, if we don't have a reference to the app (as an `App`, `AppS3Bucket` etc) then we just assume the user **IS** an app admin. Why do we do this? My initial reaction is that it's a bit "generous". Surely, if we can't determine the user is associated with anything, then we should return `False`, as I've changed things in this PR.

Feels like I'm poking at something for which I should know more context given the above behaviour.

## How to review

I'm unsure, since I don't have a working dev environment. I'll update once this is fixed. However, I can't find any unit tests in our code which reference this sort of behaviour or the named permissions I've updated in the PR. Some guidance would be welcome. #newstarter :slightly_smiling_face: 
