### PR TITLE
Provide higher contrast sign out link in site navigation

### DIFF
--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -54,7 +54,7 @@
             'active': True
           },
           {
-            'html': '<a href="' ~ url('oidc_logout') ~ '">Sign out</a>'
+            'html': '<a class="moj-header__navigation-link" href="' ~ url('oidc_logout') ~ '">Sign out</a>'
           }
         ]
       }


### PR DESCRIPTION
## What

This is a minor change that ensure the sign out link is high contrast against the top navbar. It was too dark and difficult to see, and this problem was recently highlighted by our UX/UI colleagues. You can see the modified look in the screenie below:

![sign_out](https://user-images.githubusercontent.com/37602/89625517-e7da7c80-d88f-11ea-891e-47964f5ddf2f.png)


## How to review

1. Start the app and sign in.
2. Check the sign out button looks like the screenie embedded above.

The problem was highlighted in [this report](https://docs.google.com/presentation/d/17ki5DLiwQCrZ5W7ljqb-8PFSihxQaBLD7Bf3cPHALwY/edit?pli=1#slide=id.g869afc015a_0_0).

This probably should be linked to [this Trello ticket](https://trello.com/c/egENqsu2/720-design-work-for-ripley-button-software-catalogue) covering UI changes.
