### PR TITLE
Added nginx healthcheck endpoint to nginx config

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,11 @@ upstream django {
 server {
     listen 8080;
 
+    location /nginx-health {
+        access_log off;
+        return 200 "healthy\n";
+    }
+
     location /static/ {
         root /usr/share/nginx/html;
     }


### PR DESCRIPTION
This is to be used by k8s to check the health/liveliness of the nginx
container in the CP pod.

NOTE: This configuration file for nginx is actually mounted by the
pod into the nginx container, see `cpanel` Helm Chart here:

https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/main/charts/cpanel/templates/deployment.yaml#L28:L53

Related to ticket: https://trello.com/c/eUMRw1gK