### PR TITLE
Uses postgres 12.7 for local development/tests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   db:
-    image: "postgres:9.6"
+    image: "postgres:12.7"
     environment:
       POSTGRES_DB: "controlpanel"
       POSTGRES_PASSWORD: "password"
@@ -19,7 +19,7 @@ services:
 
   migration:
     image: ${REGISTRY}/${REPOSITORY}:${IMAGE_TAG:-latest}
-    depends_on: 
+    depends_on:
       db:
         condition: service_healthy
     environment:


### PR DESCRIPTION
Our hosting platform no longer support 9.6, and so we are upgrading to
12.7, and this PR ensures that we test/develop against the same version 
as we will be using in production.
