### PR TITLE
End our reliance on pushing to quay.io

### DIFF
--- a/.github/workflows/test-and-push-docker-image.yaml
+++ b/.github/workflows/test-and-push-docker-image.yaml
@@ -90,14 +90,3 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ steps.prep.outputs.tag }}
-
-      - name: Push Docker image to Quay.io
-        env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          IMAGE_TAG: ${{ steps.prep.outputs.tag }}
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} quay.io
-          docker tag "${REGISTRY}/controlpanel:${IMAGE_TAG}" "quay.io/mojanalytics/control-panel:${IMAGE_TAG}"
-          docker push "quay.io/mojanalytics/control-panel:${IMAGE_TAG}"


### PR DESCRIPTION
## What

Quay.io is having an authentication problem and thats blocking builds.

We don't need it any more.

## How to review

1. Ensure this PR has a tag on ecr
1. Deploy this PR to dev.not-kube
2. If it works
3. Its working
