### PR TITLE
Add flag to ensure tools are filtered by target infrastructure on deployment

### DIFF
--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -157,6 +157,14 @@ class BackgroundTaskConsumer(SyncConsumer):
         tool_args = {"chart_name": message["tool_name"]}
         if "version" in message:
             tool_args["version"] = message["version"]
+        # There may be two charts with the same name and version, but
+        # targetting different instances of our infrastructure. Ensure the
+        # filter args flag which infrastructure we're running on, to make sure
+        # the correct tool is the *first* one returned.
+        if settings.EKS:
+            tool_args["target_infrastructure"] = Tool.EKS
+        else:
+            tool_args["target_infrastructure"] = Tool.OLD
 
         # On restart we don't specify the version as it doesn't make
         # sense to do so. As we're now allowing more than one


### PR DESCRIPTION
## What

The problem:

* There may be two releases with the same chart name and version number: one for our old infrastructure, one for EKS.
* The current code will only find and use the *first* result when filtering on only chart name and version number.
* This can mean the configuration from the wrong tool for the given infrastructure is used when running the helm chart. For instance, the first tool result contains configuration for the old infrastructure when, in fact, we want the tool result for the EKS infrastructure.

The solution:

* Simply ensure that filtering on deployment takes into account the target infrastructure so such a collision cannot take place again.

The approach:

* The whole way tools, releases and helm charts are run is, as a result of bit-rot, a terrible mess.
* I've tried to make the minimal viable intervention, along with a comment in the relevant part of the code to explain my intervention.
* No tests have been added since there was never any test coverage for this code anyway.
* I don't want to go down a path of Yak shaving things when the most important thing *right now* is to make it work. (Refactoring / addressing tech debt is something for a later date).

## How to review

1. I'll deploy, once the build appears.
2. Check it has fixed the problem in prod EKS.