### PR TITLE
[MVP] Show all datasources to users (including ones they can't acces)

### DIFF
--- a/controlpanel/frontend/jinja2/datasource-list.html
+++ b/controlpanel/frontend/jinja2/datasource-list.html
@@ -34,10 +34,10 @@
 {% if other_datasources %}
   <h3 class="govuk-heading-m">Other {{ datasource_type }} data sources</h3>
   <p class="govuk-body">
-    The following is a list of {{ datasource_type }} data sources you currently <span class="govuk-!-font-weight-bold">do not</span> have access to.
+    You currently <span class="govuk-!-font-weight-bold">do not</span> have access to the following {{ datasource_type }} data sources.
   </p>
   <p class="govuk-body">
-    Please refer to the <a href="https://user-guidance.services.alpha.mojanalytics.xyz/data/amazon-s3/#request-access-to-a-bucket" class="govuk-link">User Guidance</a> for information on how to get access to any of the following {{ datasource_type }} data sources.
+    Please refer to the <a href="https://user-guidance.services.alpha.mojanalytics.xyz/data/amazon-s3/#request-access-to-a-bucket" class="govuk-link">user guidance</a> for information on how to get access.
   </p>
 
   <table class="govuk-table">

--- a/controlpanel/frontend/jinja2/datasource-list.html
+++ b/controlpanel/frontend/jinja2/datasource-list.html
@@ -29,4 +29,38 @@
   </p>
   {% endif %}
 {% endif %}
+
+
+<h3 class="govuk-heading-m">Other {{ datasource_type }} data sources</h3>
+<p class="govuk-body">
+  The following is a list of {{ datasource_type }} data sources you currently don't have access to.
+</p>
+<p class="govuk-body">
+  Please refer to the <a href="https://user-guidance.services.alpha.mojanalytics.xyz/data/amazon-s3/#request-access-to-a-bucket" class="govuk-link">User Guidance</a> for information on how to get access to any of the following {{ datasource_type }} data sources.
+</p>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Name</th>
+      <th class="govuk-table__header">
+        Your access level
+        {{ modal_dialog(access_levels_html|safe) }}
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  {% for datasource in other_datasources %}
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        {{ datasource.name }}
+      </td>
+      <td class="govuk-table__cell">
+        No access
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
 {% endblock %}

--- a/controlpanel/frontend/jinja2/datasource-list.html
+++ b/controlpanel/frontend/jinja2/datasource-list.html
@@ -1,5 +1,6 @@
 {% from "modal-dialog/macro.html" import modal_dialog %}
 {% from "includes/datasource-list.html" import datasource_list with context %}
+{% from "user/macro.html" import user_name %}
 
 {% extends "base.html" %}
 
@@ -30,37 +31,44 @@
   {% endif %}
 {% endif %}
 
+{% if other_datasources %}
+  <h3 class="govuk-heading-m">Other {{ datasource_type }} data sources</h3>
+  <p class="govuk-body">
+    The following is a list of {{ datasource_type }} data sources you currently <span class="govuk-!-font-weight-bold">do not</span> have access to.
+  </p>
+  <p class="govuk-body">
+    Please refer to the <a href="https://user-guidance.services.alpha.mojanalytics.xyz/data/amazon-s3/#request-access-to-a-bucket" class="govuk-link">User Guidance</a> for information on how to get access to any of the following {{ datasource_type }} data sources.
+  </p>
 
-<h3 class="govuk-heading-m">Other {{ datasource_type }} data sources</h3>
-<p class="govuk-body">
-  The following is a list of {{ datasource_type }} data sources you currently don't have access to.
-</p>
-<p class="govuk-body">
-  Please refer to the <a href="https://user-guidance.services.alpha.mojanalytics.xyz/data/amazon-s3/#request-access-to-a-bucket" class="govuk-link">User Guidance</a> for information on how to get access to any of the following {{ datasource_type }} data sources.
-</p>
-
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">Name</th>
-      <th class="govuk-table__header">
-        Your access level
-        {{ modal_dialog(access_levels_html|safe) }}
-      </th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-  {% for datasource in other_datasources %}
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">
-        {{ datasource.name }}
-      </td>
-      <td class="govuk-table__cell">
-        No access
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Name</th>
+        <th class="govuk-table__header">
+          Your access level
+          {{ modal_dialog(access_levels_html|safe) }}
+        </th>
+        <th class="govuk-table__header">Admins</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for datasource in other_datasources %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          {{ datasource.name }}
+        </td>
+        <td class="govuk-table__cell">
+          No access
+        </td>
+        <td class="govuk-table__cell">
+          {% for admin in other_datasources_admins[datasource.id] %}
+            {{ user_name(admin) }}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
 
 {% endblock %}

--- a/controlpanel/frontend/jinja2/modals/user_data_access_levels.html
+++ b/controlpanel/frontend/jinja2/modals/user_data_access_levels.html
@@ -10,4 +10,7 @@
     <strong>Admin</strong> - user can read, modify and delete the data, and also
     grant/modify/revoke access rights to this data for other users
   </li>
+  <li>
+    <strong>No access</strong> - user cannot access the data
+  </li>
 </ul>

--- a/controlpanel/frontend/views/datasource.py
+++ b/controlpanel/frontend/views/datasource.py
@@ -80,12 +80,17 @@ class BucketList(
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
-        all_datasources = S3Bucket.objects.filter(
+        all_datasources = S3Bucket.objects.prefetch_related("users3buckets__user").filter(
             is_data_warehouse=self.datasource_type == "warehouse",
         )
         other_datasources = all_datasources.exclude(id__in=self.get_queryset())
+        other_datasources_admins = {}
+        for datasource in other_datasources:
+            admins = [ m2m.user for m2m in datasource.users3buckets.filter(is_admin=True) ]
+            other_datasources_admins[datasource.id] = admins
 
         context["other_datasources"] = other_datasources
+        context["other_datasources_admins"] = other_datasources_admins
         return context
 
 

--- a/controlpanel/frontend/views/datasource.py
+++ b/controlpanel/frontend/views/datasource.py
@@ -77,6 +77,17 @@ class BucketList(
             users3buckets__user=self.request.user,
         )
 
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+
+        all_datasources = S3Bucket.objects.filter(
+            is_data_warehouse=self.datasource_type == "warehouse",
+        )
+        other_datasources = all_datasources.exclude(id__in=self.get_queryset())
+
+        context["other_datasources"] = other_datasources
+        return context
+
 
 class AdminBucketList(BucketList):
     all_datasources = True


### PR DESCRIPTION
### What

**NOTE**: This is an MVP:

> [...] on the Warehouse Data Sources and App Data Sources tabs, below the list of buckets they have access to, let's show a list of all the other buckets too i.e. the ones they DON'T have access to.
> [...]
> this ticket is for an MVP, which is just displaying the name, and letting the user request access in the normal ways.)

Main reason for this is to give visibility of existing data sources to users. They have a rough idea of what's already available.
They can therefore avoid reinventing the wheel if the data is already present.

**NOTE**: This do **not** change [the process for requesting access to datasources](https://user-guidance.services.alpha.mojanalytics.xyz/data/amazon-s3/#request-access-to-a-bucket). Users will still request access to these as before.

### Privacy concerns
We discussed this few times and the team is happy to show the list of datasources to all users. 
We only show the datasources' names and their admins so it shouldn't constitute a problem.

The items in the list don't link to the actual datasources or users so no permission changes were required.

Also note that users will be able to see only the admins list (which was already a "nice to have" on top of the MVP), **not** the full list of users for each datasource and their access level.

### Ticket
https://trello.com/c/AIOEPlHG