### PR TITLE
Show parameters tab.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
         build-base=0.5-r1 \
         ca-certificates \
         libffi-dev=3.2.1-r6 \
-        python3-dev=3.7.5-r1 \
+        python3-dev=3.7.7-r0 \
         libressl-dev=2.7.5-r0 \
         libstdc++=8.3.0-r0 \
         postgresql-dev \

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -83,29 +83,29 @@
         "text": "Home",
         "href": home_url,
         "active": page_name == "home",
-        "admin": request.user.is_superuser
+        "admin": request.user.is_superuser,
       },
       {
         "text": "Analytical tools",
         "href": url("list-tools"),
-        "active": page_name == "tools"
+        "active": page_name == "tools",
       },
       {
         "text": "Warehouse data",
         "href": url("list-warehouse-datasources"),
-        "active": page_name == "warehouse-datasource-list"
+        "active": page_name == "warehouse-datasource-list",
       },
       {
         "hide": not request.user.users3buckets.filter(s3bucket__is_data_warehouse=False).exists(),
         "text": "Webapp data",
         "href": url("list-webapp-datasources"),
-        "active": page_name == "webapp-datasource-list"
+        "active": page_name == "webapp-datasource-list",
       },
       {
         "hide": not request.user.userapps.filter(is_admin=True).exists(),
         "text": "Webapps",
         "href": url("list-apps"),
-        "active": page_name == "webapps"
+        "active": page_name == "webapps",
       },
       {
         "text": "Parameters",
@@ -117,9 +117,9 @@
         "text": "Groups",
         "href": url("list-policies"),
         "active": page_name == "groups",
-        "admin": request.user.is_superuser
-      }
-    ]
+        "admin": request.user.is_superuser,
+      },
+    ],
   }) }}
   {% endif %}
 
@@ -134,31 +134,31 @@
         'items': [
           {
             'href': user_guidance_base_url,
-            'text': "Platform user guidance"
+            'text': "Platform user guidance",
           },
           {
             'href': user_guidance_base_url + "/support.html",
-            'text': "Platform support"
+            'text': "Platform support",
           },
           {
             'href': "https://asdslack.slack.com/messages/C1PUCG719/#",
-            'text': "R Slack channel"
+            'text': "R Slack channel",
           },
           {
             'href': "https://asdslack.slack.com/messages/C1Q09V86S/#",
-            'text': "Python slack channel"
+            'text': "Python slack channel",
           },
           {
             'href': "https://asdslack.slack.com/messages/C4PF7QAJZ#",
-            'text': "Analytical platform slack channel"
+            'text': "Analytical platform slack channel",
           },
           {
             'href': url('whats-new'),
-            'text': "What's new?"
-          }
-        ]
-      }
-    ]
+            'text': "What's new?",
+          },
+        ],
+      },
+    ],
   }) }}
 {% endblock %}
 

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -82,7 +82,8 @@
         "hide": not request.user.is_superuser,
         "text": "Home",
         "href": home_url,
-        "active": page_name == "home"
+        "active": page_name == "home",
+        "admin": request.user.is_superuser
       },
       {
         "text": "Analytical tools",
@@ -110,13 +111,15 @@
         "hide": not request.user.is_superuser,
         "text": "Parameters",
         "href": url("list-parameters"),
-        "active": page_name == "parameters"
+        "active": page_name == "parameters",
+        "admin": request.user.is_superuser
       },
       {
         "hide": not request.user.is_superuser,
         "text": "Groups",
         "href": url("list-policies"),
-        "active": page_name == "groups"
+        "active": page_name == "groups",
+        "admin": request.user.is_superuser
       }
     ]
   }) }}

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -108,11 +108,9 @@
         "active": page_name == "webapps"
       },
       {
-        "hide": not request.user.is_superuser,
         "text": "Parameters",
         "href": url("list-parameters"),
         "active": page_name == "parameters",
-        "admin": request.user.is_superuser
       },
       {
         "hide": not request.user.is_superuser,

--- a/controlpanel/frontend/static/components/navbar/macro.html
+++ b/controlpanel/frontend/static/components/navbar/macro.html
@@ -12,7 +12,7 @@
           {%- for item in params['items'] %}
             {%- if item.href and not item.hide %}
             <li class="moj-primary-navigation__item">
-              <a class="moj-primary-navigation__link" {{ 'aria-current="page"' | safe if item.active else '' }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+              <a class="moj-primary-navigation__link" {{ 'aria-current="page"' | safe if item.active else '' }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %} {% if item.admin %}style="color: red;"{% endif %}>
                 {{- item.html | safe if item.html else item.text -}}
               </a>
             </li>


### PR DESCRIPTION
## What

**THIS PR IS STACKED UPON #817**

This PR ensures the parameters tab in the main menu is displayed for all (non-admin) users.

Fixes this Trello ticket: https://trello.com/c/Hc7F4OX0/602-add-parameters-tab-for-users-who-arent-superusers

The end result looks like this:

![parameters](https://user-images.githubusercontent.com/37602/83405308-28d39200-a404-11ea-83a0-6777c78ba5f6.png)


## How to review

1. Start the dev server locally.
2. Log in as a regular user.
3. Can you see the parameters tab (and when clicking on it, does it take you to the expected location)..?

Requires an Eyeball Mk.1 to test. :eyes:
