### PR TITLE
Allow charts with the name jupyter-* to be valid chart names.

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -298,9 +298,14 @@ class ToolReleaseForm(forms.ModelForm):
 
         Hence the path of least resistance with this custom form validation.
         """
-        valid_charts = ["airflow-sqlite", "jupyter-lab", "rstudio", ]
+        valid_charts = ["airflow-sqlite", "jupyter-", "rstudio", ]
         value = self.cleaned_data['chart_name']
-        if value not in valid_charts:
+        is_valid = False
+        for chart_name in valid_charts:
+            if chart_name in value:
+                is_valid = True
+                break
+        if not is_valid:
             raise ValidationError(
                 f"'{value}' is not a valid helm chart name. ",
             )


### PR DESCRIPTION
## What

There are now several charts for Jupyter called things like `jupyter-lab`, `jupyter-lab-all-spark` and `jupyter-lab-datascience-notebook`. The chart name validation was too specific. This change means that `jupyter-foo` chart names will work.

## How to review

1. The existing validation unit tests still pass.
