### PR TITLE
Sentry will no longer ignore Shell Based Errors

### DIFF
--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -335,11 +335,10 @@ if os.environ.get("SENTRY_DSN"):
         send_default_pii=True,
     )
     set_tag("Kubernetes Env", KUBERNETES_ENV)
-    if "shell" in sys.argv or "shell_plus" in sys.argv:
-        sentry_sdk.init(
-            # discard all events
-            before_send=lambda event, hint: None,
-        )
+    if "runworker" in sys.argv:
+        set_tag("RunningIn", "Worker")
+    elif "shell" in sys.argv:
+        set_tag("RunningIn", "Shell")
 
 
 # -- Static files


### PR DESCRIPTION
## What

Currently if the shell raises the error it uses a monkeypatched sdk that doesn't send the message anywhere

Now instead it tags whether its come from the webserver (by default), worker, or shell.

The existing way is messy using an override, and if you're trying to test out sentry features, its a pain in the neck because there's some automagic undocumented happening in settings... 

Its cleaner to tell sentry the context so sentry can choose to ignore it as far as alerting goes.

## How to review

1. Exec into django-shell in container
2. Raise an error
3. You should see the error in sentry tagged with "RunningIn: Shell"
4. Raise an error in the webserver
5. You should see the error in sentry tagged with "RunningIn:Webserver"
