### PR TITLE
Add migration state column to the user list in admin page.

### DIFF
--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -19,11 +19,11 @@ class User(AbstractUser):
     REVERTED = "r"  # The user has been reverted to the old platform.
 
     MIGRATION_STATES = [
-        (VOID, "Void - not involved in migration."),
-        (PENDING, "Pending - the user is able to migrate."),
-        (MIGRATING, "Migrating - migration has started."),
-        (COMPLETE, "Complete - migration has completed."),
-        (REVERTED, "Reverted - user back on the old platform."),
+        (VOID, "Void"),
+        (PENDING, "Pending"),
+        (MIGRATING, "Migrating"),
+        (COMPLETE, "Complete"),
+        (REVERTED, "Reverted"),
     ]
 
     auth0_id = models.CharField(max_length=128, primary_key=True)

--- a/controlpanel/frontend/jinja2/user-list.html
+++ b/controlpanel/frontend/jinja2/user-list.html
@@ -7,12 +7,22 @@
 {% block content %}
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
+<p>Migration state:</p>
+<ul class="govuk-list govuk-list--bullet">
+    <li><strong>Void</strong> - not involved in migration.</li>
+    <li><strong>Pending</strong> - the user is able to migrate.</li>
+    <li><strong>Migrating</strong> - migration has started.</li>
+    <li><strong>Complete</strong> - migration has completed.</li>
+    <li><strong>Reverted</strong> - user back on the old platform.</li>
+</ul>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header"><a href="?o=username">User</a></th>
       <th class="govuk-table__header"><a href="?o=email">Email</a></th>
       <th class="govuk-table__header"><a href="?o=last_login">Last login</a></th>
+      <th class="govuk-table__header"><a href="?o=migration_state">Migration</a></th>
       <th class="govuk-table__header">
         <span class="govuk-visually-hidden">Actions</span>
       </th>
@@ -41,6 +51,7 @@
               (<strong><a href="https://github.com/orgs/moj-analytical-services/people/{{ user.username }}" target="_blank">unused?</a></strong>)
           {%- endif -%}
       </td>
+      <td class="govuk-table__cell">{{ user.get_migration_state_display() }}</td>
       <td class="govuk-table__cell">
         <a href="{{ url('manage-user', kwargs={ "pk": user.auth0_id }) }}"
            class="govuk-button govuk-button--secondary">


### PR DESCRIPTION
## What

As informally requested by Alex, an indication of each user's migration state in the user list page in the administrative part of the control panel.

It looks like this:

![migration_state](https://user-images.githubusercontent.com/37602/145370299-5476b02e-c56e-4780-8648-77f64cd8e1dd.png)


## How to review

1. Run it.
2. Check you see the migration state on the user list page.

This **does not** relate to any current ticket... but was informally requested by Alex on our Slack channel (what Alex says, goes). :smile: 