### PR TITLE
Fix 500 errors when processing an empty data source "grant access" form.

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -119,6 +119,7 @@ class GrantAccessForm(forms.Form):
             ("readwrite", "Read/write"),
             ("admin", "Admin"),
         ],
+        required=True
     )
     paths = SimpleArrayField(
         forms.CharField(
@@ -149,7 +150,7 @@ class GrantAccessForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
-        access_level = cleaned_data['access_level']
+        access_level = cleaned_data.get('access_level')
         if access_level == 'admin':
             cleaned_data['access_level'] = 'readwrite'
             cleaned_data['is_admin'] = True

--- a/controlpanel/frontend/jinja2/datasource-access-update.html
+++ b/controlpanel/frontend/jinja2/datasource-access-update.html
@@ -33,7 +33,7 @@
     <div {% if form.errors %}class="govuk-form-group--error"{% endif %}>
       <fieldset class="govuk-fieldset ">
         {% if form.errors %}
-        <span id="confirma-error" class="govuk-error-message">
+        <span id="confirm-error" class="govuk-error-message">
           <span class="govuk-visually-hidden">Error:</span>
           {% for error in form.errors.access_level %}
             {{ error | escape }}

--- a/controlpanel/frontend/jinja2/datasource-access-update.html
+++ b/controlpanel/frontend/jinja2/datasource-access-update.html
@@ -9,12 +9,40 @@
 {% block content %}
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
+{% if form.errors %}
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            There is a problem on this page
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li>
+                Please see details listed below.
+              </li>
+            </ul>
+          </div>
+        </div>
+{% endif %}
+
 <section class="cpanel-section">
   <form method="post" action="{{ action_url }}">
     {{ csrf_input }}
     <input type="hidden" name="entity_type" value="{{ entity_type }}">
     <input type="hidden" name="entity_id" value="{{ entity_id }}">
-    {{ data_access_level_options(items3bucket) }}
+
+    <div {% if form.errors %}class="govuk-form-group--error"{% endif %}>
+      <fieldset class="govuk-fieldset ">
+        {% if form.errors %}
+        <span id="confirma-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span>
+          {% for error in form.errors.access_level %}
+            {{ error | escape }}
+          {% endfor %}
+        </span>
+        {% endif %}
+        {{ data_access_level_options(items3bucket) }}
+      </fieldset>
+    </div>
 
     {{ data_access_paths_textarea(form.paths) }}
 


### PR DESCRIPTION
## What

Add form error handling to the data source access page/form.

## How to review

1. Go to a data source's access page.
2. Try to submit an empty form.
3. Marvel at the error message.

Fixes [this Trello ticket](https://trello.com/c/FfywBJqV/685-need-form-validation-on-grant-access-in-control-panel).
