### PR TITLE
Helm upgrade uses --force flag now

### DIFF
--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -73,7 +73,7 @@ class Helm(object):
         HelmRepository.update()
 
         return self.__class__.execute(
-            "upgrade", "--install", "--wait", release, chart, *args,
+            "upgrade", "--install", "--wait", "--force", release, chart, *args,
         )
 
     def delete(self, purge=True, *args):


### PR DESCRIPTION
### Problem
Quite few users ask for support related to helm upgrade problems.
It appears one of the culprits is that when there is a previous
helm release in `FAILED` state helm will refuse to cooperate and raise
an error like the following:

```
rstudio-alice has no deployed releases
```

### Solution
There is an open issue which discusses this (see below) and some of the
comments suggest to use the `--force` flag which helps with some of these
helm upgrade problems.

If this works/helps it should reduce the volume of support request where
we have to manually `helm delete --purge` `FAILED` releases and also
improve the user experience as users will see less errors.

It may also help with the Tools Catalogue epic (fingers crossed) as
we see other helm issues (e.g. `resource x not present` or
`resource x already present` or similar helm errors) which hopefully
will be avoided with the use of this flag (fingers crossed but we'll see)

Also:
- added test for `Helm#upgrade_release()` method
- use `black` for helm test file (it's a start and it shouldn't mud the
  Git history much)

### Links to GitHub issue and ticket
GH helm issue: https://github.com/helm/helm/issues/5595
Ticket: https://trello.com/c/1XIRi1JS