### PR TITLE
Add accessibility statement. First draft.

### DIFF
--- a/controlpanel/frontend/jinja2/a11y.html
+++ b/controlpanel/frontend/jinja2/a11y.html
@@ -12,9 +12,9 @@
     <p>This accessibility statement applies to the Ministry of Justice's
     Analytical Platform.</p>
 
-    <p>This service is run by Analytical Platform Team of the Ministry of
+    <p>This service is run by Analytical Platform team of the Ministry of
     Justice. We want as many people as possible to be able to use this service.
-    For example, on the Control Panel website (this website) you
+    For example, on the Control Panel application (this website) you
     should be able to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -27,7 +27,7 @@
 
     <p>We've also made our textual content as simple as possible to understand.</p>
 
-    <p><a rel="external" href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a>
+    <p><a rel="external" target="_blank" href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a>
     has advice on making your device easier to use if you have a disability.</p>
 
     <h3 class="govuk-heading-m" id="how-accessible-this-service-is">How accessible this service is</h3>
@@ -46,18 +46,18 @@
     <h3 class="govuk-heading-m" id="feedback-and-contact-information">Feedback and contact information</h3>
 
     <p>Any feedback and/or requests for help should be made via the
-    <a href="https://asdslack.slack.com/messages/C4PF7QAJZ#">Analytical Platform
+    <a rel="external" target="_blank" href="https://asdslack.slack.com/messages/C4PF7QAJZ#">Analytical Platform
     Slack Channel</a>. We also have a
-    <a href="https://user-guidance.services.alpha.mojanalytics.xyz/">platform user guide</a>
+    <a rel="external" target="_blank" href="https://user-guidance.services.alpha.mojanalytics.xyz/">platform user guide</a>
     and
-    <a href="https://user-guidance.services.alpha.mojanalytics.xyz/support.html">platform support documentation</a>.</p>
+    <a rel="external" target="_blank" href="https://user-guidance.services.alpha.mojanalytics.xyz/support.html">platform support documentation</a>.</p>
 
     <h3 class="govuk-heading-m" id="reporting-accessibility-problems-with-this-service">Reporting accessibility problems with this service</h3>
 
     <p>We're always looking to improve the accessibility of this service. If
     you find any problems not listed on this page or think we're not meeting
     accessibility requirements, please contact us via the links listed in the
-    <a href="#feedback-and-contact-information">feedback and contact information section</a>.</p>
+    <a rel="external" target="_blank" href="#feedback-and-contact-information">feedback and contact information section</a>.</p>
 
     <h3 class="govuk-heading-m" id="enforcement-procedure">Enforcement procedure</h3>
 
@@ -65,11 +65,11 @@
     enforcing the Public Sector Bodies (Websites and Mobile Applications)
     (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').
     If you’re not happy with how we respond to your complaint,
-    <a rel="external" href="https://www.equalityadvisoryservice.com/" class="govuk-link">contact the Equality Advisory and Support Service (EASS)</a>.</p>
+    <a rel="external" target="_blank" href="https://www.equalityadvisoryservice.com/" class="govuk-link">contact the Equality Advisory and Support Service (EASS)</a>.</p>
 
     <h2 class="govuk-heading-l" id="technical-information-about-this-services-accessibility">Technical information about this service’s accessibility</h2>
 
-    <p>The Ministry of Justice's Analytical Platform Team is committed to
+    <p>The Ministry of Justice's Analytical Platform team is committed to
     making its service accessible, in accordance with the Public Sector Bodies
     (Websites and Mobile Applications) (No. 2) Accessibility Regulations
     2018.</p>
@@ -91,9 +91,9 @@
     <p>This service was last tested on 27th August 2020. The test was carried
     out by a member of the Analytical Platform team.</p>
 
-    <p>We checked all the pages in the control panel application (excluding
+    <p>We checked all the pages in the Control Panel application (excluding
     those that are parts of Jupyter, Airflow and RStudio) against
-    <a href="https://accessibility.18f.gov/checklist/">this accessibility
+    <a rel="external" target="_blank" href="https://accessibility.18f.gov/checklist/">this accessibility
     checklist</a>.</p>
 
     <p>A full accessibility audit by an independent third party will take

--- a/controlpanel/frontend/jinja2/a11y.html
+++ b/controlpanel/frontend/jinja2/a11y.html
@@ -9,12 +9,13 @@
 
     <h2 class="govuk-heading-l" id="accessibility-statement-for-analytical-platform">Accessibility statement for the MoJ Analytical Platform</h2>
 
-    <p>This accessibility statement applies to the Control Panel web
-    application: a part of the Ministry of Justice's Analytical Platform.</p>
+    <p>This accessibility statement applies to the Ministry of Justice's
+    Analytical Platform.</p>
 
-    <p>This website is run by Analytical Platform Team of the Ministry of
-    Justice. We want as many people as possible to be able to use this website.
-    For example, that means you should be able to:</p>
+    <p>This service is run by Analytical Platform Team of the Ministry of
+    Justice. We want as many people as possible to be able to use this service.
+    For example, on the Control Panel website (this website) you
+    should be able to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>zoom in up to 300% without the text spilling off the screen</li>

--- a/controlpanel/frontend/jinja2/a11y.html
+++ b/controlpanel/frontend/jinja2/a11y.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+
+{% set page_title = "Accessibility Statement" %}
+
+{% block content %}
+  <div class="govuk-grid-row" id="reset-container">
+   <div class="govuk-grid-column-two-thirds">
+
+
+    <h2 class="govuk-heading-l" id="accessibility-statement-for-analytical-platform">Accessibility statement for the MoJ Analytical Platform</h2>
+
+    <p>This accessibility statement applies to the Control Panel web
+    application: a part of the Ministry of Justice's Analytical Platform.</p>
+
+    <p>This website is run by Analytical Platform Team of the Ministry of
+    Justice. We want as many people as possible to be able to use this website.
+    For example, that means you should be able to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>zoom in up to 300% without the text spilling off the screen</li>
+      <li>navigate most of the website using just a keyboard</li>
+      <li>navigate most of the website using speech recognition software</li>
+      <li>listen to most of the website using a screen reader (including the
+      most recent versions of JAWS, NVDA and VoiceOver)</li>
+    </ul>
+
+    <p>We've also made the website text as simple as possible to understand.</p>
+
+    <p><a rel="external" href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a>
+    has advice on making your device easier to use if you have a disability.</p>
+
+    <h3 class="govuk-heading-m" id="how-accessible-this-website-is">How accessible this website is</h3>
+
+    <p>We know some parts of this website are not fully accessible:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>we understand there is reasonable accessibility compliance of
+        R Studio and Jupyter, and will be updating to the latest versions, but
+        there may be accessibility issues with older versions we provide via
+        this platform</li>
+        <li>you cannot change colours, contrast levels and fonts to aid
+        readability</li>
+    </ul>
+
+    <h3 class="govuk-heading-m" id="feedback-and-contact-information">Feedback and contact information</h3>
+
+    <p>Any feedback and/or requests for help should be made via the
+    <a href="https://asdslack.slack.com/messages/C4PF7QAJZ#">Analytical Platform
+    Slack Channel</a>. We also have a
+    <a href="https://user-guidance.services.alpha.mojanalytics.xyz/">platform user guide</a>
+    and
+    <a href="https://user-guidance.services.alpha.mojanalytics.xyz/support.html">platform support documentation</a>.</p>
+
+    <h3 class="govuk-heading-m" id="reporting-accessibility-problems-with-this-website">Reporting accessibility problems with this website</h3>
+
+    <p>We're always looking to improve the accessibility of this website. If
+    you find any problems not listed on this page or think we're not meeting
+    accessibility requirements, please contact us via the links listed in the
+    <a href="#feedback-and-contact-information">feedback and contact information section</a>.</p>
+
+    <h3 class="govuk-heading-m" id="enforcement-procedure">Enforcement procedure</h3>
+
+    <p>The Equality and Human Rights Commission (EHRC) is responsible for
+    enforcing the Public Sector Bodies (Websites and Mobile Applications)
+    (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').
+    If you’re not happy with how we respond to your complaint,
+    <a rel="external" href="https://www.equalityadvisoryservice.com/" class="govuk-link">contact the Equality Advisory and Support Service (EASS)</a>.</p>
+
+    <h2 class="govuk-heading-l" id="technical-information-about-this-websites-accessibility">Technical information about this website’s accessibility</h2>
+
+    <p>The Ministry of Justice's Analytical Platform Team is committed to
+    making its website accessible, in accordance with the Public Sector Bodies
+    (Websites and Mobile Applications) (No. 2) Accessibility Regulations
+    2018.</p>
+
+    <h3 class="govuk-heading-m" id="compliance-status">Compliance status</h3>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>we have been through an accessibility checklist for the Control
+        Panel and believe it is compliant</li>
+        <li>we are in the process of booking a full accessibility audit of the
+        Analaytical Platform and will promptly update this statement</li>
+    </ul>
+
+    <h2 class="govuk-heading-l" id="preparation-of-this-accessibility-statement">Preparation of this accessibility statement</h2>
+
+    <p>This statement was prepared on 22nd October 2020. It was last reviewed
+    on 23rd October 2020.</p>
+
+    <p>This website was last tested on 27th August 2020. The test was carried
+    out by a member of the Analytical Platform team.</p>
+
+    <p>We checked all the pages in the control panel application (excluding
+    those that are parts of Jupyter, Airflow and RStudio) against
+    <a href="https://accessibility.18f.gov/checklist/">this accessibility
+    checklist</a>.</p>
+
+    <p>A full accessibility audit by an independent third party will take
+    place very soon.</p>
+   </div>
+  </div>
+{% endblock %}

--- a/controlpanel/frontend/jinja2/a11y.html
+++ b/controlpanel/frontend/jinja2/a11y.html
@@ -25,14 +25,14 @@
       most recent versions of JAWS, NVDA and VoiceOver)</li>
     </ul>
 
-    <p>We've also made the website text as simple as possible to understand.</p>
+    <p>We've also made our textual content as simple as possible to understand.</p>
 
     <p><a rel="external" href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a>
     has advice on making your device easier to use if you have a disability.</p>
 
-    <h3 class="govuk-heading-m" id="how-accessible-this-website-is">How accessible this website is</h3>
+    <h3 class="govuk-heading-m" id="how-accessible-this-service-is">How accessible this service is</h3>
 
-    <p>We know some parts of this website are not fully accessible:</p>
+    <p>We know some parts of this service are not fully accessible:</p>
 
     <ul class="govuk-list govuk-list--bullet">
         <li>we understand there is reasonable accessibility compliance of
@@ -52,9 +52,9 @@
     and
     <a href="https://user-guidance.services.alpha.mojanalytics.xyz/support.html">platform support documentation</a>.</p>
 
-    <h3 class="govuk-heading-m" id="reporting-accessibility-problems-with-this-website">Reporting accessibility problems with this website</h3>
+    <h3 class="govuk-heading-m" id="reporting-accessibility-problems-with-this-service">Reporting accessibility problems with this service</h3>
 
-    <p>We're always looking to improve the accessibility of this website. If
+    <p>We're always looking to improve the accessibility of this service. If
     you find any problems not listed on this page or think we're not meeting
     accessibility requirements, please contact us via the links listed in the
     <a href="#feedback-and-contact-information">feedback and contact information section</a>.</p>
@@ -67,10 +67,10 @@
     If you’re not happy with how we respond to your complaint,
     <a rel="external" href="https://www.equalityadvisoryservice.com/" class="govuk-link">contact the Equality Advisory and Support Service (EASS)</a>.</p>
 
-    <h2 class="govuk-heading-l" id="technical-information-about-this-websites-accessibility">Technical information about this website’s accessibility</h2>
+    <h2 class="govuk-heading-l" id="technical-information-about-this-services-accessibility">Technical information about this service’s accessibility</h2>
 
     <p>The Ministry of Justice's Analytical Platform Team is committed to
-    making its website accessible, in accordance with the Public Sector Bodies
+    making its service accessible, in accordance with the Public Sector Bodies
     (Websites and Mobile Applications) (No. 2) Accessibility Regulations
     2018.</p>
 
@@ -88,7 +88,7 @@
     <p>This statement was prepared on 22nd October 2020. It was last reviewed
     on 23rd October 2020.</p>
 
-    <p>This website was last tested on 27th August 2020. The test was carried
+    <p>This service was last tested on 27th August 2020. The test was carried
     out by a member of the Analytical Platform team.</p>
 
     <p>We checked all the pages in the control panel application (excluding

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -155,6 +155,10 @@
             'text': "Analytical platform slack channel",
           },
           {
+            'href': url('accessibility'),
+            'text': "Accessibility Statement",
+          },
+          {
             'href': url('whats-new'),
             'text': "What's new?",
           },

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -156,7 +156,7 @@
           },
           {
             'href': url('accessibility'),
-            'text': "Accessibility Statement",
+            'text': "Accessibility statement",
           },
           {
             'href': url('whats-new'),

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -54,9 +54,9 @@ urlpatterns = [
     path("webapp-datasource-access/<int:pk>/delete/", views.RevokeAppAccess.as_view(), name="revoke-app-access"),
     path("reset-user-home/", views.ResetHome.as_view(), name="home-reset"),
     path("whats-new/", views.WhatsNew.as_view(), name="whats-new"),
-
     path("releases/", views.ReleaseList.as_view(), name="list-tool-releases"),
     path("release/new/", views.ReleaseCreate.as_view(), name="create-tool-release"),
     path("release/<int:pk>/", views.ReleaseDetail.as_view(), name="manage-tool-release"),
     path("release/<int:pk>/delete/", views.ReleaseDelete.as_view(), name="delete-tool-release"),
+    path("accessibility/", views.Accessibility.as_view(), name="accessibility"),
 ]

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -68,6 +68,7 @@ from controlpanel.frontend.views.release import (
 )
 from controlpanel.frontend.views.reset import ResetHome
 from controlpanel.frontend.views.whats_new import WhatsNew
+from controlpanel.frontend.views.accessibility import Accessibility 
 
 
 class IndexView(LoginRequiredMixin, TemplateView):

--- a/controlpanel/frontend/views/accessibility.py
+++ b/controlpanel/frontend/views/accessibility.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic.base import TemplateView
+import requests
+
+
+class Accessibility(LoginRequiredMixin, TemplateView):
+    template_name = "a11y.html"


### PR DESCRIPTION
## What

This PR adds several things:

* An "Accessibility Statement" link into our footer.
* A view for displaying the a11y statement.
* A template containing the content, based upon [this sample](https://www.gov.uk/government/publications/sample-accessibility-statement/sample-accessibility-statement-for-a-fictional-public-sector-website).

I've added the suggested site-specific comments to the appropriate sections of the template:

* we have been through an accessibility checklist for the Control Panel and believe it is compliant
* we understand there is reasonable accessibility compliance of R Studio and Jupyter, and will be updating to the latest versions
* we are in the process of booking a full accessibility audit of the Analaytical Platform and will promptly update this statement

**PLEASE CHECK THE CONTENT** - feedback and suggested changes most welcome as part of the review process for this PR.

## How to review

1. Start the app locally then log in.
2. Find the a11y statement link in the footer.
3. Click it and wonder at the content therein.

Related Trello ticket: https://trello.com/c/Fx2OdCRq/791-write-an-accessibility-statement