### PR TITLE
Update copy and URLs in the old login-fail page

### DIFF
--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -7,13 +7,30 @@
    <div class="govuk-grid-column-two-thirds">
 
 
-    <h2 class="govuk-heading-l">Login Failure</h2>
+    <h2 class="govuk-heading-l">There is a problem with your session</h2>
 
-    <p>Something went wrong when you tried to authenticate.</p>
+    <p>It might have timed out, or something went wrong when you tried to
+    authenticate.</p>
 
-    <p>Please
+    <ul class="govuk-list govuk-list--bullet">
+        <li>You may need to ensure you are in the 
+    <a href="https://github.com/moj-analytical-services">MoJ Analytical Services</a>
+    team on GitHub.</li>
+        <li>You may have migrated to a newer version of the platform, so your
+        account on this version is no longer available.</li>
+        <li>If you think your session has simply timed out, please 
+        {% if EKS %}
+    <a href="https://alpha-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.analytical-platform.service.justice.gov.uk%2Foidc%2Flogout%2F">reset your session</a>,
+        {% else %}
     <a href="https://{{ environment }}-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.{{ environment }}.mojanalytics.xyz%2Foidc%2Flogout%2F">reset your session</a>,
-    and try again.</p>
+        {% endif %}
+    and try again.</li>
+    </ul>
+    <p>Alternatively, please refer to our guide for
+    <a href="https://user-guidance.services.alpha.mojanalytics.xyz/get-started.html">getting started on the Analytical Platform</a>
+    for more information.</p>
+
+    <p>Thank you.</p>
    </div>
   </div>
 {% endblock %}

--- a/controlpanel/frontend/views/login_fail.py
+++ b/controlpanel/frontend/views/login_fail.py
@@ -8,4 +8,5 @@ class LoginFail(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["environment"] = settings.ENV 
+        context["EKS"] = settings.EKS
         return context


### PR DESCRIPTION
## What

* The session reset URL was wrong for EKS instances, so this is now fixed.
* I took the liberty to update the copy so it more friendly and informative. See the screenie below:

![login_fail3](https://user-images.githubusercontent.com/37602/135439854-637f4770-553d-4a5d-86a3-ca8967fb84d9.png)


## How to review

1. Copy changes checked with Alex.
2. Unit tests should all pass.
