### PR TITLE
Dockerfile: unpin `ca-certificates` to avoid problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /home/controlpanel
 # install build dependencies
 RUN apk add --no-cache \
         build-base=0.5-r1 \
-        ca-certificates=20190108-r0 \
+        ca-certificates \
         libffi-dev=3.2.1-r6 \
         python3-dev=3.7.5-r1 \
         libressl-dev=2.7.5-r0 \


### PR DESCRIPTION
### What
Use latest stable version of alpine's `ca-certificates` package in `Dockerfile`.

### Why
Alpine released a new version of this package which caused a
docker build problem because of the fact this package was pinned in
our `Dockerfile`:

```
ERROR: unsatisfiable constraints:
  ca-certificates-20191127-r0:
    breaks: world[ca-certificates=20190108-r0]
```

There shouldn't be any specific reason to not use the latest version
of `ca-certificates` anyway.

### How to review

Check that tests and quay.io builds are fine.

### Ticket
https://trello.com/c/M1mhemDt