### PR TITLE
Fixes bug where user's username was used instead of slug

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -191,7 +191,7 @@ def create_user_role(user):
     }
     policy["Statement"].append(oidc_statement)
     eks_statement = deepcopy(EKS_STATEMENT)
-    match = f"system:serviceaccount:user-{user.username}:{user.username}-*"
+    match = f"system:serviceaccount:user-{user.slug}:{user.slug}-*"
     eks_statement["Condition"]["StringLike"] = {
         f"{settings.OIDC_EKS_PROVIDER}:sub": match
     }
@@ -228,13 +228,13 @@ def migrate_user_role(user):
     if the user already exists from the old platform infrastructure.
     """
     eks_statement = deepcopy(EKS_STATEMENT)
-    match = f"system:serviceaccount:user-{user.username}:{user.username}-*"
+    match = f"system:serviceaccount:user-{user.slug}:{user.slug}-*"
     eks_statement["Condition"]["StringLike"] = {
         f"{settings.OIDC_EKS_PROVIDER}:sub": match
     }
     log.warning(
         "Attempting to update policy as part of user migration for "
-        f"{user.username}."
+        f"{user.slug}."
     )
     iam = boto3.client("iam")
     role = iam.get_role(RoleName=user.iam_role_name)

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -143,7 +143,7 @@ def oidc_assume_role(stmt, user):
 
 
 def eks_assume_role(stmt, user):
-    match = f"system:serviceaccount:user-{user.username}:{user.username}-*"
+    match = f"system:serviceaccount:user-{user.slug}:{user.slug}-*"
     return stmt_match(
         stmt,
         Action="sts:AssumeRoleWithWebIdentity",


### PR DESCRIPTION
Service accounts for users do not typically contain mixed case letters,
they should be all lower-case. This code currently uses the user's 
username when referencing it, which can be mixed case.  These 
serviceaccounts are created when deploying tools using the relevant
charts and [using values such as](https://github.com/ministryofjustice/analytics-platform-control-panel/blob/0fe19f52b119d8604e22e9ce11383f5ffe5ecbbb/controlpanel/api/cluster.py#L423-L429)

```python
values = {
    "username": self.user.username.lower(),
    # XXX backwards compatibility
    "Username": self.user.username.lower(),
    "aws.iamRole": self.user.iam_role_name,
    "toolsDomain": settings.TOOLS_DOMAIN,
}
```

When adding the trust relationship to the OIDC provider, this PR 
switches to using `user.slug` so that we only produce valid policy 
constraints that have a chance of matching. 

Whereas, for user `DataAnalyst` we would currently generate a 
trust relationship with 

```json
{
    "Effect": "Allow",
    "Principal": {
        "Federated": "OIDC_ARN"
    },
    "Action": "sts:AssumeRoleWithWebIdentity",
    "Condition": {
        "StringLike": {
            "OIDC_SUBJECT_URL": "system:serviceaccount:user-DataAnalyst:DataAnalyst-*"
        }
    }
}
```

after applying this PR we will instead generate 

```json
{
    "Effect": "Allow",
    "Principal": {
        "Federated": "OIDC_ARN"
    },
    "Action": "sts:AssumeRoleWithWebIdentity",
    "Condition": {
        "StringLike": {
            "OIDC_SUBJECT_URL": "system:serviceaccount:user-dataanalyst:dataanalyst-*"
        }
    }
}
```

Fixes: https://dsdmoj.atlassian.net/browse/ANPL-826