### PR TITLE
Fix the issue where re-running charts is corrupting user's PV/PVCs

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -179,6 +179,7 @@ class User:
                 self.user.migration_state == self.user.VOID
             )
             if not is_migrated and has_charts: #This state SHOULD NOT happen but appears to be occuring
+                log.warning(f"{self.user} was in state {self.user.get_migration_state_display()}, but has b/p charts")
                 aws.migrate_user_role(self.user) #This appears deterministic and we don't have a test (yet)
                 self.user.migration_state = self.user.COMPLETE
                 self.user.save()
@@ -197,8 +198,10 @@ class User:
                 self.user.save()
             elif not has_charts or not bootstrapped:  # user missing all charts
                 # Or at least bootstrap chart, so needs both charts to be re-run.
+                log.warning(f"{self.user} missing charts, so re-running")
                 self._init_user()
             elif not provisioned:
+                log.warning(f"{self.user} is missing the provision chart so re-running")
                 self._provision_user()
         else:
             # On the old infrastructure...


### PR DESCRIPTION
## What

### Black restructure
It doesn't change anything but every time my editor saves it re-orders

### Refactor each stage of charts init into sub methods
The methods were not easily readable, and you couldn't run each chart separately

### Explicitly delete before running the chart
The list_releases only checks for deployed charts, so alt-states can be overwritten causing problems

### Work out which charts are missing
Its useful to know which charts are missing, and whether both charts are missing for diagnosing state

### If the user is in "not-migrated"
Essentially, if the user already has the charts, then their state is wrong, and so they shouldn't be re-run, fix the mistake and move on.

### If only provision is missing 
Again this shouldn't happen, BUT if so only re-run the provision chart.

## How to review

Does this make sense?
1. Check your charts in alpha-dev
2. Deploy to alpha-dev infra
3. Try to log in
4. Check your charts have not changed
5. Check your charts in eks-dev
6. Deploy to eks-dev infra
7. Try to log in 
8. Check your charts have not changed

Provide [http://example.com](links) to relevant tickets, articles or other
resources.

Note the Trello Github integration links tickets to PRs/branches/commits (in
both directions).
