### PR TITLE
Dockerfile: pull alpine Base image from quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10 AS base
+FROM quay.io/mojanalytics/alpine:3.10 AS base
 
 LABEL maintainer="andy.driver@digital.justice.gov.uk"
 


### PR DESCRIPTION
### Why
This is the same docker image but we now pull from quay.io (public)
to avoid recently introduced DockerHub limits.

### Details
Currently Concourse build fails with the following error message because of DockerHub rate limits:

```
Sending build context to Docker daemon  1.131MB
Step 1/35 : FROM alpine:3.10 AS base
toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

### Why quay.io
We already use it for other things and in this case the fact this repository is public helps as we don't have to modify the GitHub Action.