### PR TITLE
Change base image from Alpine to official Python 3.9.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN ./node_modules/.bin/node-sass --include-path ./node_modules/ -o dist/ --outp
 WORKDIR /src
 RUN /node_modules/.bin/jest
 
-FROM quay.io/mojanalytics/alpine:3.13 AS base
+FROM python:3.9 AS base
 
 ARG HELM_VERSION=2.13.1
 ARG HELM_TARBALL=helm-v${HELM_VERSION}-linux-amd64.tar.gz
@@ -19,8 +19,8 @@ ENV DJANGO_SETTINGS_MODULE="controlpanel.settings" \
   HELM_HOME=/tmp/helm
 
 # create a user to run as
-RUN addgroup -g 1000 -S controlpanel && \
-  adduser -u 1000 -S controlpanel -G controlpanel
+RUN addgroup -gid 1000 controlpanel && \
+  adduser -uid 1000 --gid 1000 controlpanel
 
 WORKDIR /home/controlpanel
 
@@ -33,31 +33,16 @@ RUN wget ${HELM_BASEURL}/${HELM_TARBALL} -nv -O - | \
   chown -R root:controlpanel ${HELM_HOME} && \
   chmod -R g+rwX ${HELM_HOME}
 
-RUN apk add --no-cache \
-            python3 \
-            alpine-sdk \
-            gcc \
-            cargo \
-            musl-dev \
-            ca-certificates \
-            libffi-dev \
-            python3-dev \
-            py3-pip \
-            libressl-dev \
-            postgresql-dev \
-            libstdc++ \
-            postgresql-client \
-            graphviz \
-            graphviz-dev \
-            ttf-freefont \
-  && pip3 install -U pip
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install -U pip
 
 COPY requirements.txt requirements.dev.txt manage.py ./
-RUN pip3 install -U --no-cache-dir pip
-RUN pip3 install -r requirements.txt
-RUN python3 -m venv --system-site-packages dev-packages \
-    && dev-packages/bin/pip3 install -U --no-cache-dir pip \
-    && dev-packages/bin/pip3 install -r requirements.dev.txt
+RUN pip install -U --no-cache-dir pip
+RUN pip install -r requirements.txt
 
 USER controlpanel
 COPY controlpanel controlpanel

--- a/Dockerfile_EKS
+++ b/Dockerfile_EKS
@@ -9,7 +9,7 @@ RUN ./node_modules/.bin/node-sass --include-path ./node_modules/ -o dist/ --outp
 WORKDIR /src
 RUN /node_modules/.bin/jest
 
-FROM quay.io/mojanalytics/alpine:3.13 AS base
+FROM python:3.9 AS base
 
 ARG HELM_VERSION=3.5.4
 ARG HELM_TARBALL=helm-v${HELM_VERSION}-linux-amd64.tar.gz
@@ -23,8 +23,8 @@ ENV DJANGO_SETTINGS_MODULE="controlpanel.settings" \
   EKS=True
 
 # create a user to run as
-RUN addgroup -g 1000 -S controlpanel && \
-  adduser -u 1000 -S controlpanel -G controlpanel
+RUN addgroup -gid 1000 controlpanel && \
+  adduser -uid 1000 --gid 1000 controlpanel
 
 WORKDIR /home/controlpanel
 
@@ -36,31 +36,16 @@ RUN wget ${HELM_BASEURL}/${HELM_TARBALL} -nv -O - | \
   chown -R root:controlpanel ${HELM_HOME} && \
   chmod -R g+rwX ${HELM_HOME}
 
-RUN apk add --no-cache \
-            python3 \
-            alpine-sdk \
-            gcc \
-            cargo \
-            musl-dev \
-            ca-certificates \
-            libffi-dev \
-            python3-dev \
-            py3-pip \
-            libressl-dev \
-            postgresql-dev \
-            libstdc++ \
-            postgresql-client \
-            graphviz \
-            graphviz-dev \
-            ttf-freefont \
-  && pip3 install -U pip
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install -U pip
 
 COPY requirements.txt requirements.dev.txt manage.py ./
-RUN pip3 install -U --no-cache-dir pip
-RUN pip3 install -r requirements.txt
-RUN python3 -m venv --system-site-packages dev-packages \
-    && dev-packages/bin/pip3 install -U --no-cache-dir pip \
-    && dev-packages/bin/pip3 install -r requirements.dev.txt
+RUN pip install -U --no-cache-dir pip
+RUN pip install -r requirements.txt
 
 USER controlpanel
 COPY controlpanel controlpanel


### PR DESCRIPTION
## What

Relates to: https://dsdmoj.atlassian.net/browse/ANPL-578

These changes are for the docker files for bit "old world" and "new EKS" `Docker` files.

They update the base image to the standard Python3.9 image (QUESTION: from docker.org - should we cache somewhere else?).

I've thrown away all the apk-add packages except for the minimal Postgres client things we need.

`pip install -r requirements.txt` does the rest.

I've removed installation of `requirements.txt.dev` since we never use this.

## How to review

1. `make build` succeeds.
2. `make test` with that build, succeeds.