### PR TITLE
Ensure buttons marked cpanel-button--destructive have confirmation alerts

### DIFF
--- a/controlpanel/frontend/jinja2/datasource-access-update.html
+++ b/controlpanel/frontend/jinja2/datasource-access-update.html
@@ -54,7 +54,7 @@
 <section class="cpanel-section">
   <form method="post" action="{{ revoke_url }}">
     {{ csrf_input }}
-    <button class="govuk-button cpanel-button--destructive">Revoke access</button>
+    <button class="govuk-button cpanel-button--destructive js-confirm">Revoke access</button>
   </form>
 </section>
 {% endif %}

--- a/controlpanel/frontend/jinja2/includes/parameter-list.html
+++ b/controlpanel/frontend/jinja2/includes/parameter-list.html
@@ -20,7 +20,7 @@
       <td class="govuk-table__cell">
         <form method="POST" action="{{ url("delete-parameter", kwargs={ "pk": parameter.id }) }}">
             {{ csrf_input }}
-            <button class="govuk-button cpanel-button--destructive">Delete parameter</button>
+            <button class="govuk-button cpanel-button--destructive js-confirm">Delete parameter</button>
         </form>
       </td>
     </tr>

--- a/controlpanel/frontend/jinja2/policy-update.html
+++ b/controlpanel/frontend/jinja2/policy-update.html
@@ -63,6 +63,6 @@
 
   <form method="POST" action="{{ url("delete-policy", kwargs={ "pk": policy.id }) }}">
       {{ csrf_input }}
-      <button class="govuk-button cpanel-button--destructive">Delete group</button>
+      <button class="govuk-button cpanel-button--destructive js-confirm">Delete group</button>
   </form>
 {% endblock %}

--- a/controlpanel/frontend/jinja2/webapp-detail.html
+++ b/controlpanel/frontend/jinja2/webapp-detail.html
@@ -170,7 +170,7 @@
           {% if user.id %}
             <form action="{{ url('revoke-app-admin', kwargs={ "pk": app.id, "user_id": user.id }) }}" method="post">
               {{ csrf_input }}
-              <button class="confirm govuk-button govuk-button--secondary right">
+              <button class="js-confirm govuk-button govuk-button--secondary right">
               Revoke admin
               </button>
             </form>
@@ -247,14 +247,14 @@
           <form action="{{ url('update-app-access', kwargs={ "pk": bucket.id }) }}" method="post" class="form-control-prefix">
             {{ csrf_input }}
             <input type="hidden" name="access_level" value="{{ yes_no(bucket.access_level, 'readwrite', 'readonly', 'readwrite') }}">
-            <button class="confirm govuk-button govuk-button--secondary">
+            <button class="js-confirm govuk-button govuk-button--secondary">
               Set {{ yes_no(bucket.access_level, 'readwrite', 'read only', 'read/write') }}
             </button>
           </form>
           {% if request.user.has_perm('api.remove_app_bucket', app) %}
           <form action="{{ url('revoke-app-access', kwargs={ "pk": bucket.id }) }}" method="post" class="form-control-prefix">
             {{ csrf_input }}
-            <button class="confirm govuk-button govuk-button--secondary">
+            <button class="js-confirm govuk-button govuk-button--secondary">
               Disconnect
             </button>
           </form>


### PR DESCRIPTION
## What

Following discussion with @davidread on Slack, we decided that the scope of UI elements that needed confirmation alerts should be widened to buttons associated with the `cpanel-button--destructive` class. In addition, those buttons that had mistakenly been mislabelled with the `confirm` CSS class have been updated to `js-confirm`.

In #859 I only updated buttons that had a confirmation message associated with them (indicating such functionality was missing). It turns out that if a button is labelled for confirmation no message is required since it defaults to "Are you sure..?". 

## How to review

1. Do you see an alert when you click on the associated buttons..?

This is an ad-hoc code gardening PR for cleaning up and mowing the proverbial lawn of JavaScript. :sunflower: :seedling: 
