### PR TITLE
Fix elastic filter to correct key.

### DIFF
--- a/controlpanel/api/elasticsearch.py
+++ b/controlpanel/api/elasticsearch.py
@@ -53,7 +53,7 @@ def app_logs(app, num_hours=None):
     s = s.filter(
         Q('exists', field='message')
         & Q('term', **{
-            "app_name.keyword": f'{app.release_name}-webapp',
+            "kubernetes.labels.app.keyword": f'{app.release_name}-webapp',
         })
     )
 


### PR DESCRIPTION
## What

Logs are not returned because the application is filtering on the wrong key for the app's name. This change was recommended by @tomskelley-gjs to fix that.

## How to review

1. Deploy to `dev`
2. Check for logs..?!?!? Alternatively, check the expected search request is coming into Elastic.
3. ???
4. Profit
