### PR TITLE
Ensure the 'open' button on the tools page is, in fact a button.

### DIFF
--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -72,14 +72,14 @@
     </button>
   </form>
 
-  <a class="govuk-button govuk-button--secondary govuk-!-margin-right-1 govuk-!-margin-top-0 tool-action"
+  <button class="govuk-button govuk-button--secondary govuk-!-margin-right-1 govuk-!-margin-top-0 tool-action"
     data-action-name="open"
-    href="{{ tool_info['url'] }}"
+    onclick="window.open('{{ tool_info['url'] }}', '_blank');"
     rel="noopener"
     target="_blank"
     {% if not deployment %} disabled {% endif %}>
       Open
-  </a>
+  </button>
 
   <form action="{{ url('restart-tool', kwargs={'name': chart_name}) }}"
     data-action-name="restart"


### PR DESCRIPTION
## What

As explained in [this Trello ticket](https://trello.com/c/N6x7KTQd/765-accessibility-refinement-of-open-button-in-tools-page-of-control-panel), the "Open" button on the tools page was in fact an anchor styled to look like a button. It meant that such anchors **always** appeared in the tab order, even if they appeared to be disabled. This was identified as an accessibility issue.

This change simply turns "Open" into an HTML button with a fragment of JavaScript to open the expected URL in a new tab.

![open-button](https://user-images.githubusercontent.com/37602/92128208-151c3b00-edfa-11ea-92d6-b7a4e359900e.gif)

## How to review

1. Load the new tools page.
2. Inspect the "Open" button to confirm it's an HTML button.
3. Click it and see the page appear in a new browser tab.
4. Tab forward and backwards around the focusable elements on the screen and marvel with great enthusiasm that disabled "Open" buttons are never selected.
