### PR TITLE
Avoid a 500 error if the app admin user has no Auth0 id.

### DIFF
--- a/controlpanel/frontend/jinja2/webapp-detail.html
+++ b/controlpanel/frontend/jinja2/webapp-detail.html
@@ -156,10 +156,14 @@
     {% for user in app_admins %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
+        {% if user.auth0_id %}
           <a class="{% if request.user.auth0_id == user.auth0_id %}highlight-current{% endif %}"
               href="{{ url('manage-user', kwargs={ "pk": user.auth0_id }) }}">
             {{ user_name(user) }}
           </a>
+        {% else %}
+          {{ user_name(user) }}
+        {% endif %}
         </td>
         {% if request.user.has_perm('api.revoke_app_admin', app) %}
         <td class="govuk-table__cell align-right">


### PR DESCRIPTION
## What

This afternoon we had reports that some users were experiencing 500 errors from the application. A look at the logs turned up this error:

```
cpanel-5db49bc644-qwdjr backend   File "/home/controlpanel/controlpanel/frontend/jinja2/webapp-detail.html", line 160, in block "content"
cpanel-5db49bc644-qwdjr backend     href="{{ url('manage-user', kwargs={ "pk": user.auth0_id }) }}">
cpanel-5db49bc644-qwdjr backend   File "/usr/lib/python3.7/site-packages/django/urls/base.py", line 87, in reverse
cpanel-5db49bc644-qwdjr backend     return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
cpanel-5db49bc644-qwdjr backend   File "/usr/lib/python3.7/site-packages/django/urls/resolvers.py", line 677, in _reverse_with_prefix
cpanel-5db49bc644-qwdjr backend     raise NoReverseMatch(msg)
cpanel-5db49bc644-qwdjr backend django.urls.exceptions.NoReverseMatch: Reverse for 'manage-user' with keyword arguments '{'pk': ''}' not found. 1 pattern(s) tried: ['users/(?P<pk>[^/]+)/$']
```

It turns out that some users added as app admins have not, perhaps, already logged into Auth0, so their Auth0 id is `None`. Hence the URL created in the template resolves to `users/` rather than `users/1234`. This is what leads to the `NoReverseMatch` exception.

This PR simply adds a guard around the block of could that could produce such a URL and ensures the username is displayed, but since there's not (yet) an Auth0 id associated with the user, you can't click on their name to edit their details.

## How to review

This is a minor change of an added conditional. We'd need to try to re-create a problem user in the `dev` environment before pushing to `alpha`. This can be done as part of the review process.

cc/@andylightfoot
