### PR TITLE
Adds admin tools for S3Buckets and Apps

### DIFF
--- a/controlpanel/api/admin.py
+++ b/controlpanel/api/admin.py
@@ -26,7 +26,14 @@ class S3Admin(admin.ModelAdmin):
 
 
 class UserAdmin(admin.ModelAdmin):
-    list_display = ("username", "auth0_id", "email", "is_superuser", "migration_state")
+    list_display = (
+        "username",
+        "auth0_id",
+        "email",
+        "is_superuser",
+        "migration_state",
+        "last_login",
+    )
     actions = [make_migration_pending]
     exclude = ("password",)
     list_filter = ("migration_state",)


### PR DESCRIPTION
Currently there is no easy way to view/modify this data short of using
the REPL.  This PR adds tools for the Apps and the S3Buckets so that we
can obtain more info about them (e.g. who created them and when)

Also adds the last_login time to the User list to make processing inactive
accounts easier.