### PR TITLE
Add 'list bucket version' permission on our S3 buckets.

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -100,6 +100,7 @@ BASE_S3_ACCESS_POLICY = {
             "Action": [
                 "s3:GetBucketLocation",
                 "s3:ListAllMyBuckets",
+                "s3:ListBucketVersions",
             ],
             "Effect": "Allow",
             "Resource": ["arn:aws:s3:::*"],

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -477,6 +477,7 @@ def test_create_group(iam, settings):
     assert stmt['Action'] == [
         's3:GetBucketLocation',
         's3:ListAllMyBuckets',
+        's3:ListBucketVersions',
     ]
     assert stmt['Resource'] == ['arn:aws:s3:::*']
     assert stmt['Effect'] == 'Allow'


### PR DESCRIPTION
## What

Due to an update in AWS, and because all our S3 buckets are versioned, all users need to have the `s3:ListBucketVersions` permission in order to be able to see what's in their buckets. See image reported by user in our support channel:

![image](https://user-images.githubusercontent.com/37602/98547206-ba86db80-228f-11eb-802e-9b4ea96ad86c.png)

## How to review

1. ask @damacus 
