### PR TITLE
ANPL-1089 Extend the timeout value

### DIFF
--- a/controlpanel/api/auth0.py
+++ b/controlpanel/api/auth0.py
@@ -22,7 +22,10 @@ PER_PAGE = 50
 # This is the maximum they'll allow for group/members API
 PER_PAGE_FOR_GROUP_MEMBERS = 25
 
-# Default value for time_out
+# The default value for timeout in auth0.v3.management is 5 seconds which will get ReadTimeOut error quite easily on
+# Auth0 dev tenant when Control panel initialises the connection with it. In order to avoid this, a longer timeout
+# is defined below as the default value for this app. This value will be passed down and overwrite the default 5 seconds
+# when the API classes in Auth0 package are created
 DEFAULT_TIMEOUT = 20
 
 


### PR DESCRIPTION
## :memo: Summary
This PR closes/completes/contributes to issue #ANPL-1083

This PR is to address the issue of reading timeout when call Auth0 API on dev environment. Based on my finding, the error was due to the longer time required to get any response from auth0 platform on Dev compared with on Live env,   the previous timeout value was 5 seconds [from base auth0 package] which somehow is a little bit short for dev env,  the solution from this PR is to extend the timeout from 5 seconds to 20 seconds. 

Merging this PR will have the following side-effects:
- No

## :mag: What should the reviewer concentrate on?
- Time out for  all those auth0 APIs

## :technologist: How should the reviewer test these changes?
- Create an app
- Add more than 10 customers at least 
- check whether there will be any errors during this process

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [X] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
