### PR TITLE
Ensure a user, who is not a superuser, is directed to the tools list on login.

### DIFF
--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic.base import TemplateView
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 from mozilla_django_oidc.views import OIDCLogoutView
 
 from controlpanel.frontend.views.app import (
@@ -64,6 +66,18 @@ from controlpanel.frontend.views.whats_new import WhatsNew
 
 class IndexView(LoginRequiredMixin, TemplateView):
     template_name = "home.html"
+
+    def get(self, request):
+        """
+        If the user is a superuser display the home page (containing useful
+        admin related links). Otherwise, redirect the user to the list of the
+        tools they currently have available on the platform.
+        """
+        if request.user.is_superuser:
+            return super().get(request)
+        else:
+            # Redirect to the tools page.
+            return HttpResponseRedirect(reverse("list-tools"))
 
 
 class LogoutView(OIDCLogoutView):


### PR DESCRIPTION
## What

Trello ticket here: https://trello.com/c/k67GGgVh/561-show-tools-tab-when-you-open-control-panel-not-a-blank-tab

When a user visits the control panel `/` endpoint the old behaviour simply displayed a "Hello {username}" message with no indication of what they should do. The linked-to Trello ticket asked that users should be directed to the tools list instead. I've changed this so such a change only effects normal users. Super users have several useful links on the homepage and so will remain unaffected by this change.

## How to review

1. Login as a super user and see the current home page.
2. Login as a regular user and see your tool list.
3. That's it..!

Screenie:

![login-to-tools](https://user-images.githubusercontent.com/37602/85033574-03bb7f00-b179-11ea-88d7-22a368cc82b9.gif)
