### PR TITLE
Remove twisted dependency (its not used anywhere)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,5 @@ rules==3.0
 sentry-sdk==1.4.2
 service-identity==18.1.0
 slackclient==2.8.1
-Twisted==20.3.0
 urllib3==1.26.5
 uvicorn==0.11.8


### PR DESCRIPTION
## What

Dependabot wants to update twisted, but in no sense are we using twisted so the dependency should be removed.

## How to review

1. Double check the source code to ensure that we're not using it somewhere.
