### PR TITLE
Add repository syncronization GitHub action.

### DIFF
--- a/.github/workflows/sync-repo.yaml
+++ b/.github/workflows/sync-repo.yaml
@@ -1,0 +1,21 @@
+---
+name: Repo Sync
+
+"on":
+  push:
+    branches: [main]
+
+jobs:
+  repo-sync:
+    name: Repo Sync
+    if: ${{ github.repository }} == 'analytics-platform-control-panel'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync main branch to public fork
+        uses: wei/git-sync@v2
+        with:
+          source_repo: "${{ github.repository }}"
+          source_branch: "main"
+          destination_repo: "ministryofjustice/analytics-platform-control-panel-public"
+          destination_branch: "main"
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## What

This GitHub action change will ensure our "internal" repository for the control panel, always pushes any changes to the public version. This is required because we use self-hosted Github Action runners.

## How to review

The `ministryofjustice/analytics-platform-control-panel-public` repository should match the state of this repository.

This GitHub runner is a part of the work needed to fulfil this ticket: ANPL-228