### PR TITLE
Update sentry version to install redisintegration

### DIFF
--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -318,10 +318,12 @@ REST_FRAMEWORK = {
 if os.environ.get("SENTRY_DSN"):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.redis import RedisIntegration
+
     sentry_sdk.init(
         dsn=os.environ["SENTRY_DSN"],
         environment=os.environ.get("ENV", "dev"),
-        integrations=[DjangoIntegration()],
+        integrations=[DjangoIntegration(), RedisIntegration()],
         traces_sample_rate=0.0,
         send_default_pii=True,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pytest==6.0.1
 pytest-django==3.9.0
 python-jose==3.2.0
 rules==3.0
-sentry-sdk==1.4.2
+sentry-sdk==1.5.1
 slackclient==2.8.1
 urllib3==1.26.5
 uvicorn==0.11.8


### PR DESCRIPTION
Following hints from sentry.io, this PR updates the version of sentry in
use.
