### PR TITLE
Remove unused service-identity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ pytest-django==3.9.0
 python-jose==3.2.0
 rules==3.0
 sentry-sdk==1.4.2
-service-identity==18.1.0
 slackclient==2.8.1
 Twisted==20.3.0
 urllib3==1.26.5


### PR DESCRIPTION
## What

Remove the requirements entry for service-identity.

We're not using it anywhere that I can see.

## How to review

1. Ensure we're not using the library anywhere https://service-identity.readthedocs.io/en/stable/api.html
