### PR TITLE
Allow admins to order columns in user list.

### DIFF
--- a/controlpanel/frontend/jinja2/user-list.html
+++ b/controlpanel/frontend/jinja2/user-list.html
@@ -10,9 +10,9 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header">User</th>
-      <th class="govuk-table__header">Email</th>
-      <th class="govuk-table__header">Last login</th>
+      <th class="govuk-table__header"><a href="?o=username">User</a></th>
+      <th class="govuk-table__header"><a href="?o=email">Email</a></th>
+      <th class="govuk-table__header"><a href="?o=last_login">Last login</a></th>
       <th class="govuk-table__header">
         <span class="govuk-visually-hidden">Actions</span>
       </th>

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -29,14 +29,17 @@ class UserList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     queryset = User.objects.exclude(auth0_id='')
     template_name = "user-list.html"
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
+    def get_ordering(self):
         order_by = self.request.GET.get("o", "username")
         valid_fields = ["username", "email", "last_login", ]
         if order_by not in valid_fields:
             order_by = "username"
+        return order_by
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
         unused_users = []
-        for user in self.queryset.order_by(order_by):
+        for user in self.queryset:
             if user.last_login:
                 if user.last_login.date() < ninety_days_ago():
                     unused_users.append(user)

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -31,8 +31,12 @@ class UserList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        order_by = self.request.GET.get("o", "username")
+        valid_fields = ["username", "email", "last_login", ]
+        if order_by not in valid_fields:
+            order_by = "username"
         unused_users = []
-        for user in self.queryset:
+        for user in self.queryset.order_by(order_by):
             if user.last_login:
                 if user.last_login.date() < ninety_days_ago():
                     unused_users.append(user)


### PR DESCRIPTION
## What

In the end, the actual change needed was very small (and it should be easy to add to other pages that need ordering by column).

Clicking on the column title will re-load the page with the table ordered by column selected column. See screenie below for this behaviour demonstrated:

![order_columns](https://user-images.githubusercontent.com/37602/93598324-71638b00-f9b4-11ea-9de3-ed7d0d034f8a.gif)


## How to review

1. Go visit `dev` as an admin.
2. Click on the user list.
3. Order the columns by clicking on the column title as per the screenie above.

Related Trello ticket: https://trello.com/c/cApsTxp5/781-add-ordering-of-columns-in-admin-lists-on-control-panel
