### PR TITLE
Adds a new navigation link to the training page

### DIFF
--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -125,6 +125,12 @@
         "admin": request.user.is_superuser,
       },
       {
+        "text": "Training",
+        "href": "https://moj-analytical-services.github.io/ap-tools-training/",
+        "active": page_name == "training",
+        "attributes": [["target", "_blank"]]
+      },
+      {
         "text": "Help",
         "href": url("help"),
         "active": page_name == "help",


### PR DESCRIPTION
The content for the training page was originally included in
https://github.com/ministryofjustice/analytics-platform-control-panel/pull/916
but isn't really an efficient way of managing the content.  Instead this
PR adds the nav item and links to the training in a new tab.
