### PR TITLE
Configure dependabot to ignore node dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

After enabling dependabot, it insists on checking node dependencies for what are
development only tools.  This will result in a lot of churn for issues that are
highly unlikely to affect us in production.  We are more interested in just the
python dependencies and code that will run in production.

Adding the dependabot config should enable us to be specific about what we want
to check, without it making assumptions because of the presence of the node
package.json file.

Title the PR to complete the sentence: "Merging this PR will ..."

## How to review

1. Install it
2. Check we don't get node dependency alerts
3. Sleep well

