### PR TITLE
Ensure correct handling of AnonymousUser instances in login-fail view.

### DIFF
--- a/controlpanel/frontend/views/login_fail.py
+++ b/controlpanel/frontend/views/login_fail.py
@@ -10,7 +10,7 @@ class LoginFail(TemplateView):
         context = super().get_context_data(**kwargs)
         context["environment"] = settings.ENV 
         context["EKS"] = settings.EKS
-        if self.request.user and hasattr(self.request.user, "migration_state"):
+        if self.request.user.is_authenticated and hasattr(self.request.user, "migration_state"):
             is_migrated = self.request.user.migration_state == User.COMPLETE
         else:
             is_migrated = False


### PR DESCRIPTION
## What

Fixes https://dsdmoj.atlassian.net/browse/ANPL-741 that was causing 500 errors for users in certain circumstances.

## How to review

1. There have never been unit tests for the `login-fail` view. :disappointed: 
2. However, start the application locally (`./manage.py runserver`), and visit 127.0.0.1:8000/login-fail to exercise this code.
3. Since you'll be visiting the `login-fail` endpoint without having been logged in, you'll be viewed as (the problematic) AnonymousUser.
4. It works because you see a helpful message about sessions! (rather than a 500 error as before)
