### PR TITLE
Turn plain <br> that's escaped by template renderer to a full stop.

### DIFF
--- a/controlpanel/frontend/jinja2/datasource-create.html
+++ b/controlpanel/frontend/jinja2/datasource-create.html
@@ -39,7 +39,7 @@
         "maxlength": "60",
       },
       "value": form.name.value(),
-      "errorMessage": { "html": form.name.errors|join("<br>") } if form.name.errors else {}
+      "errorMessage": { "html": form.name.errors|join(". ") } if form.name.errors else {}
     }) }}
     <button class="govuk-button">Create data source</button>
   </form>

--- a/controlpanel/frontend/jinja2/parameter-create.html
+++ b/controlpanel/frontend/jinja2/parameter-create.html
@@ -36,7 +36,7 @@
           "attributes": {},
           "items": app_type_choices,
           "value": form.app_type.value(),
-          "errorMessage": { "html": form.app_type.errors|join("<br>") } if form.app_type.errors else {}
+          "errorMessage": { "html": form.app_type.errors|join(". ") } if form.app_type.errors else {}
         })
       }}
     
@@ -54,7 +54,7 @@
           "maxlength": "60",
           "data-role-endpoint": url("parameters-list-roles"),
         },
-        "errorMessage": {"html": form.role_name.errors|join("<br>")} if form.role_name.errors else {},
+        "errorMessage": {"html": form.role_name.errors|join(". ")} if form.role_name.errors else {},
         "classes": "govuk-input--error govuk-!-width-two-thirds" if form.role_name.errors else "govuk-!-width-two-thirds",
         "value": form.role_name.value(),
         "items": []
@@ -80,7 +80,7 @@
             "maxlength": "60",
           },
           "value": form.key.value(),
-          "errorMessage": { "html": form.key.errors|join("<br>") } if form.key.errors else {}
+          "errorMessage": { "html": form.key.errors|join(". ") } if form.key.errors else {}
         })
       }}
 
@@ -95,7 +95,7 @@
           "attributes": {
           },
           "value": form.value.value(),
-          "errorMessage": { "html": form.value.errors|join("<br>") } if form.value.errors else {}
+          "errorMessage": { "html": form.value.errors|join(". ") } if form.value.errors else {}
         })
       }}
       <button class="govuk-button">Create parameter</button>

--- a/controlpanel/frontend/jinja2/policy-create.html
+++ b/controlpanel/frontend/jinja2/policy-create.html
@@ -36,7 +36,7 @@
             "maxlength": "60",
           },
           "value": form.name.value(),
-          "errorMessage": { "html": form.name.errors|join("<br>") } if form.name.errors else {}
+          "errorMessage": { "html": form.name.errors|join(". ") } if form.name.errors else {}
         })
       }}
 

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -23,7 +23,7 @@
     <tr class="govuk-table__row sse-listener tool-status" data-tool-name="{{ tool.chart_name }}">
       <td class="govuk-table__cell">
         {{ tool.name }}
-        <br>
+        <br/>
         <small class="tool-app-version">
           {% if deployment %}
             {{ deployment.get_installed_app_version(id_token) or "Unknown" }}

--- a/controlpanel/frontend/jinja2/webapp-create.html
+++ b/controlpanel/frontend/jinja2/webapp-create.html
@@ -20,7 +20,7 @@
     "hint": {
       "text": '60 chars max, only lowercase letters, numbers, periods and hyphens, auto-prefixed with "' + env + '"'
     },
-    "errorMessage": {"text": form.new_datasource_name.errors|join("<br>")} if form.new_datasource_name.errors else {},
+    "errorMessage": {"text": form.new_datasource_name.errors|join(". ")} if form.new_datasource_name.errors else {},
     "value": form.new_datasource_name.value()
   }) }}
   </div>
@@ -33,7 +33,7 @@
                 {%- if form.existing_datasource_id.errors %} govuk-form-group--error{% endif %}">
       {{ govukLabel({"text": "Select webapp data source"}) }}
       {% if form.existing_datasource_id.errors -%}
-      {{ govukErrorMessage({"text": form.existing_datasource_id.errors|join("<br>")}) }}
+      {{ govukErrorMessage({"text": form.existing_datasource_id.errors|join(". ")}) }}
       {%- endif %}
       {{ form.existing_datasource_id }}
     </div>
@@ -57,7 +57,7 @@
       "text": "Github repository",
       "classes": "govuk-label--m"
     },
-    "errorMessage": {"html": form.repo_url.errors|join("<br>")} if form.repo_url.errors else {},
+    "errorMessage": {"html": form.repo_url.errors|join(". ")} if form.repo_url.errors else {},
     "classes": "govuk-input--error" if form.repo_url.errors else "",
     "value": form.repo_url.value(),
     "items": repos

--- a/controlpanel/frontend/jinja2/webapp-detail.html
+++ b/controlpanel/frontend/jinja2/webapp-detail.html
@@ -282,7 +282,7 @@
     <div class="govuk-form-group">
       {{ govukLabel({"text": "Connect an app data source"}) }}
       {% if grant_access_form.datasource.errors -%}
-      {{ govukErrorMessage({"text": grant_access_form.datasource.errors|join("<br>")}) }}
+      {{ govukErrorMessage({"text": grant_access_form.datasource.errors|join(". ")}) }}
       {%- endif %}
       {{ grant_access_form.datasource }}
     </div>


### PR DESCRIPTION
## What

See ticket: https://trello.com/c/ThgiskvR/641-stray-br-showing-on-control-panel-app-registration-form

It was possible for a stray "escaped" fragment of HTML `<br>` to appear in certain forms in the control panel. Django/Jinja2 are doing the correct behaviour and we shouldn't put plain HTML into random strings expecting them to be rendered properly. I've replaced `<br>` with `. `  to delineate between error messages.

## How to review

1. Try to create an app in the erroneous way as described in the Trello ticket.
2. Observe the magnificent absence of `<br>`.