### PR TITLE
Add a svelte way to highlight and remove unused user accounts.

### DIFF
--- a/controlpanel/frontend/jinja2/user-detail.html
+++ b/controlpanel/frontend/jinja2/user-detail.html
@@ -24,8 +24,7 @@
       </h2>
 
       <p>
-        <strong>The user of this account has not logged in for over three
-        months.</strong>
+        <strong>The user of this account has not logged in for over 90 days.</strong>
       </p>
 
       <p>If appropriate, please <a href="https://github.com/orgs/moj-analytical-services/people/{{ user.username }}" target="_blank">visit the GitHub page for their membership of the

--- a/controlpanel/frontend/jinja2/user-detail.html
+++ b/controlpanel/frontend/jinja2/user-detail.html
@@ -13,6 +13,27 @@
 <span class="govuk-caption-xl">User</span>
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
+{% if unused %}
+<div class="govuk-grid-row">
+  <div class="govuk-column-two-thirds">
+
+    <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+
+      <h2 class="govuk-heading-m govuk-error-summary-heading">
+      This Account Could be Unused
+      </h2>
+
+      <p>
+        <strong>The user of this account has not logged in for over three
+        months.</strong>
+      </p>
+
+      <p>If appropriate, please <a href="https://github.com/orgs/moj-analytical-services/people/{{ user.username }}" target="_blank">visit the GitHub page for their membership of the
+      Ministry of Justice organisation</a> to free up space.</p>
+    </div>
+</div>
+{% endif %}
+
 {% if request.user.has_perm('api.add_superuser') %}
 <section class="cpanel-section">
   <form action="{{ url('set-superadmin', kwargs={ "pk": user.auth0_id }) }}" method="post">

--- a/controlpanel/frontend/jinja2/user-list.html
+++ b/controlpanel/frontend/jinja2/user-list.html
@@ -29,12 +29,17 @@
       </td>
       <td class="govuk-table__cell">{{ user.email }}</td>
       <td class="govuk-table__cell">
-        {%- with login=last_login.get(user.auth0_id) -%}
-          {%- if login -%}
+        {%- with login_details=last_login.get(user.auth0_id) -%}
+          {%- if login_details -%}
+          {%- with login = login_details.get("last_login") -%}
           <span data-last-login="{{login}}"
                 title="{{login.strftime("%Y/%m/%d %H:%M:%S")}}">
             {{ timesince(login) }} ago
           </span>
+          {%- if login_details.get("unused") -%}
+          (<strong><a href="https://github.com/orgs/moj-analytical-services/people/{{ user.username }}" target="_blank">unused?</a></strong>)
+          {%- endif -%}
+          {%- endwith -%}
           {%- else -%}
           {%- endif -%}
         {%- endwith -%}

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -13,13 +13,13 @@ from controlpanel.api import auth0
 from controlpanel.api.models import User
 
 
-def three_months_ago():
+def ninety_days_ago():
     """
     Returns a datetime object referencing approximately three months in the
     past, from the current date. The assumption made here is that a month is
     roughly 30 days (so the result is always 90 days in the past).
     """
-    return datetime.now() - timedelta(days=30*3)
+    return datetime.now() - timedelta(days=90)
 
 
 class UserList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
@@ -30,44 +30,68 @@ class UserList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     template_name = "user-list.html"
 
     def get_context_data(self, **kwargs):
+        # TODO: Refactor this. I've added annotations for future reference.
         context = super().get_context_data(**kwargs)
 
+        # This returns a list of dictionary objects from Auth0. Each dictionary
+        # represents a user.
         users = auth0.ManagementAPI().list_users(
             params={
                 'q': 'identities.connection:"github"'
             },
         )
 
+        # We also need the django.contrib.auth.User instances for each user
+        # too. The auth0_mapper dictionary stores a User instance for each user
+        # against their Auth0 ID (so we can connect them to the dictionary
+        # related record from Auth0 -- see above). These objects are used as a
+        # fallback for when we don't have a last_login for the user from Auth0.
         auth0_mapper = {}
         for db_user in self.queryset:
             if db_user.auth0_id:
                 auth0_mapper[db_user.auth0_id] = db_user
 
-        last_logins = []
+        # This dictionary will store details of last logins for those users for
+        # whom such data is available (apparently, not all users may have
+        # logged in). TODO: Investigate if this is actually the case. Surely
+        # all users must have logged in to set up their account and get
+        # registered via Auth0.
+        last_logins = {}
         for user in users:
             auth0_id = user['user_id']
-
+            # Apparently some Auth0 users won't have a "user_id". TODO: WAT?
+            # Check if this is the case.
             if auth0_id == '':
                 continue
-
+            # This next block is a confusing mess. TODO: Investigate is we
+            # can't just use Django's User model's last_login field.
+            last_login = None
             try:
+                # First check the Auth0 based record / dictionary.
                 auth0_last_login = user.get("last_login")
                 if auth0_last_login:
                     last_login = dateutil.parser.parse(user.get('last_login'))
                 else: 
+                    # Fall back to Django's User model's last_login field.
                     db_user = auth0_mapper.get(auth0_id, None)
                     if db_user:
                         last_login = db_user.last_login
             except (TypeError, ValueError):
                 last_login = None
+            # Only add a last_login record to the context if there's something
+            # to add.
+            if last_login:
+                last_logins[auth0_id] = {
+                    # The datetime of last login to display in the template.
+                    "last_login": last_login,
+                    # Not logged in for 90 days? Perhaps the account is unused
+                    # so set this flag to indicate the account should be
+                    # checked by a human for legitimate inactivity and thus
+                    # removal from the system.
+                    "unused": last_login.utcnow() < ninety_days_ago(),
+                }
 
-            last_logins.append((auth0_id, {
-                "last_login": last_login,
-                "unused": last_login.utcnow() < three_months_ago(),
-            }))
-
-        context['last_login'] = dict(last_logins)
-
+        context['last_login'] = last_logins
         return context
 
 
@@ -88,7 +112,9 @@ class UserDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["unused"] = self.object.last_login.utcnow() < three_months_ago()
+        # A flag to indicate if the user hasn't logged in for 90 days - so the
+        # account maybe unused and so a candidate for removal.
+        context["unused"] = self.object.last_login.utcnow() < ninety_days_ago()
         return context
 
 

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -1,4 +1,5 @@
 import dateutil.parser
+from datetime import datetime, timedelta
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
@@ -10,6 +11,15 @@ from rules.contrib.views import PermissionRequiredMixin
 
 from controlpanel.api import auth0
 from controlpanel.api.models import User
+
+
+def three_months_ago():
+    """
+    Returns a datetime object referencing approximately three months in the
+    past, from the current date. The assumption made here is that a month is
+    roughly 30 days (so the result is always 90 days in the past).
+    """
+    return datetime.now() - timedelta(days=30*3)
 
 
 class UserList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
@@ -28,6 +38,11 @@ class UserList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
             },
         )
 
+        auth0_mapper = {}
+        for db_user in self.queryset:
+            if db_user.auth0_id:
+                auth0_mapper[db_user.auth0_id] = db_user
+
         last_logins = []
         for user in users:
             auth0_id = user['user_id']
@@ -36,11 +51,20 @@ class UserList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
                 continue
 
             try:
-                last_login = dateutil.parser.parse(user.get('last_login'))
+                auth0_last_login = user.get("last_login")
+                if auth0_last_login:
+                    last_login = dateutil.parser.parse(user.get('last_login'))
+                else: 
+                    db_user = auth0_mapper.get(auth0_id, None)
+                    if db_user:
+                        last_login = db_user.last_login
             except (TypeError, ValueError):
                 last_login = None
 
-            last_logins.append((auth0_id, last_login))
+            last_logins.append((auth0_id, {
+                "last_login": last_login,
+                "unused": last_login.utcnow() < three_months_ago(),
+            }))
 
         context['last_login'] = dict(last_logins)
 
@@ -61,6 +85,11 @@ class UserDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
     model = User
     permission_required = 'api.retrieve_user'
     template_name = "user-detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["unused"] = self.object.last_login.utcnow() < three_months_ago()
+        return context
 
 
 class SetSuperadmin(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):

--- a/tests/frontend/views/test_user.py
+++ b/tests/frontend/views/test_user.py
@@ -63,6 +63,8 @@ def reset_mfa(client, users, *args):
     ],
 )
 def test_permission(client, users, view, user, expected_status):
+    for key, val in users.items():
+        client.force_login(val)
     client.force_login(users[user])
     response = view(client, users)
     assert response.status_code == expected_status


### PR DESCRIPTION
## What

This change makes it easy for admin users of the control panel to quickly identify users who have not logged in after approximately three months (90 days). Furthermore, links are provided to GitHub for the specific users' team membership settings for the MoJ organisation so they can be easily removed. This work needs to be done since the number of seats in the organisation is limited and we need a way to quickly curate such membership as admin users.

Setting aside the erroneous last-login time (done for testing purposes), the functionality looks like this:

![unused_users](https://user-images.githubusercontent.com/37602/92473597-be847780-f1d2-11ea-9765-8bd98c955ffe.gif)

**Remember, the screenie was created with test data.** Obviously, the "unused" flag/link and related warning message won't appear unless the user hasn't logged in for 90 days.

## How to review

1. Make sure the `timedelta` used in the `three_months_ago` function in your local copy of this branch returns something not so far in the past.
2. Log in as an admin user.
3. Confirm you can see behaviour similar to that in the attached screenie.

The related ticket in Trello can be [found here](https://trello.com/c/uH1cuRhJ/65-check-users-are-still-active-and-automatically-suspend-inactive-accounts).