### PR TITLE
Update the migration link to our production EKS domain.

### DIFF
--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -137,7 +137,7 @@
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive">Warning</span>
         Migrate to our new infrastructure. This cannot be reversed.
-        <a href="https://controlpanel.services.dev.analytical-platform.service.justice.gov.uk/">Click here to begin</a>.
+        <a href="https://controlpanel.services.analytical-platform.service.justice.gov.uk/">Click here to begin</a>.
       </strong>
     </div>
     <hr class="govuk-section-break govuk-section-break--visible">


### PR DESCRIPTION
## What
The href for the link to migrate to the new EKS domain was pointing to the dev instance. This PR changes it to the prod one.

## How to review

1. Check the URL.
