### PR TITLE
Ensure chart name validation and chart context values re-used.

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -285,6 +285,26 @@ class ToolReleaseForm(forms.ModelForm):
         else:
             return []
 
+    def clean_chart_name(self):
+        """
+        Ensures that the helm chart name entered by the user is a valid one.
+
+        Why not use a "choice" argument in the Tool model's class? It would
+        result in a new Django migration for the database to enforce this (and
+        we'd have to keep adding new migrations to the database every time we
+        created a new helm chart for a new tool). Furthermore, the HTML select
+        field we'd use in the form isn't supported in the macros we use.
+
+        Hence the path of least resistance with this custom form validation.
+        """
+        valid_charts = ["airflow-sqlite", "jupyter-lab", "rstudio", ]
+        value = self.cleaned_data['chart_name']
+        if value not in valid_charts:
+            raise ValidationError(
+                f"'{value}' is not a valid helm chart name. ",
+            )
+        return value
+
     class Meta:
         model = Tool
         fields = ["name", "chart_name", "version", "is_restricted", ]

--- a/controlpanel/frontend/jinja2/release-create.html
+++ b/controlpanel/frontend/jinja2/release-create.html
@@ -42,7 +42,7 @@
       },
       "classes": "govuk-!-width-two-thirds",
       "hint": {
-        "text": 'Helm chart name. 60 chars max, only lowercase letters and hyphens'
+        "text": 'Helm chart name. Use only one of: airflow-sqlite, jupyter-lab or rstudio'
       },
       "name": "chart_name",
       "attributes": {

--- a/controlpanel/frontend/jinja2/release-detail.html
+++ b/controlpanel/frontend/jinja2/release-detail.html
@@ -44,7 +44,7 @@ Create a new release of a tool in the analytical platform.
       },
       "classes": "govuk-!-width-two-thirds",
       "hint": {
-        "text": 'Helm chart name. 60 chars max, only lowercase letters and hyphens'
+        "text": 'Helm chart name. Use only one of: airflow-sqlite, jupyter-lab or rstudio'
       },
       "name": "chart_name",
       "attributes": {

--- a/tests/frontend/views/test_release.py
+++ b/tests/frontend/views/test_release.py
@@ -19,3 +19,29 @@ def test_release_detail_context_data():
     v.object = mock_object
     result = v.get_context_data()
     assert result["target_users"] == "aldo, nicholas"
+
+
+def test_release_create_form_valid():
+    """
+    Ensure that JSON values from a previous release are annotated to the
+    new release.
+
+    HERE BE DRAGONS: use of mocking to avoid database related errors with
+    pytest test-runner (that doesn't create temp test databases).
+    """
+    JSONValues = {"foo": "bar", }  # placeholder mock data for JSON values.
+    v = release.ReleaseCreate()
+    v.request = mock.MagicMock()
+    old_tool = mock.MagicMock()
+    old_tool.values = JSONValues
+    v.request.method = "POST"
+    mock_form = mock.MagicMock()
+    mock_object = mock.MagicMock()
+    mock_form.save.return_value = mock_object
+    mock_form.get_target_users.return_value = []
+    mock_tool = mock.MagicMock()
+    mock_tool.objects.filter().exclude().order_by().first.return_value = old_tool
+    with mock.patch("controlpanel.frontend.views.release.Tool", mock_tool):
+        v.form_valid(mock_form)
+    assert mock_object.values == JSONValues
+    mock_object.save.assert_called_once_with()


### PR DESCRIPTION
## What

This PR addresses the bug spotted by Aldo, where the helm chart for a new release does not contain the JSON context values.

It introduces the following changes:

* Ensure that only *valid* chart names can be used in the release form.
* Update the UI to remind the user what these valid chart names are.
* When a new release is created, the JSON values from the release for the most recent live version of the referenced helm chart are copied over to the new release.
* A unit test to ensure the JSON values are copied as expected.

Here's a GIF-y of the changes in the UI:

![create_release](https://user-images.githubusercontent.com/37602/103651873-21580680-4f5a-11eb-9b7e-859fe1c5cabe.gif)

## How to review

1. Create a new release with a valid chart name, as per the GIF-y above.
2. Open the Django shell: `./manage.py shell`
3. Import the model for releases: `from controlpanel.api.models import Tool`
4. Get the most recent release relating to your chart name (i.e. the one you just created): `release = Tool.objects.filter(chart_name="jupyter-lab").order_by("-created").first()`
5. Ensure you see JSON data in the values field: `release.value`
6. Exit the shell: `exit()`.

See Jira ticket: https://dsdmoj.atlassian.net/browse/ANPL-233
