### PR TITLE
Update Boto version to current, and remove botocore requirement to fix dependabot raised version issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 asgiref==3.2.10
 auth0-python==3.13.0
 boto3==1.20.13
-botocore==1.17.55
 channels==2.4.0
 channels-redis==3.0.1
 Django>=3.1.1


### PR DESCRIPTION
## What

The version of BotoCore was a year out of date, and this caused a version conflict as part of resolving dependabot issues.

I've removed the requirement for botocore, because fundamentally it is a dependency of boto3 which is the library we actually access and having a library and its version linked dependency in requirements seems a recipe for version conflicts.

## How to review

1. Ensure that it makes sense to jump a years worth of version changes.
2. Approve, or tell Gemma she's being silly.

This is part of the [dependabot appeasment ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/ANPL/boards/551?modal=detail&selectedIssue=ANPL-618)