### PR TITLE
Reduce noise from failed Helm tasks

### DIFF
--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -130,7 +130,7 @@ class BackgroundTaskConsumer(SyncConsumer):
         status = wait_for_deployment(tool_deployment, id_token)
 
         if status == TOOL_DEPLOY_FAILED:
-            log.error(f"Failed deploying {tool.name} for {user}")
+            log.warning(f"Failed deploying {tool.name} for {user}")
         else:
             log.debug(f"Deployed {tool.name} for {user}")
 
@@ -149,7 +149,7 @@ class BackgroundTaskConsumer(SyncConsumer):
         status = wait_for_deployment(tool_deployment, id_token)
 
         if status == TOOL_DEPLOY_FAILED:
-            log.error(f"Failed restarting {tool.name} for {user}")
+            log.warning(f"Failed restarting {tool.name} for {user}")
         else:
             log.debug(f"Restarted {tool.name} for {user}")
 
@@ -185,13 +185,13 @@ class BackgroundTaskConsumer(SyncConsumer):
         user = User.objects.get(auth0_id=message["user_id"])
         home_directory = HomeDirectory(user)
         update_home_status(home_directory, HOME_RESETTING)
-        
+
         home_directory.reset()
 
         status = wait_for_home_reset(home_directory)
 
         if status == HOME_RESET_FAILED:
-            log.error(f"Failed to reset home directory for user {user}")
+            log.warning(f"Failed to reset home directory for user {user}")
         else:
             log.debug(f"Reset home directory for user {user}")
 


### PR DESCRIPTION
Currently sentry.io contains lots of issues such as:

```
Failed|Successed deploying|restarting jupyterlab|rstudio for $user
```

Once recorded in sentry, they are essentially ignored.  

Whilst we clearly need a better mechanism for processing these errors, 
this should be done as part of future refactoring, instead of ineffective 
logging.

Without these errors being recorded, we will still find out about the
issues from users rather than the system, so we may as well remove the
noise.

