### PR TITLE
Update ipython to a more recent version

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,5 +3,5 @@ django-debug-toolbar-requests>=1.0.5,<1.1
 django-elasticsearch-debug-toolbar>=2.0.0,<2.1
 pylint>=2.12.2,<2.13
 pylint-django>=2.4.4,<2.5
-ipython>=7.20.0,<7.21.0
+ipython>=7.31.1
 ipdb>=0.13.4,<0.14.0


### PR DESCRIPTION
Versions of ipython <7.31.1 are vulnerable to CVE-2022-21699
This update should mitigate and close https://github.com/ministryofjustice/analytics-platform-control-panel/security/dependabot/21 