### PR TITLE
[Testing] Add github workflow to create a release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,26 @@
+name: Create a release
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: release_${{ github.event.number }}
+          release_name: Release ${{ github.event.number }}
+          body: See [Pull Request ${{ github.event.number }}](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/${{ github.event.number }}) for details
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Testing!

This is an effort to propose a change in the current deployment workflow.


- See the diagram for a loose description of the flow
- What I’m proposing is to have github to create a release per pull request (this PR and release [here](https://github.com/ministryofjustice/analytics-platform-control-panel/releases/tag/release_1034)) with this we go to flux and change it so that we can test it in dev environment (staging), peer review becomes a team sport by announcing that a change is now ready in staging anyone can go and test besides developers and devops.
- Developer receives a positive peer review (code and staging), that merges to the main branch
- Developer now goes to flux and triggers that exact release to go to production
- Job done, no more production testing (staging is our testing playground)
- By doing this we are now sending less changes all at once and reducing the risk of something going wrong
- I’m assuming that staging is an exact replica of production, any release that has problems in staging will not go to production until fixed
- The developer is responsible for that one release, if anything goes wrong in production we can rollback to previous stable release

![deployment-workflow-v2](https://user-images.githubusercontent.com/136777/169973402-ea5f76f2-1094-43e8-9961-417f47dbba75.jpeg)


