### PR TITLE
Update helm download URL in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/mojanalytics/alpine:3.13 AS base
 
 ARG HELM_VERSION=2.13.1
 ARG HELM_TARBALL=helm-v${HELM_VERSION}-linux-amd64.tar.gz
-ARG HELM_BASEURL=https://storage.googleapis.com/kubernetes-helm
+ARG HELM_BASEURL=https://get.helm.sh
 
 ENV DJANGO_SETTINGS_MODULE="controlpanel.settings" \
   HELM_HOME=/tmp/helm


### PR DESCRIPTION
## What

Changes the helm URL to one that does not raise a 403 for the version of
helm that we require (2.13.1) so that the dockerfile can build properly.

## How to review

Ensure that github action checks pass (and dockerfile built correctly)