### PR TITLE
Show deployed tools versions

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -20,6 +20,7 @@ TOOL_DEPLOY_FAILED = 'Failed'
 TOOL_IDLED = 'Idled'
 TOOL_NOT_DEPLOYED = 'Not deployed'
 TOOL_READY = 'Ready'
+TOOL_RESTARTING = 'Restarting'
 TOOL_UPGRADED = 'Upgraded'
 TOOL_STATUS_UNKNOWN = 'Unknown'
 

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -345,6 +345,23 @@ class ToolDeployment():
 
         return deployments[0]
 
+
+    def get_installed_chart_version(self, id_token):
+        """
+        Returns the installed helm chart version of the tool
+
+        This is extracted from the `chart` label in the corresponding
+        `Deployment`.
+        """
+
+        try:
+            deployment = self.get_deployment(id_token)
+            _, chart_version = deployment.metadata.labels["chart"].rsplit("-", 1)
+            return chart_version
+        except ObjectDoesNotExist:
+            return None
+
+
     def get_status(self, id_token):
         try:
             deployment = self.get_deployment(id_token)

--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -19,7 +19,8 @@ class HelmError(APIException):
 
 class Helm(object):
 
-    def _execute(self, *args, check=True, **kwargs):
+    @classmethod
+    def _execute(cls, *args, check=True, **kwargs):
         should_wait = False
         if 'timeout' in kwargs:
             should_wait = True
@@ -67,11 +68,12 @@ class Helm(object):
 
         return proc
 
-    def update_repositories(self, *args):
-        self._execute("repo", "update", timeout=None)
+    @classmethod
+    def update_repositories(cls):
+        cls._execute("repo", "update", timeout=None)
 
     def upgrade_release(self, release, chart, *args):
-        self.update_repositories()
+        self.__class__.update_repositories()
 
         return self._execute(
             "upgrade", "--install", "--wait", release, chart, *args,
@@ -81,11 +83,11 @@ class Helm(object):
         default_args = []
         if purge:
             default_args.append("--purge")
-        self._execute("delete", *default_args, *args)
+        self.__class__._execute("delete", *default_args, *args)
 
     def list_releases(self, *args):
         # TODO - use --max and --offset to paginate through releases
-        proc = self._execute("list", "-q", "--max=1024", *args, timeout=None)
+        proc = self.__class__._execute("list", "-q", "--max=1024", *args, timeout=None)
         return proc.stdout.read().split()
 
 

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -50,14 +50,12 @@ class ToolDeploymentManager:
         return tool_deployment
 
     def filter(self, **kwargs):
-        deployed_versions = {}
         user = kwargs["user"]
         id_token = kwargs["id_token"]
         filter = Q(chart_name=None)  # Always False
         deployments = cluster.ToolDeployment.get_deployments(user, id_token)
         for deployment in deployments:
             chart_name, version = deployment.metadata.labels["chart"].rsplit("-", 1)
-            deployed_versions[chart_name] = version
             filter = filter | (
                 Q(chart_name=chart_name)
                 # & Q(version=version)
@@ -66,8 +64,7 @@ class ToolDeploymentManager:
         tools = Tool.objects.filter(filter)
         results = []
         for tool in tools:
-            deployed_chart_version = deployed_versions.get(tool.chart_name, None)
-            tool_deployment = ToolDeployment(tool, user, deployed_chart_version)
+            tool_deployment = ToolDeployment(tool, user)
             results.append(tool_deployment)
         return results
 
@@ -83,19 +80,17 @@ class ToolDeployment:
 
     objects = ToolDeploymentManager()
 
-    def __init__(self, tool, user, deployed_chart_version=None):
+    def __init__(self, tool, user):
         self._subprocess = None
         self.tool = tool
         self.user = user
-        self.deployed_chart_version = deployed_chart_version
 
     def __repr__(self):
         return f'<ToolDeployment: {self.tool!r} {self.user!r}>'
 
-    @property
-    def deployed_tool_version(self):
+    def get_installed_app_version(self, id_token):
         """
-        Returns the version of the tool deployed to the user
+        Returns the version of the deployed tool
 
         NOTE: This is the version coming from the helm
         chart `appVersion` field, **not** the version
@@ -114,18 +109,34 @@ class ToolDeployment:
         in the helm repository index.
         """
 
-        if self.deployed_chart_version:
-            chart_name = self.tool.chart_name
-            chart_info = HelmRepository.get_chart_info(chart_name)
+        td = cluster.ToolDeployment(self.user, self.tool)
+        chart_version = td.get_installed_chart_version(id_token)
+        if chart_version:
+            chart_info = HelmRepository.get_chart_info(self.tool.chart_name)
 
-            if self.deployed_chart_version in chart_info:
-                return chart_info[self.deployed_chart_version].app_version
+            version_info = chart_info.get(chart_version, None)
+            if version_info:
+                return version_info.app_version
 
         return None
 
-    @property
-    def outdated(self):
-        return self.tool.version != self.deployed_chart_version
+
+    def outdated(self, id_token):
+        """
+        Returns true if the tool helm chart version is old
+
+        NOTE: This is simple/naive at the moment and it returns true if
+        the installed chart for the tool has a different version
+        than the one in the corresponding Tool record.
+        """
+
+        td = cluster.ToolDeployment(self.user, self.tool)
+        chart_version = td.get_installed_chart_version(id_token)
+
+        if chart_version:
+            return self.tool.version != chart_version
+
+        return False
 
     def delete(self, id_token):
         """

--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -16,6 +16,7 @@ from controlpanel.api.cluster import (
     TOOL_DEPLOY_FAILED,
     TOOL_IDLED,
     TOOL_READY,
+    TOOL_RESTARTING,
     TOOL_UPGRADED,
 )
 from controlpanel.api.models import Tool, ToolDeployment, User
@@ -146,7 +147,7 @@ class BackgroundTaskConsumer(SyncConsumer):
         id_token = message["id_token"]
 
         tool_deployment = ToolDeployment(tool, user)
-        update_tool_status(tool_deployment, id_token, "Restarting")
+        update_tool_status(tool_deployment, id_token, TOOL_RESTARTING)
 
         tool_deployment.restart(id_token=id_token)
 

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -24,8 +24,8 @@
       <td class="govuk-table__cell">
         {{ tool.name }}
         {% if deployment %}
-          <br><small>
-            {{ deployment.deployed_tool_version or "Unknown" }}
+          <br><small class="tool-app-version">
+            {{ deployment.get_installed_app_version(id_token) or "Unknown" }}
           </small>
         {% endif %}
       </td>
@@ -58,7 +58,7 @@
           {# <input type="hidden" value="{{ tool.version }}" name="version"> #}
           <button class="govuk-button govuk-button--secondary right">Deploy</button>
         </form>
-        {% if deployment.outdated %}
+        {% if deployment.outdated(id_token) %}
           <form action="{{ url('upgrade-tool', kwargs={"name": tool.chart_name}) }}"
                 class="background-submit tool-action {% if not deployment %} govuk-visually-hidden {% endif %}"
                 data-action-name="upgrade"

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -23,7 +23,11 @@
     <tr class="govuk-table__row sse-listener tool-status" data-tool-name="{{ tool.chart_name }}">
       <td class="govuk-table__cell">
         {{ tool.name }}
-        {# <br><small>{{ tool.description }}</small> #}
+        {% if deployment %}
+          <br><small>
+            {{ deployment.deployed_tool_version or "Unknown" }}
+          </small>
+        {% endif %}
       </td>
       <td class="govuk-table__cell">
         <div class="tool-status-label">

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -23,11 +23,12 @@
     <tr class="govuk-table__row sse-listener tool-status" data-tool-name="{{ tool.chart_name }}">
       <td class="govuk-table__cell">
         {{ tool.name }}
-        {% if deployment %}
-          <br><small class="tool-app-version">
+        <br>
+        <small class="tool-app-version">
+          {% if deployment %}
             {{ deployment.get_installed_app_version(id_token) or "Unknown" }}
-          </small>
-        {% endif %}
+          {% endif %}
+        </small>
       </td>
       <td class="govuk-table__cell">
         <div class="tool-status-label">
@@ -58,7 +59,7 @@
           {# <input type="hidden" value="{{ tool.version }}" name="version"> #}
           <button class="govuk-button govuk-button--secondary right">Deploy</button>
         </form>
-        {% if deployment.outdated(id_token) %}
+        {% if deployment and deployment.outdated(id_token) %}
           <form action="{{ url('upgrade-tool', kwargs={"name": tool.chart_name}) }}"
                 class="background-submit tool-action {% if not deployment %} govuk-visually-hidden {% endif %}"
                 data-action-name="upgrade"

--- a/controlpanel/frontend/static/javascripts/modules/tool-status.js
+++ b/controlpanel/frontend/static/javascripts/modules/tool-status.js
@@ -4,6 +4,7 @@ moj.Modules.toolStatus = {
   hidden: "govuk-visually-hidden",
   listenerClass: ".tool-status",
   statusLabelClass: ".tool-status-label",
+  toolAppVersionClass: ".tool-app-version",
 
   init() {
     const toolStatusListeners = document.querySelectorAll(this.listenerClass);
@@ -39,15 +40,23 @@ moj.Modules.toolStatus = {
         case 'READY':
         case 'IDLED':
           this.showActions(listener, ['open', 'restart', 'upgrade', 'remove']);
+          this.updateAppVersion(listener, data.appVersion);
           break;
         case 'UPGRADED':
           this.showActions(listener, ['open']);
+          this.updateAppVersion(listener, data.appVersion);
           break;
         case 'FAILED':
           this.showActions(listener, ['restart', 'upgrade', 'remove']);
           break;
       }
     };
+  },
+
+  updateAppVersion(listener, newAppVersion) {
+    if (newAppVersion) {
+      listener.querySelector(this.toolAppVersionClass).innerText = newAppVersion;
+    }
   },
 
   showActions(listener, action_names) {

--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -29,7 +29,7 @@ class ToolList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
         user = self.request.user
         id_token = user.get_id_token()
 
-        deployments = ToolDeployment.objects.filter(
+        tool_deployments = ToolDeployment.objects.filter(
             user=user,
             id_token=id_token,
         )
@@ -37,9 +37,10 @@ class ToolList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
         context = super().get_context_data(*args, **kwargs)
         context["id_token"] = id_token
         context["deployed_tools"] = {
-            deployment.tool: deployment
-            for deployment in deployments
+            tool_deployment.tool: tool_deployment
+            for tool_deployment in tool_deployments
         }
+
         return context
 
 

--- a/tests/api/cluster/test_tool_deployment.py
+++ b/tests/api/cluster/test_tool_deployment.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock, patch
+
+from controlpanel.api.cluster import ToolDeployment
+from controlpanel.api.models import Tool, User
+
+
+def test_get_installed_chart_version():
+    user = User(username="test-user")
+    tool = Tool(chart_name="test-chart")
+    id_token = "dummy"
+
+    installed_chart_version = "1.2.3"
+
+    td = ToolDeployment(user, tool)
+
+    deploy_metadata = Mock("k8s Deployment - metadata")
+    deploy_metadata.labels = {
+        "chart": f"{tool.chart_name}-{installed_chart_version}"
+    }
+    deploy = Mock("k8s Deployment", metadata=deploy_metadata)
+
+    with patch("controlpanel.api.cluster.ToolDeployment.get_deployment") as get_deployment:
+        get_deployment.return_value = deploy
+        assert td.get_installed_chart_version(id_token) == installed_chart_version
+        get_deployment.assert_called_with(id_token)

--- a/tests/api/fixtures/helm_mojanalytics_index.py
+++ b/tests/api/fixtures/helm_mojanalytics_index.py
@@ -1,0 +1,37 @@
+# Python dictionary version (excerpt) of what you'd find in the helm
+# repository index YAML file at
+# $(helm home)/repository/cache/mojanalytics-index.yaml
+#
+# used for testing the `helm` module
+#
+# (see `helm home --help`)
+HELM_MOJANALYTICS_INDEX = {
+    "apiVersion": "v1",
+    "entries": {
+        "rstudio": [
+            {
+                "apiVersion": "v1",
+                "appVersion": "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 10",
+                "created": "2020-05-18T10:28:14.187538013Z",
+                "description": "RStudio with Auth0 authentication proxy",
+                "digest": "283e735476479425a76634840d73024f83e9d0bed7f009cb18b87916a3b84741",
+                "name": "rstudio",
+                "urls": [
+                    "http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com/rstudio-2.2.5.tgz",
+                ],
+                "version": "2.2.5",
+            },
+            {
+                "apiVersion": "v1",
+                "created": "2018-05-18T16:05:37.748243984Z",
+                "description": "A Helm chart for RStudio",
+                "digest": "a2df2dfe7aa0d04a6d7de175b134cc2e1e3e1b930f8b2acfdbda52fb396a4329",
+                "name": "rstudio",
+                "urls": [
+                    "https://ministryofjustice.github.io/analytics-platform-helm-charts/charts/rstudio-1.0.0.tgz",
+                ],
+                "version": "1.0.0",
+            },
+        ],
+    },
+}

--- a/tests/api/models/test_tool.py
+++ b/tests/api/models/test_tool.py
@@ -48,3 +48,65 @@ def test_deploy_for_generic(helm, token_hex, tool, users):
         '--set', f'aws.iamRole={user.iam_role_name}',
         '--set', f'toolsDomain={settings.TOOLS_DOMAIN}',
     )
+
+
+@pytest.yield_fixture
+def cluster():
+    with patch("controlpanel.api.models.tool.cluster") as cluster:
+        yield cluster
+
+
+@pytest.mark.parametrize(
+    "chart_version, expected_outdated",
+    [
+        (None, False),
+        ("0.0.1", True),
+        ("1.0.0", False),
+    ],
+    ids=[
+        "no-chart-version",
+        "old-chart-version",
+        "up-to-date-chart-version",
+    ],
+)
+def test_tool_deployment_outdated(cluster, chart_version, expected_outdated):
+    tool = Tool(chart_name="test-tool", version="1.0.0")
+    user = User(username="test-user")
+    td = ToolDeployment(tool, user)
+    id_token = "dummy"
+
+    cluster_td = cluster.ToolDeployment.return_value
+    cluster_td.get_installed_chart_version.return_value = chart_version
+
+    assert td.outdated(id_token) == expected_outdated
+    cluster.ToolDeployment.assert_called_with(user, tool)
+    cluster_td.get_installed_chart_version.assert_called_with(id_token)
+
+
+
+
+@pytest.mark.parametrize(
+    "chart_version, expected_app_version",
+    [
+        (None, None),
+        ("1.0.0", None),
+        ("2.2.5", "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 10"),
+    ],
+    ids=[
+        "no-chart-installed",
+        "old-chart-version",
+        "new-chart-version",
+    ],
+)
+def test_tool_deployment_get_installed_app_version(helm_repository_index, cluster, chart_version, expected_app_version):
+    tool = Tool(chart_name="rstudio")
+    user = User(username="test-user")
+    td = ToolDeployment(tool, user)
+    id_token = "dummy"
+
+    cluster_td = cluster.ToolDeployment.return_value
+    cluster_td.get_installed_chart_version.return_value = chart_version
+
+    assert td.get_installed_app_version(id_token) == expected_app_version
+    cluster.ToolDeployment.assert_called_with(user, tool)
+    cluster_td.get_installed_chart_version.assert_called_with(id_token)

--- a/tests/api/test_helm.py
+++ b/tests/api/test_helm.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timedelta
+import pytest
+from unittest.mock import mock_open, patch
+
+import yaml
+
+from controlpanel.api.helm import (
+    Chart,
+    HelmRepository,
+)
+from tests.api.fixtures.helm_mojanalytics_index import HELM_MOJANALYTICS_INDEX
+
+
+def setup_function(fn):
+    print("Resetting HelmRepository._updated_at ...")
+    HelmRepository._updated_at = None
+
+
+@pytest.fixture
+def helm_repository_index():
+    content = yaml.dump(HELM_MOJANALYTICS_INDEX)
+    return mock_open(read_data=content)
+
+
+def test_chart_app_version():
+    app_version = "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 10"
+    chart = Chart(
+        "rstudio",
+        "RStudio with Auth0 authentication proxy",
+        "2.2.5",
+        app_version,
+    )
+
+    assert chart.app_version == app_version
+
+
+def test_helm_repository_update_when_recently_updated(helm_repository_index):
+    HelmRepository._updated_at = datetime.utcnow()
+
+    with patch("controlpanel.api.helm.Helm") as helm:
+        HelmRepository.update(force=False)
+        helm.execute.assert_not_called()
+
+
+def test_helm_repository_update_when_cache_old(helm_repository_index):
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    HelmRepository._updated_at = yesterday
+
+    with patch("controlpanel.api.helm.Helm") as helm:
+        HelmRepository.update(force=False)
+        helm.execute.assert_called_once()
+
+
+def test_helm_repository_chart_info_when_chart_not_found(helm_repository_index):
+    with patch("controlpanel.api.helm.open", helm_repository_index):
+        info = HelmRepository.get_chart_info("notfound")
+        assert info == {}
+
+
+def test_helm_repository_chart_info_when_chart_found(helm_repository_index):
+    with patch("controlpanel.api.helm.open", helm_repository_index):
+        # See tests/api/fixtures/helm_mojanalytics_index.py
+        rstudio_info = HelmRepository.get_chart_info("rstudio")
+
+        rstudio_2_2_5_app_version = "RStudio: 1.2.1335+conda, R: 3.5.1, Python: 3.7.1, patch: 10"
+
+        assert len(rstudio_info) == 2
+        assert "2.2.5" in rstudio_info
+        assert "1.0.0" in rstudio_info
+
+        assert rstudio_info["2.2.5"].app_version == rstudio_2_2_5_app_version
+        # Helm added `appVersion` field in metadata only
+        # "recently" so for testing that for old chart
+        # version this returns `None`
+        assert rstudio_info["1.0.0"].app_version == None

--- a/tests/api/test_helm.py
+++ b/tests/api/test_helm.py
@@ -1,25 +1,16 @@
 from datetime import datetime, timedelta
 import pytest
-from unittest.mock import mock_open, patch
-
-import yaml
+from unittest.mock import patch
 
 from controlpanel.api.helm import (
     Chart,
     HelmRepository,
 )
-from tests.api.fixtures.helm_mojanalytics_index import HELM_MOJANALYTICS_INDEX
 
 
 def setup_function(fn):
     print("Resetting HelmRepository._updated_at ...")
     HelmRepository._updated_at = None
-
-
-@pytest.fixture
-def helm_repository_index():
-    content = yaml.dump(HELM_MOJANALYTICS_INDEX)
-    return mock_open(read_data=content)
 
 
 def test_chart_app_version():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 from model_mommy import mommy
+import yaml
 import pytest
+
+from tests.api.fixtures.helm_mojanalytics_index import HELM_MOJANALYTICS_INDEX
 
 
 @pytest.yield_fixture(autouse=True)
@@ -47,6 +50,15 @@ def helm():
     """
     with patch('controlpanel.api.cluster.helm') as helm:
         yield helm
+
+
+@pytest.fixture
+def helm_repository_index(autouse=True):
+    """
+    Mock the helm repository with some data
+    """
+    content = yaml.dump(HELM_MOJANALYTICS_INDEX)
+    return mock_open(read_data=content)
 
 
 @pytest.yield_fixture(autouse=True)

--- a/tests/frontend/test_consumers.py
+++ b/tests/frontend/test_consumers.py
@@ -1,0 +1,180 @@
+import json
+
+import pytest
+from unittest.mock import patch, Mock
+
+from controlpanel.api.models import Tool, ToolDeployment, User
+from controlpanel.api.cluster import (
+    TOOL_DEPLOYING,
+    TOOL_RESTARTING,
+    TOOL_UPGRADED,
+)
+from controlpanel.frontend import consumers
+
+
+@pytest.fixture
+def users(db):
+    print("Setting up users...")
+    User(auth0_id="github|1", username="alice").save()
+    User(auth0_id="github|2", username="bob").save()
+
+
+@pytest.fixture
+def tools(db):
+    print("Setting up tools...")
+    Tool(chart_name="a_tool").save()
+    Tool(chart_name="another_tool").save()
+
+
+@pytest.yield_fixture
+def update_tool_status():
+    with patch("controlpanel.frontend.consumers.update_tool_status") as update_tool_status:
+        yield update_tool_status
+
+
+@pytest.yield_fixture
+def wait_for_deployment():
+    with patch("controlpanel.frontend.consumers.wait_for_deployment") as wait_for_deployment:
+        yield wait_for_deployment
+
+
+def test_tool_deploy(users, tools, update_tool_status, wait_for_deployment):
+    user = User.objects.first()
+    tool = Tool.objects.first()
+    id_token = "secret user id_token"
+
+    with patch("controlpanel.frontend.consumers.ToolDeployment") as ToolDeployment:
+        tool_deployment = Mock()
+        ToolDeployment.return_value = tool_deployment
+
+        consumer = consumers.BackgroundTaskConsumer("test")
+        consumer.tool_deploy(
+            message={
+                "user_id": user.auth0_id,
+                "tool_name": tool.chart_name,
+                "id_token": id_token,
+            }
+        )
+
+        # 1. Instanciate `ToolDeployment` correctly
+        ToolDeployment.assert_called_with(tool, user)
+        # 2. Send status update
+        update_tool_status.assert_called_with(
+            tool_deployment,
+            id_token,
+            TOOL_DEPLOYING,
+        )
+        # 3. Call save() on ToolDeployment (trigger deployment)
+        tool_deployment.save.assert_called()
+        # 4. Wait for deployment to complete
+        wait_for_deployment.assert_called_with(tool_deployment, id_token)
+
+
+def test_tool_upgrade(users, tools, update_tool_status):
+    user = User.objects.first()
+    tool = Tool.objects.first()
+    id_token = "secret user id_token"
+
+    with patch("controlpanel.frontend.consumers.ToolDeployment") as ToolDeployment:
+        tool_deployment = Mock()
+        ToolDeployment.return_value = tool_deployment
+
+        message = {
+            "user_id": user.auth0_id,
+            "tool_name": tool.chart_name,
+            "id_token": id_token,
+        }
+
+        consumer = consumers.BackgroundTaskConsumer("test")
+        consumer.tool_deploy = Mock() # mock tool_deploy() method
+        consumer.tool_upgrade(message=message)
+
+        # 1. calls/reuse tool_deploy()
+        consumer.tool_deploy.assert_called_with(message)
+        # 2. Instanciate `ToolDeployment` correctly
+        ToolDeployment.assert_called_with(tool, user)
+        # 3. Send status update
+        update_tool_status.assert_called_with(
+            tool_deployment,
+            id_token,
+            TOOL_UPGRADED,
+        )
+
+
+def test_tool_restart(users, tools, update_tool_status, wait_for_deployment):
+    user = User.objects.first()
+    tool = Tool.objects.first()
+    id_token = "secret user id_token"
+
+    with patch("controlpanel.frontend.consumers.ToolDeployment") as ToolDeployment:
+        tool_deployment = Mock()
+        ToolDeployment.return_value = tool_deployment
+
+        consumer = consumers.BackgroundTaskConsumer("test")
+        consumer.tool_restart(
+            message={
+                "user_id": user.auth0_id,
+                "tool_name": tool.chart_name,
+                "id_token": id_token,
+            }
+        )
+
+        # 1. Instanciate `ToolDeployment` correctly
+        ToolDeployment.assert_called_with(tool, user)
+        # 2. Send status update
+        update_tool_status.assert_called_with(
+            tool_deployment,
+            id_token,
+            TOOL_RESTARTING,
+        )
+        # 3. Call restart() on ToolDeployment (trigger deployment)
+        tool_deployment.restart.assert_called_with(id_token=id_token)
+        # 4. Wait for deployment to complete
+        wait_for_deployment.assert_called_with(tool_deployment, id_token)
+
+
+def test_get_tool_and_user(users, tools):
+    expected_user = User.objects.first()
+    expected_tool = Tool.objects.first()
+    message = {
+        "user_id": expected_user.auth0_id,
+        "tool_name": expected_tool.chart_name,
+        "id_token": "not used by this method",
+    }
+
+    consumer = consumers.BackgroundTaskConsumer("test")
+    tool, user = consumer.get_tool_and_user(message)
+    assert expected_user == user
+    assert expected_tool == tool
+
+
+def test_update_tool_status():
+    tool = Tool(chart_name="a_tool", version="v1.0.0")
+    user = User(auth0_id="github|123")
+    id_token = "user id_token"
+    status = TOOL_UPGRADED
+    app_version = "R: 42, Python: 2.0.0"
+
+    tool_deployment = Mock()
+    tool_deployment.tool = tool
+    tool_deployment.user = user
+    tool_deployment.get_installed_app_version.return_value = app_version
+
+    expected_sse_event = {
+        "event": "toolStatus",
+        "data": json.dumps({
+            "toolName": tool.chart_name,
+            "version": tool.version,
+            "appVersion": app_version,
+            "status": status,
+        }),
+    }
+
+    with patch("controlpanel.frontend.consumers.send_sse") as send_sse:
+        consumers.update_tool_status(
+            tool_deployment,
+            id_token,
+            status,
+        )
+        tool_deployment.get_installed_app_version.assert_called_with(id_token)
+        send_sse.assert_called_with(user.auth0_id, expected_sse_event)


### PR DESCRIPTION
### What
Show users the current version of the tools they're using.

This is **not** the version of the helm chart but it's meant to show the version of the packaged tool.

This is part of the ongoing improvements to the Tools Catalogue.

<img width="1048" alt="Screen Shot 2020-05-20 at 10 10 48" src="https://user-images.githubusercontent.com/238563/82429168-67bc2c00-9a83-11ea-81f2-1e446e03580b.png">

### How
We use the helm repository index as source of true when it comes to version of tools installed.
Helm charts have some metadata and we've been using the `appVersion` field to record the version of the underlying tool (e.g. RStudio 1.2, R 3.4, etc...).

Unfortunately this information is partial and we rely on the helm repository metadata to be accurate.

Furthermore the `appVersion` field was added only "recently" and for very old charts this is not available. When the version can't be determined we show "Unknown" as version.


Ticket: https://trello.com/c/74QeufKf