### PR TITLE
Correctly delete helm chart releases (including when deleting a user).

### DIFF
--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -152,14 +152,22 @@ def upgrade_release(release, chart, *args):
     )
 
 
-def delete(*args):
+def delete(namespace, *args):
     """
-    Delete a helm chart identified by the content of the args list. Logs the
-    stdout result of the command.
+    Delete helm charts identified by the content of the args list in the
+    referenced namespace.
+
+    Logs the stdout result of the command.
     """
+    if not namespace:
+        raise ValueError(
+            "Cannot proceed: a namespace needed for removal of release."
+        )
     proc = _execute(
-        "delete",
+        "uninstall",
         *args,
+        "--namespace",
+        namespace
     )
     stdout = proc.stdout.read()
     log.info(stdout)

--- a/tests/api/cluster/test_app.py
+++ b/tests/api/cluster/test_app.py
@@ -26,7 +26,7 @@ def test_app_delete(aws, app, authz, helm):
 
     aws.delete_role.assert_called_with(app.iam_role_name)
     authz.delete_group.assert_called_with(group_name=app.slug)
-    helm.delete.assert_called_with(app.release_name)
+    helm.delete.assert_called_with(cluster.App.APPS_NS, app.release_name)
 
 
 mock_ingress = MagicMock(name="Ingress")

--- a/tests/api/cluster/test_user.py
+++ b/tests/api/cluster/test_user.py
@@ -54,14 +54,15 @@ def test_reset_home(helm, users):
 
 def test_delete(aws, helm, users):
     user = users['normal_user']
+    helm.list_releases.return_value = ["chart-release", ]
     cluster.User(user).delete()
 
     aws.delete_role.assert_called_with(user.iam_role_name)
-    expected_calls = [
-        call(helm.list_releases.return_value),
-        call(f"init-user-{user.slug}"),
-    ]
-    helm.delete.assert_has_calls(expected_calls)
+    helm.delete.assert_called_once_with(
+        user.k8s_namespace,
+        "chart-release",
+        f"init-user-{user.slug}"
+    )
 
 
 def test_delete_with_no_releases(aws, helm, users):
@@ -74,4 +75,7 @@ def test_delete_with_no_releases(aws, helm, users):
     cluster.User(user).delete()
 
     aws.delete_role.assert_called_with(user.iam_role_name)
-    helm.delete.assert_called_once_with(f"init-user-{user.slug}")
+    helm.delete.assert_called_once_with(
+        user.k8s_namespace,
+        f"init-user-{user.slug}"
+    )

--- a/tests/api/test_helm.py
+++ b/tests/api/test_helm.py
@@ -239,8 +239,15 @@ def test_delete():
     The delete function results in the expected helm command to be executed.
     """
     with patch("controlpanel.api.helm._execute") as mock_execute:
-        helm.delete("foo", "bar", "baz")
-        mock_execute.assert_called_once_with("delete", "foo", "bar", "baz")
+        helm.delete("my_namespace", "foo", "bar", "baz")
+        mock_execute.assert_called_once_with(
+            "uninstall",
+            "foo",
+            "bar",
+            "baz",
+            "--namespace",
+            "my_namespace"
+        )
 
 
 def test_list_releases_with_release():


### PR DESCRIPTION
## What

This PR addresses: https://dsdmoj.atlassian.net/browse/ANPL-473

Put simply, the code was incorrect, we were using the old `delete` command (replaced by `uninstall`) and the command wasn't scoped by a namespace.

This PR introduces the following changes:

* The broken code is fixed.
* The code uses the `uninstall` helm command.
* The helm command is always scoped by a `--namespace` argument.
* The client code that calls this feature has been updated to supply the correct namespace, as well as the names of the chart releases to delete.
* Unit tests have been updated as needed, and all pass.

Now, the instructions for deleting a user ([found here](https://github.com/ministryofjustice/analytics-platform/wiki/Control-panel#delete-user)) should work.

## How to review

1. `make clean`
2. `make build`
3. `make test`
4. When this build is deployed on EKS, we need to test it works as advertised.
