### PR TITLE
Add a message/links for users trying to log into the old control panel after they have migrated to the new EKS control panel.

### DIFF
--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -5,8 +5,18 @@
 {% block content %}
   <div class="govuk-grid-row" id="reset-container">
    <div class="govuk-grid-column-two-thirds">
+   {% if in_wrong_place %}
+    <h2 class="govuk-heading-l">You seem to be lost</h2>
+    <p>You have migrated to the new infrastructure, but you're trying to use
+    the old infrastructure. Please update your bookmarks for the control panel
+    to:</p>
 
+    <p><a href="https://controlpanel.services.analytical-platform.service.justice.gov.uk">https://controlpanel.services.analytical-platform.service.justice.gov.uk</a></p>
 
+    <p>Please
+    <a href="https://alpha-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.analytical-platform.service.justice.gov.uk%2Foidc%2Flogout%2F">click here</a>
+    to sign in on the new infrastructure.</p>
+   {% else %}
     <h2 class="govuk-heading-l">There is a problem with your session</h2>
 
     <p>It might have timed out, or something went wrong when you tried to
@@ -31,6 +41,7 @@
     for more information.</p>
 
     <p>Thank you.</p>
+    {% endif %}
    </div>
   </div>
 {% endblock %}

--- a/controlpanel/frontend/views/login_fail.py
+++ b/controlpanel/frontend/views/login_fail.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.views.generic.base import TemplateView
+from controlpanel.api.models.user import User
 
 
 class LoginFail(TemplateView):
@@ -9,4 +10,9 @@ class LoginFail(TemplateView):
         context = super().get_context_data(**kwargs)
         context["environment"] = settings.ENV 
         context["EKS"] = settings.EKS
+        is_migrated = self.request.user.migration_state == User.COMPLETE
+        # This flag denotes the user has migrated but is trying to log into the
+        # old infrastructure. Used in the template to point them in the right
+        # direction. ;-)
+        context["in_wrong_place"] = is_migrated and not settings.EKS
         return context


### PR DESCRIPTION
## What

This ticket is a sticking plaster to address the problem found by our EKS test users described here:

https://dsdmoj.atlassian.net/browse/ANPL-686

Basically, when they try to go back to the old `alpha` instance, they can't log in. This change ensures they see a helpful message with a link to the new instance they should be using instead.

## How to review

I've tested this on my local machine. Normally, when a user cannot log into the alpha version of the control panel they see this:

![login_fail](https://user-images.githubusercontent.com/37602/138081763-9d6c650e-1c42-450f-9b29-cec9fed1556b.png)

If the user is migrated and in the alpha version of the control panel, they'll now see this instead:

![lost](https://user-images.githubusercontent.com/37602/138081828-b7aa7998-f39e-489d-9d44-fcb3a8156476.png)
