### PR TITLE
Ensure admin tabs are highlighted in red.

### DIFF
--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -82,7 +82,8 @@
         "hide": not request.user.is_superuser,
         "text": "Home",
         "href": home_url,
-        "active": page_name == "home"
+        "active": page_name == "home",
+        "admin": request.user.is_superuser
       },
       {
         "text": "Analytical tools",
@@ -110,13 +111,15 @@
         "hide": not request.user.is_superuser,
         "text": "Parameters",
         "href": url("list-parameters"),
-        "active": page_name == "parameters"
+        "active": page_name == "parameters",
+        "admin": request.user.is_superuser
       },
       {
         "hide": not request.user.is_superuser,
         "text": "Groups",
         "href": url("list-policies"),
-        "active": page_name == "groups"
+        "active": page_name == "groups",
+        "admin": request.user.is_superuser
       }
     ]
   }) }}

--- a/controlpanel/frontend/static/components/navbar/macro.html
+++ b/controlpanel/frontend/static/components/navbar/macro.html
@@ -12,8 +12,9 @@
           {%- for item in params['items'] %}
             {%- if item.href and not item.hide %}
             <li class="moj-primary-navigation__item">
-              <a class="moj-primary-navigation__link" {{ 'aria-current="page"' | safe if item.active else '' }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %} {% if item.admin %}style="color: red;"{% endif %}>
+              <a class="moj-primary-navigation__link" {{ 'aria-current="page"' | safe if item.active else '' }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
                 {{- item.html | safe if item.html else item.text -}}
+                {% if item.admin %}&#128295;{% endif %}
               </a>
             </li>
             {% endif -%}

--- a/controlpanel/frontend/static/components/navbar/macro.html
+++ b/controlpanel/frontend/static/components/navbar/macro.html
@@ -12,7 +12,7 @@
           {%- for item in params['items'] %}
             {%- if item.href and not item.hide %}
             <li class="moj-primary-navigation__item">
-              <a class="moj-primary-navigation__link" {{ 'aria-current="page"' | safe if item.active else '' }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+              <a class="moj-primary-navigation__link" {{ 'aria-current="page"' | safe if item.active else '' }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %} {% if item.admin %}style="color: red;"{% endif %}>
                 {{- item.html | safe if item.html else item.text -}}
               </a>
             </li>


### PR DESCRIPTION
## What

See this Trello ticket: https://trello.com/c/rz1BbD1f/562-investigate-labeling-the-superuser-tab-and-other-superuser-things-in-control-panel-so-that-when-doing-support-we-know-what-regul

This change ensures admin only tabs are highlighted in red, as per the screenie "mock-up" shown below:

![admins](https://user-images.githubusercontent.com/37602/83404168-08a2d380-a402-11ea-88e3-32299a57fb45.png)

## How to review

Start the dev app as an admin. Ensure only the admin tabs are highlighted in red. Requires an Eyeball Mk.1 to accomplish. :eyes: 
