### PR TITLE
Update the fallback default Elastic index for user app logs.

### DIFF
--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -535,7 +535,7 @@ ELASTICSEARCH = {
         ),
         'app-logs': os.environ.get(
             'ELASTICSEARCH_INDEX_APPLOGS',
-            f'logstash-apps-{ENV}-*',
+            f'Node-{ENV}-*',
         ),
     },
 }


### PR DESCRIPTION
## What

Now that Elastic is logging to a new index, the default fallback value should be changed in the Control Panel's settings, to reflect this. In addition, the `ELASTICSEARCH_INDEX_APPLOGS` environment variable should be revised (where???) to reflect this too.

## How to review

1. Is the index in the diff the correct one for Elastic.
2. ???
3. Profit!

This is some quick code gardening to make sure we don't grow weeds in our code.