### PR TITLE
Uninstall old RStudio (tools) release before helm upgrade

### DIFF
--- a/tests/api/models/test_tool.py
+++ b/tests/api/models/test_tool.py
@@ -25,11 +25,19 @@ def test_deploy_for_generic(helm, token_hex, tool, users):
         cookie_secret_proxy,
         cookie_secret_tool
     ]
-
     user = users['normal_user']
+
+    # simulate release with old naming scheme installed
+    old_release_name = f"{user.username}-{tool.chart_name}"
+    helm.list_releases.return_value = [old_release_name]
+
     tool_deployment = ToolDeployment(tool, user)
     tool_deployment.save()
 
+    # uninstall tool with old naming scheme
+    helm.delete.assert_called_with(True, old_release_name)
+
+    # install new release
     helm.upgrade_release.assert_called_with(
         f'{tool.chart_name}-{user.slug}',
         f'mojanalytics/{tool.chart_name}',


### PR DESCRIPTION
### What
Fix problem where some users with an old RStudio instance fail to upgrade.

Uninstall old, "badly"-named, release of a tool before installing/upgrading the new one.

Tools releases are now `TOOL-USERNAME` while old RStudio instances were installed on `USERNAME-rstudio`, causing problem below.

### Why
Due to the change in the release naming scheme of RStudio, old users
can't upgrade their RStudio from the Control Panel because of an
underlying helm error.

[This can be manually resolved](https://github.com/ministryofjustice/analytics-platform/wiki/Deploying-R-Studio#2-release-problem) by running `helm delete --purge` on
old release but it's annoying from a support and UX standpoint.

After this change the CP will check if there is a release with
the old naming scheme (e.g. `USERNAME-rstudio` instead of the correct
`rstudio-USERNAME` name) and delete it before installing the new release.


Ticket: https://trello.com/c/llxQG72F
