### PR TITLE
Fix duplicate datasource name problem.

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -73,6 +73,7 @@ class CreateAppForm(forms.Form):
                 try:
                     S3Bucket.objects.get(name=new_datasource)
                     self.add_error(
+                        "new_datasource_name",
                         f"Datasource named {new_datasource} already exists"
                     )
                 except S3Bucket.DoesNotExist:

--- a/tests/frontend/test_forms.py
+++ b/tests/frontend/test_forms.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest import mock
 from controlpanel.frontend import forms
-
+from controlpanel.api.models import S3Bucket
 
 
 def test_tool_release_form_get_target_users():
@@ -16,6 +16,135 @@ def test_tool_release_form_get_target_users():
     mock_user = mock.MagicMock()
     with mock.patch("controlpanel.frontend.forms.User", mock_user):
         f.get_target_users()
-        mock_user.objects.filter.assert_called_once_with(username__in=set([
-            "aldo", "nicholas", "cal"
-        ]))
+        mock_user.objects.filter.assert_called_once_with(
+            username__in=set(["aldo", "nicholas", "cal"])
+        )
+
+
+def test_create_app_form_clean_new_datasource():
+    """
+    The CreateAppForm class has a bespoke "clean" method. We should ensure it
+    checks the expected things in the correct way.
+    """
+    f = forms.CreateAppForm(
+        data={
+            "repo_url": "https://github.com/moj-analytical-services/my_repo",
+            "connect_bucket": "new",
+            "new_datasource_name": "test-bucketname",
+        }
+    )
+    f.clean_repo_url = mock.MagicMock()
+    mock_s3 = mock.MagicMock()
+    mock_s3.get.side_effect = S3Bucket.DoesNotExist("Boom")
+    # A valid form returns True.
+    with mock.patch("controlpanel.frontend.forms.S3Bucket.objects", mock_s3):
+        assert f.is_valid() is True
+    # A new datasource name is required if the connection is new.
+    f = forms.CreateAppForm(
+        data={
+            "repo_url": "https://github.com/moj-analytical-services/my_repo",
+            "connect_bucket": "new",
+        }
+    )
+    f.clean_repo_url = mock.MagicMock()
+    assert f.is_valid() is False
+    assert "new_datasource_name" in f.errors
+    # If a datasource already exists, report the duplication.
+    f = forms.CreateAppForm(
+        data={
+            "repo_url": "https://github.com/moj-analytical-services/my_repo",
+            "connect_bucket": "new",
+            "new_datasource_name": "test-bucketname",
+        }
+    )
+    f.clean_repo_url = mock.MagicMock()
+    mock_s3 = mock.MagicMock()
+    with mock.patch("controlpanel.frontend.forms.S3Bucket.objects", mock_s3):
+        assert f.is_valid() is False
+        assert "new_datasource_name" in f.errors
+
+
+def test_create_app_form_clean_existing_datasource():
+    """
+    An existing datasource name is required if the datasource is marked as
+    already existing.
+    """
+    f = forms.CreateAppForm(
+        data={
+            "repo_url": "https://github.com/moj-analytical-services/my_repo",
+            "connect_bucket": "existing",
+        }
+    )
+    f.clean_repo_url = mock.MagicMock()
+    # A valid form returns True.
+    assert f.is_valid() is False
+    assert "existing_datasource_id" in f.errors
+
+
+def test_create_app_form_clean_repo_url():
+    """
+    Ensure the various states of a GitHub repository result in a valid form or
+    errors.
+    """
+    # The good case.
+    f = forms.CreateAppForm(
+        data={
+            "repo_url": "https://github.com/moj-analytical-services/my_repo",
+            "connect_bucket": "new",
+            "new_datasource_name": "test-bucketname",
+        }
+    )
+    f.request = mock.MagicMock()
+    mock_get_repo = mock.MagicMock(return_value=True)
+    mock_app = mock.MagicMock()
+    mock_app.objects.filter().exists.return_value = False
+    mock_s3 = mock.MagicMock()
+    mock_s3.get.side_effect = S3Bucket.DoesNotExist("Boom")
+    with mock.patch(
+        "controlpanel.frontend.forms.get_repository", mock_get_repo
+    ), mock.patch("controlpanel.frontend.forms.App", mock_app), mock.patch(
+        "controlpanel.frontend.forms.S3Bucket.objects", mock_s3
+    ):
+        assert f.is_valid() is True
+    # Repo not found.
+    f = forms.CreateAppForm(
+        data={
+            "repo_url": "https://github.com/moj-analytical-services/my_repo",
+            "connect_bucket": "new",
+            "new_datasource_name": "test-bucketname",
+        }
+    )
+    f.request = mock.MagicMock()
+    mock_get_repo = mock.MagicMock(return_value=None)
+    mock_app = mock.MagicMock()
+    mock_app.objects.filter().exists.return_value = False
+    mock_s3 = mock.MagicMock()
+    mock_s3.get.side_effect = S3Bucket.DoesNotExist("Boom")
+    with mock.patch(
+        "controlpanel.frontend.forms.get_repository", mock_get_repo
+    ), mock.patch("controlpanel.frontend.forms.App", mock_app), mock.patch(
+        "controlpanel.frontend.forms.S3Bucket.objects", mock_s3
+    ):
+        assert f.is_valid() is False
+        assert "repo_url" in f.errors
+    # App already exists.
+    f = forms.CreateAppForm(
+        data={
+            "repo_url": "https://github.com/moj-analytical-services/my_repo",
+            "connect_bucket": "new",
+            "new_datasource_name": "test-bucketname",
+        }
+    )
+    f.request = mock.MagicMock()
+    mock_get_repo = mock.MagicMock(return_value=True)
+    mock_app = mock.MagicMock()
+    mock_app.objects.filter().exists.return_value = True
+    mock_s3 = mock.MagicMock()
+    mock_s3.get.side_effect = S3Bucket.DoesNotExist("Boom")
+    with mock.patch(
+        "controlpanel.frontend.forms.get_repository", mock_get_repo
+    ), mock.patch("controlpanel.frontend.forms.App", mock_app), mock.patch(
+        "controlpanel.frontend.forms.S3Bucket.objects", mock_s3
+    ):
+        assert f.is_valid() is False
+        assert "repo_url" in f.errors


### PR DESCRIPTION
## What

This PR makes a very minor change to an incorrect line of code which was causing 500 errors. This bug is covered by: https://dsdmoj.atlassian.net/browse/ANPL-411

If the new data source already existed, then an error was raised in an incorrect manner, thus causing the 500 errors.

This PR:

* Fixes the problem validation error.
* Adds a bunch of unit tests around the changed form so we can be sure its bespoke validation works as expected.
* Black formatted the unit tests.

## How to review

1. `make clean`
2. `make build`
3. `make test`
