### PR TITLE
Fix Dockerfile with python version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
         build-base=0.5-r1 \
         ca-certificates \
         libffi-dev=3.2.1-r6 \
-        python3-dev=3.7.7-r0 \
+        python3-dev=3.7.7-r1 \
         libressl-dev=2.7.5-r0 \
         libstdc++=8.3.0-r0 \
         postgresql-dev \


### PR DESCRIPTION
This fixes an error on Dockerfile build:
```
Step 10/35 : RUN apk add --no-cache ... python3-dev=3.7.7-r0
ERROR: unsatisfiable constraints:
  python3-dev-3.7.7-r1:
    breaks: world[python3-dev=3.7.7-r0]
```
which is no doubt caused by the base Alpine packages now coming with 3.7.7-r1 now.

(We might also consider specifying <3.8, to take the latest 3.7.x release. But on balance we
might take a bit of brittleness since we value pinning/reproducibility)
