### PR TITLE
Dockerfile: Also pull node:8-alpine/jsdep image from quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY tests tests
 
 
 # fetch javascript dependencies in separate stage
-FROM node:8-alpine AS jsdep
+FROM quay.io/mojanalytics/node:8-alpine AS jsdep
 COPY package.json package-lock.json ./
 COPY controlpanel/frontend/static src
 RUN npm install && \


### PR DESCRIPTION
We missed this `BASE` image in previous commit. 

Again this is to avoid hitting the newly introduced DockerHub pulls rate limit and we're pulling the same image but from our (public) quay.io repository.