### PR TITLE
Doc: Note that we should use Helm v2

### DIFF
--- a/doc/running.md
+++ b/doc/running.md
@@ -280,6 +280,8 @@ kubectl cluster-info
 Install Helm (the K8s package manager) by following
 [these instructions for your OS](https://helm.sh/docs/intro/install/).
 
+**NOTE**: Be sure to use Helm 2. Helm 3 may not work (e.g. a new joiner couldn't run the tests because of differences in where Helm keep the repostory cache)
+
 You'll need to initialise Helm too:
 
 ```sh


### PR DESCRIPTION
### What
A new joiner was getting the following error while running the tests using Helm 3.x:

```
FAILED tests/api/models/test_tool.py::test_tool_app_version[chart-with-appVersion] - controlpanel.api.helm.HelmError: Error while opening/parsing helm repository cache: 'reposi...
```

So this is to add a note/warning that you should use Helm 2.x when setting your local environment.
