### PR TITLE
Change sentry environment for debugging

### DIFF
--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -316,17 +316,25 @@ REST_FRAMEWORK = {
 # -- Sentry error tracking
 
 if os.environ.get("SENTRY_DSN"):
+    SENTRY_ENVIRONMENT = ENV
+    if EKS:
+        KUBERNETES_ENV = "EKS"
+        if ENV == "alpha":
+            SENTRY_ENVIRONMENT = "prod"
+    else:
+        KUBERNETES_ENV = "NotKS"
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.redis import RedisIntegration
-
+    from sentry_sdk import set_tag
     sentry_sdk.init(
         dsn=os.environ["SENTRY_DSN"],
-        environment=os.environ.get("ENV", "dev"),
+        environment=SENTRY_ENVIRONMENT,
         integrations=[DjangoIntegration(), RedisIntegration()],
         traces_sample_rate=0.0,
         send_default_pii=True,
     )
+    set_tag("Kubernetes Env", KUBERNETES_ENV)
     if "shell" in sys.argv or "shell_plus" in sys.argv:
         sentry_sdk.init(
             # discard all events


### PR DESCRIPTION
## What

Currently sentry doesn't distinguish between EKS and NotEKS, and the production errors are tagged with alpha.

This fix does two things.
* Tags events with EKS/NotEKS (Kubernetes-Env tag)
* If the environment is EKS it sets the sentry environment to be prod instead.

Ticket [https://dsdmoj.atlassian.net/browse/ANPL-757?atlOrigin=eyJpIjoiNzI2Mzg3M2JiOGQzNGYyODgzYjA5MTEzOGRkMGU2OGYiLCJwIjoiaiJ9](ANPL-757)

## How to review

1. Set your eks env to false
1. Trigger an error in your environment (from shell wont work, will be followup tag), you should have an event dev environment and notks
2. Set your environment to alpha
3. Trigger an error in your env, you should have an event alpha environment and notks
4. Set your eks env to true
5. Trigger an error in your env you should have an event prod environment and eks
6. Set your environment to dev
7. Trigger an error in your env you should haev an event dev environment and eks
8. If all these worked, you're good
