### PR TITLE
Ensure the expected app URL is available in the app detail page, on EKS.

### DIFF
--- a/controlpanel/frontend/jinja2/webapp-detail.html
+++ b/controlpanel/frontend/jinja2/webapp-detail.html
@@ -37,6 +37,11 @@
 
   {% if app_url %}
   <h2 class="govuk-heading-m">Deployed URL</h2>
+      {% if EKS %}
+      <p>For the foreseeable future, apps will remain hosted on the old
+      infrastructure. If the app is successfully built, it will be deployed
+      here:</p>
+      {% endif %}
   <p class="govuk-body">
       <a href="{{ app_url }}">{{ app_url }}</a>
   </p>

--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -77,7 +77,18 @@ class AppDetail(OIDCLoginRequiredMixin, PermissionRequiredMixin, DetailView):
             if not user.auth0_id:
                 log.warning("User without Auth0 ID, {}, is admin for app: {}.".format(user, app))
 
-        context["app_url"] = cluster.App(app).url
+        context['EKS'] = settings.EKS
+        if settings.EKS:
+            # TODO: Fix this.
+            # THIS IS A TEMPORARY STICKING PLASTER
+            # During migration to EKS, just use the hard coded domain with the
+            # app's SLUG as the bottom subdomain.
+            # The reason for this change is apps will be hosted on our
+            # old infrastructure while users migrate to EKS. Once we have our
+            # app hosting story figured out, we should do this properly.
+            context["app_url"] = f"https://{ app.slug }.apps.alpha.mojanalytics.xyz"
+        else:
+            context["app_url"] = cluster.App(app).url
         context["admin_options"] = User.objects.filter(
             auth0_id__isnull=False,
         ).exclude(


### PR DESCRIPTION
## What

For the foreseeable future RShiny apps will remain hosted on the old `alpha` infrastructure.

This PR contains a temporary sticking plaster so the control panel deployed to the new EKS infrastructure generates the expected URL to where the app is deployed.

**THIS NEEDS CHECKING/REVISING WHEN MIGRATION IS COMPLETE AND/OR WE HAVE A PROPER APP HOSTING SOLUTION**

## How to review

1. On EKS, the user sees the expected URL, along with the description explaining the temporary situation.
