### PR TITLE
ANPL-892: Fix link on login-fail page

### DIFF
--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% set page_title = "Login Failure" %}
+{% set signout_url = url("oidc_logout") %}
+
 
 {% block content %}
 <div class="govuk-grid-row" id="reset-container">
@@ -26,7 +28,7 @@
 
         <p>
             It might have timed out in which case you can
-            <a href="{{ auth0_logout_url }}?client_id={{ auth0_client_id }}&returnTo={{ request.scheme }}%3A%2F%2F{{ request.get_host() }}%2Foidc%2Flogout%2F">
+            <a href={{ signout_url }}>
                 reset your session
             </a>
             , and login again.

--- a/controlpanel/frontend/views/login_fail.py
+++ b/controlpanel/frontend/views/login_fail.py
@@ -10,9 +10,6 @@ class LoginFail(TemplateView):
         context = super().get_context_data(**kwargs)
         context["environment"] = settings.ENV 
         context["EKS"] = settings.EKS
-        context["auth0_logout_url"] = settings.AUTH0["logout_url"]
-        context["auth0_client_id"] = settings.AUTH0["client_id"]
-
         if self.request.user.is_authenticated and hasattr(self.request.user, "migration_state"):
             is_migrated = self.request.user.migration_state == User.COMPLETE
         else:


### PR DESCRIPTION
## :memo: Summary
This PR contributes to issue #ANPL-982.

This PR fixes the link to "reset your session" on the failed login page. Currently, the link works fine on prod but not on dev/local.

The changes in this PR are needed because of the following issues when working on the development cluster or locally:
- Clicking the link attempts to log the user out of our production instance of Control Panel because the logout request is sent to the production endpoint.
- The user is then returned to the production Control Panel where they are prompted to log in again.
- This is confusing when working locally or on the development cluster.

Merging this PR will have the following side-effects:

None, but we should note the following:
- Rather than constructing the logout URL piece by piece, the update uses Control Panel's logout function.
- This logs the user out of first Control Panel and then Control Panel's Auth0 client. Previously, the `returnTo` parameter of the URL was of the form `<control-panel-url>/oidc/logout` to force logout from Control Panel after the Auth0 logout.
- We now pass the client ID to Auth0's logout endpoint, so redirect to a URL of the form `<control-panel-url>` that is in the client-level list of URLs, rather than the tenant-level list:
  - The tenant-level list is maintained in Auth0: Auth0 dev/prod tenant / Settings / Advanced / Login and Logout.
  - The client-level list can be found in the following Terraform files: [prod](https://github.com/ministryofjustice/analytics-platform-infrastructure/blob/main/ap/prod/cluster/control_panel_auth0_clients.tf#L47) | [dev](https://github.com/ministryofjustice/analytics-platform-infrastructure/blob/main/ap/dev/cluster/control_panel_auth0_clients.tf#L47)
- We should probably clear up the tenant-level logout URL lists 🧹 

## :mag: What should the reviewer concentrate on?
- ~~Is there a better way of obtaining the logout URL than the current structure in `login-fail.html`?~~ Fixed

## :technologist: How should the reviewer test these changes?
- Checkout this branch, then build and run Control Panel locally by following the instructions in `docs/running.md`.
- Go to `localhost:8000/` and log in.
- Go to `localhost:8000/login-fail/`: the link to "reset your session" has been changed here.
- Check that the structure of the link itself looks reasonable.
- Click the link.
  - This should log you out and return you to a login page.
  - Log into this page. It should return you to your local instance of Control Panel. (Not to the production instance, as would have happened previously.)
- Once we've deployed on the dev cluster, check the same.

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)