### PR TITLE
Add help tab for user support content/videos

### DIFF
--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -121,6 +121,11 @@
         "active": page_name == "groups",
         "admin": request.user.is_superuser,
       },
+      {
+        "text": "Help",
+        "href": url("help"),
+        "active": page_name == "help",
+      },
     ],
   }) }}
   {% endif %}

--- a/controlpanel/frontend/jinja2/help.html
+++ b/controlpanel/frontend/jinja2/help.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% set page_title = "Help" %}
+
+{% block content %}
+  <div class="govuk-grid-row" id="reset-container">
+      <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Help</h1>
+
+    <p class="govuk-body">Common queries, support tasks and problems are
+    explained in the following videos.</p>
+
+    <p class="govuk-body">Should you still require help, please visit our
+    <a href="https://asdslack.slack.com/messages/C4PF7QAJZ#">support channel on Slack</a>, ask your question whilst remembering to tell us your
+    username and the name of any affected S3 buckets or applications on the
+    analytical platform that are part of the context of your request.</p>
+
+    <h2 class="govuk-heading-m">How do I..?</h2>
+
+    <p>Home Reset:</p>
+
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ziu8dWRRcVM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </div>
+    </div>
+{% endblock %}

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path("webapp-datasource-access/<int:pk>/delete/", views.RevokeAppAccess.as_view(), name="revoke-app-access"),
     path("reset-user-home/", views.ResetHome.as_view(), name="home-reset"),
     path("whats-new/", views.WhatsNew.as_view(), name="whats-new"),
+    path("help/", views.Help.as_view(), name="help"),
 
     path("releases/", views.ReleaseList.as_view(), name="list-tool-releases"),
     path("release/new/", views.ReleaseCreate.as_view(), name="create-tool-release"),

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -68,6 +68,7 @@ from controlpanel.frontend.views.release import (
 )
 from controlpanel.frontend.views.reset import ResetHome
 from controlpanel.frontend.views.whats_new import WhatsNew
+from controlpanel.frontend.views.help import Help
 
 
 class IndexView(LoginRequiredMixin, TemplateView):

--- a/controlpanel/frontend/views/help.py
+++ b/controlpanel/frontend/views/help.py
@@ -1,0 +1,6 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic.base import TemplateView
+
+
+class Help(LoginRequiredMixin, TemplateView):
+    template_name = "help.html"


### PR DESCRIPTION
## What

This is a work in progress. Discussion of content/copy should happen in this PR ticket and I'll refine the code as we find a consensus for what this should look like.

## How to review

1. Start the app locally.
2. Log in.
2. Click the "Help" tab.

Related Trello tickets:

* https://trello.com/c/NQTZLrqf/825-add-a-help-tab-to-the-control-panel-for-easy-to-access-user-guidance-and-videos
* https://trello.com/c/ghEd5K3C/810-create-a-reset-user-home-2-min-video-training-resource-to-explain-the-process-and-reasons-for-using-it
* https://trello.com/c/LiXzZWYq/807-create-a-how-to-start-using-ap-2-minute-video-training-resource-giving-step-by-step-instructions-for-signing-up-and-logging-in
