### PR TITLE
Renamed the secret name based on the discussion

### DIFF
--- a/controlpanel/api/models/app.py
+++ b/controlpanel/api/models/app.py
@@ -50,7 +50,7 @@ class App(TimeStampedModel):
 
     @property
     def app_aws_secret_name(self):
-        return f"{settings.ENV}_app_secret/{self.slug}"
+        return f"{settings.ENV}/apps/{self.slug}/auth"
 
     def construct_secret_data(self, client):
         return {


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR closes/completes/contributes to issue #ANPL-1067
This small PR is to rename the secret name based on our discussion about how to manage an app's secret for auth


Merging this PR will have the following side-effects:
NO
<img width="1013" alt="Screenshot 2022-06-22 at 15 00 39" src="https://user-images.githubusercontent.com/26111671/175048429-edbc3101-2936-4aec-9937-f42d82b9ff7e.png">

## :mag: What should the reviewer concentrate on?

Check the secret name does match our decision

## :technologist: How should the reviewer test these changes?
- login as super user
- click Home page/all apps
- Register an new app
- Login AWS console page for admin-data and choose Secret Manage.
- Check the name of the secret

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [X] Documentation will be added in the future because ... (see #ANPL-990)
