### PR TITLE
Fixes an error where a tool has missing settings values.

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -11,7 +11,6 @@ from controlpanel.api.helm import HelmError, helm
 from controlpanel.api.kubernetes import KubernetesClient
 from controlpanel.utils import github_repository_name
 
-
 log = logging.getLogger(__name__)
 
 
@@ -304,9 +303,11 @@ class ToolDeployment:
         values.update(kwargs)
         set_values = []
         for key, val in values.items():
-            escaped_val = val.replace(",", "\,")
-            set_values.extend(["--set", f"{key}={escaped_val}"])
-
+            if val: # Helpful for debugging configs: ignore parameters with missing values and log that the value is missing.
+                escaped_val = val.replace(",", "\,")
+                set_values.extend(["--set", f"{key}={escaped_val}"])
+            else:
+                log.warning(f"Missing value for helm chart param release - {self.release_name} version - {self.tool.version} namespace - {self.k8s_namespace}, key name - {key}")
         return set_values
 
     def install(self, **kwargs):


### PR DESCRIPTION
## What

Essentially, my local database was missing some values (I think, I need to double check how this state happened), but as a result, assuming that there were values for keys led to some unspecified error garbage.

The fix doesn't guarantee the helm chart works, because thats not introspectable, but it does ensure that a valid helm command will be executed.

Since there's no "default value" in helm syntax its better to  not put the key with no value in, for example:
```bash
--<key_name>=<nothing_here> --<next_value>....
```
Instead it skips the value, and emits a warning log message.

## How to review

1. Prior to pulling in the branch, add a new key/value pair to a tool, with no value as the value.
2. Try to deploy the key, and notice that the stack trace is in the worker logs
3. Pull in the branch
4. Re-run the deploy, and the deployment should happen but there will be a warning in the logs.
