### PR TITLE
Update the text on the login fail page

### DIFF
--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -3,45 +3,58 @@
 {% set page_title = "Login Failure" %}
 
 {% block content %}
-  <div class="govuk-grid-row" id="reset-container">
-   <div class="govuk-grid-column-two-thirds">
-   {% if in_wrong_place %}
-    <h2 class="govuk-heading-l">You seem to be lost</h2>
-    <p>You have migrated to the new infrastructure, but you're trying to use
-    the old infrastructure. Please update your bookmarks for the control panel
-    to:</p>
+<div class="govuk-grid-row" id="reset-container">
+    <div class="govuk-grid-column-two-thirds">
+        {% if in_wrong_place %}
+        <h2 class="govuk-heading-l">You seem to be lost</h2>
+        <p>You have migrated to the new infrastructure, but you're trying to use
+            the old version. Please update your bookmarks for the control panel
+            to:</p>
 
-    <p><a href="https://controlpanel.services.analytical-platform.service.justice.gov.uk">https://controlpanel.services.analytical-platform.service.justice.gov.uk</a></p>
+        <p><a
+                href="https://controlpanel.services.analytical-platform.service.justice.gov.uk">https://controlpanel.services.analytical-platform.service.justice.gov.uk</a>
+        </p>
 
-    <p>Please
-    <a href="https://alpha-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.analytical-platform.service.justice.gov.uk%2Foidc%2Flogout%2F">click here</a>
-    to sign in on the new infrastructure.</p>
-   {% else %}
-    <h2 class="govuk-heading-l">There is a problem with your session</h2>
-
-    <p>It might have timed out, or something went wrong when you tried to
-    authenticate.</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-        <li>You may need to ensure you are in the 
-    <a href="https://github.com/moj-analytical-services">MoJ Analytical Services</a>
-    team on GitHub.</li>
-        <li>You may have migrated to a newer version of the platform, so your
-        account on this version is no longer available.</li>
-        <li>If you think your session has simply timed out, please 
-        {% if EKS %}
-    <a href="https://alpha-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.analytical-platform.service.justice.gov.uk%2Foidc%2Flogout%2F">reset your session</a>,
+        <p>Please
+            <a
+                href="https://alpha-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.analytical-platform.service.justice.gov.uk%2Foidc%2Flogout%2F">click
+                here</a>
+            to sign in on the new infrastructure.
+        </p>
         {% else %}
-    <a href="https://{{ environment }}-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.{{ environment }}.mojanalytics.xyz%2Foidc%2Flogout%2F">reset your session</a>,
-        {% endif %}
-    and try again.</li>
-    </ul>
-    <p>Alternatively, please refer to our guide for
-    <a href="https://user-guidance.services.alpha.mojanalytics.xyz/get-started.html">getting started on the Analytical Platform</a>
-    for more information.</p>
+        <h2 class="govuk-heading-l">There is a problem with your session</h2>
 
-    <p>Thank you.</p>
-    {% endif %}
-   </div>
-  </div>
+        <p>
+            It might have timed out in which case you can
+
+            {% if EKS %}
+            <a
+                href="https://alpha-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.analytical-platform.service.justice.gov.uk%2Foidc%2Flogout%2F">reset
+                your session</a>,
+            {% else %}
+            <a
+                href="https://{{ environment }}-analytics-moj.eu.auth0.com/v2/logout?returnTo=https%3A%2F%2Fcontrolpanel.services.{{ environment }}.mojanalytics.xyz%2Foidc%2Flogout%2F">reset
+                your session</a>,
+            {% endif %}
+            and login again.
+        </p>
+
+        <p>
+            If resetting your session doesn't help, it's possible that
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>You may need to ensure you are in the <a href="https://github.com/moj-analytical-services">MoJ
+                    Analytical Services</a> team on GitHub.</li>
+            <li>You may have migrated to a newer version of the platform, so your account on this version is no longer
+                available.</li>
+        </ul>
+        </p>
+        <p>Alternatively, please refer to our guide for
+            <a href="https://user-guidance.services.alpha.mojanalytics.xyz/get-started.html">getting started on the
+                Analytical Platform</a>
+            for more information.
+        </p>
+        {% endif %}
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
The login fail page shows the user a lot of reasons that they could have
ended up on that page, but the most likely reason (timeout) is buried in
a paragraph of text.

This PR moves the most likely reason to the top, to make it easier to
find the login link.

![Login_Failure___Analytical_Platform_Control_Panel](https://user-images.githubusercontent.com/118063/146437636-d485d288-6220-4865-ac9f-5f9d98e19868.png)

This should resolve https://dsdmoj.atlassian.net/browse/ANPL-750 