### PR TITLE
Update Sentry version to latest.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pytest==6.0.1
 pytest-django==3.9.0
 python-jose==3.2.0
 rules==2.2
-sentry-sdk==0.17.3
+sentry-sdk==1.4.2
 service-identity==18.1.0
 slackclient==2.8.1
 Twisted==20.3.0


### PR DESCRIPTION
## What
Addresses technical debt potential.

I've updated `sentry-sdk` to version 1.4.2 in `requirements.txt`. I've run the control panel locally on my machine and caused a crash which I've been able to observe in our Sentry logs (i.e. it works).

## How to review

1. I've run the control panel locally on my machine with the new version of Sentry.
2. I caused the app to crash.
3. I saw the log file turn up (see: https://sentry.io/organizations/ministryofjustice/issues/2766254991/events/85cb1670c42848e8975436898de64b5c/?project=5606313)

Relates to: https://dsdmoj.atlassian.net/browse/ANPL-673
