### PR TITLE
Ensure all JavaScript alerts on destructive buttons are configured correctly with the expected CSS classes.

### DIFF
--- a/controlpanel/frontend/jinja2/user-detail.html
+++ b/controlpanel/frontend/jinja2/user-detail.html
@@ -99,8 +99,8 @@
 <section class="cpanel-section">
   <form action="{{ url("delete-user", kwargs={ "pk": user.auth0_id }) }}" method="post">
     {{ csrf_input }}
-    <button class="govuk-button cpanel-button--destructive confirm"
-            data-confirmation-prompt="Are you sure you want to delete this user?">
+    <button class="govuk-button cpanel-button--destructive js-confirm"
+            data-confirm-message="Are you sure you want to delete this user?">
       Delete user
     </button>
   </form>

--- a/controlpanel/frontend/jinja2/webapp-detail.html
+++ b/controlpanel/frontend/jinja2/webapp-detail.html
@@ -311,7 +311,7 @@
 <section class="cpanel-section">
   <form action="{{ url('delete-app', kwargs={ "pk": app.id }) }}" method="post">
     {{ csrf_input }}
-    <button class="govuk-button cpanel-button--destructive"
+    <button class="govuk-button cpanel-button--destructive js-confirm"
             data-confirm-message="Are you sure you want to delete this app?">
       Delete app
     </button>


### PR DESCRIPTION
## What

Some of the confirmation dialog alerts were not firing when they should have been. This was due to the wrong css class and data attribute set in the affected `button` tag. It meant admins could delete a user without a confirmation check (dangerous, due to accidental clicking).

Now the updated buttons work like this:

![are_you_sure](https://user-images.githubusercontent.com/37602/100755276-ea835380-33e3-11eb-8f1a-43b9455eff31.gif)

## How to review

1. Start the app locally.
2. Log in as an admin user.
3. Visit the user or webapp admin functionality and click on an individual user/app instance.
4. Click on the delete button: an alert will magically appear..!

This PR has no ticket since it's an example of code gardening :rose: (small steps, carefully taken, as we go about our other "scheduled" coding tasks). Thanks to @davidread for pointing out the problem.
