### PR TITLE
Add login-fail page and recovery link to control panel.

### DIFF
--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -100,9 +100,11 @@ class SSEConsumer(PatchedAsyncHttpConsumer):
         """
         self.streaming = False
 
-        # leave the group
-        group = sanitize_dns_label(self.scope.get("user").auth0_id)
-        await self.channel_layer.group_discard(group, self.channel_name)
+        # leave the group if user is logged in.
+        user = self.scope.get("user")
+        if user.is_authenticated:
+            group = sanitize_dns_label(user.auth0_id)
+            await self.channel_layer.group_discard(group, self.channel_name)
 
 
 class BackgroundTaskConsumer(SyncConsumer):

--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% set page_title = "Login Failure" %}
+
+{% block content %}
+  <div class="govuk-grid-row" id="reset-container">
+   <div class="govuk-grid-column-two-thirds">
+
+
+    <h2 class="govuk-heading-l">Login Failure</h2>
+
+    <p>Something went wrong when you tried to authenticate.</p>
+
+    <p>Please <a href="https://{{ environment }}-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.{{ environment }}.mojanalytics.xyz%2Foidc%2Flogout%2F">try again</a>.</p>
+   </div>
+  </div>
+{% endblock %}

--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -11,7 +11,9 @@
 
     <p>Something went wrong when you tried to authenticate.</p>
 
-    <p>Please <a href="https://{{ environment }}-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.{{ environment }}.mojanalytics.xyz%2Foidc%2Flogout%2F">try again</a>.</p>
+    <p>Please
+    <a href="https://{{ environment }}-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.{{ environment }}.mojanalytics.xyz%2Foidc%2Flogout%2F">reset your session</a>,
+    and try again.</p>
    </div>
   </div>
 {% endblock %}

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path("webapp-datasource-access/<int:pk>/delete/", views.RevokeAppAccess.as_view(), name="revoke-app-access"),
     path("reset-user-home/", views.ResetHome.as_view(), name="home-reset"),
     path("whats-new/", views.WhatsNew.as_view(), name="whats-new"),
+    path("login-fail/", views.LoginFail.as_view(), name="login-fail"),
     path("releases/", views.ReleaseList.as_view(), name="list-tool-releases"),
     path("release/new/", views.ReleaseCreate.as_view(), name="create-tool-release"),
     path("release/<int:pk>/", views.ReleaseDetail.as_view(), name="manage-tool-release"),

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -69,6 +69,7 @@ from controlpanel.frontend.views.release import (
 from controlpanel.frontend.views.reset import ResetHome
 from controlpanel.frontend.views.whats_new import WhatsNew
 from controlpanel.frontend.views.accessibility import Accessibility 
+from controlpanel.frontend.views.login_fail import LoginFail
 
 
 class IndexView(LoginRequiredMixin, TemplateView):

--- a/controlpanel/frontend/views/login_fail.py
+++ b/controlpanel/frontend/views/login_fail.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic.base import TemplateView
+import requests
+
+
+class LoginFail(TemplateView):
+    template_name = "login-fail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["environment"] = settings.ENV 
+        return context

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -155,7 +155,7 @@ LOGIN_URL = "oidc_authentication_init"
 LOGOUT_REDIRECT_URL = "/"
 
 # URL where requests are redirected after a failed login
-LOGIN_REDIRECT_URL_FAILURE = "/"
+LOGIN_REDIRECT_URL_FAILURE = "/login-fail/"
 
 # Length of time it takes for an OIDC ID token to expire (default 15m)
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 15 * 60


### PR DESCRIPTION
## What

This PR fixes [this Trello ticket](https://trello.com/c/2X2Bb3UM/864-cp-login-errors-are-displayed-instead-of-redirect-loop) and mitigates the misconfiguration described in [this Trello ticket](https://trello.com/c/0i7JurE1/863-allow-a-user-to-cp-rstudio-after-having-already-logged-into-an-app) (work on which is ongoing with Auth0).

I have made the following changes:

* The `LOGIN_REDIRECT_URL_FAILURE` setting in the configuration of the application is changed from `/` (causing an infinite loop) to a new endpoint `/login-fail/`.
* The new endpoint (see screenie below) includes a link that clears the Auth0 cookie for the user's session and redirects them back to the control panel application in order to log in again from a clean state.
* I've also made a slight modification to `frontend/consumers.py` to check if a `user` is logged in before using the `auth0_id` attribute. This was causing an unhandled exception in the background worker when the (not-logged-in) user was redirected to the `login-fail` page.

![fail](https://user-images.githubusercontent.com/37602/101014326-9d2af180-355d-11eb-80ce-ca8f207b808b.png)

It's also important to note that for this change to work, we need to update the Auth0 tenant settings so that the `/oidc/logout/` endpoint is in the "Allowed Logout URLs" setting (see screenie below).

![tenant_logout](https://user-images.githubusercontent.com/37602/101014718-378b3500-355e-11eb-8874-4406718017d5.png)

## How to review

1. We should deploy this branch to `dev`.
2. We should have a working RShiny app running in `dev`.
3. Work through the steps to recreate the "wrong cookie" bug when a user tries to log into the control panel after having been logged into an application.
4. The user should see the expected login challenge rather than an error complaining about cookies and recursive redirects.

This is the API endpoint we're using to achieve the clearing of the Auth0 cookie: https://auth0.com/docs/api/authentication#logout (documentation for which can be [found here](https://auth0.com/docs/logout/log-users-out-of-auth0)). We use [this feature of the API](https://auth0.com/docs/logout/redirect-users-after-logout) to redirect users back to our application.
