### PR TITLE
Improve the usability flow of home-directory reset

### DIFF
--- a/controlpanel/frontend/jinja2/reset.html
+++ b/controlpanel/frontend/jinja2/reset.html
@@ -61,7 +61,10 @@
               </div>
             </div>
           </fieldset>
-          <input type="submit" class="govuk-button govuk-button--warning" value="Reset"/>
+          <input type="submit"
+                 class="govuk-button govuk-button--warning cpanel-button--destructive js-confirm"
+                 data-confirm-message="I understand that my conda environment will be irretrievably reset"
+                 value="Reset"/>
           </form>
         </div>
     </div>


### PR DESCRIPTION
## What
This changes the usability of the reset home-directory reset flow by requiring a second explicit confirmation of the reset process.

The only change is additional input tag classes and a confirmation message.

## How to review
1. Go to analytical tools (/tools/) on the control panel
2. Click on reset home directory
3. Click the confirmation tick box
4. Click the reset button
5. You will get a final confirmation message with a choice to continue or cancel.
6. Click cancel will not do anything
7. Repeat the previous steps and ensure that "Ok" triggers the reset.

Satisfies the requirement of https://trello.com/c/TJGXpIXj/859-the-home-reset-button-should-include-a-confirmation-before-actually-resetting
