### PR TITLE
ANPL-1095 fixed the issue of not reading old deployed tool instance

### DIFF
--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -31,6 +31,14 @@ class Tool(TimeStampedModel):
         (EKS, "Amazon EKS infrastructure."),
     )
 
+    # Defines how a matching chart name is put into a named tool bucket.
+    # E.g. jupyter-* charts all end up in the jupyter-lab bucket.
+    # chart name match: tool bucket
+    TOOL_BOX_CHART_LOOKUP = {
+        "jupyter": "jupyter-lab",
+        "rstudio": "rstudio"
+    }
+
     description = models.TextField(blank=True)
     chart_name = models.CharField(max_length=100, blank=False)
     name = models.CharField(max_length=100, blank=False)


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR closes/completes/contributes to issue #ANPL-1095

This PR is to fix the issue of not displaying deployed older version of tool due to the reason 
 that the chart_name in tool db somehow couldn't fit the pattern of finding deployed chart in the old code

Merging this PR will have the following side-effects:
- NO

## :mag: What should the reviewer concentrate on?
- Review the codes for refactoring the process of reading tools from db and cluster

## :technologist: How should the reviewer test these changes?
- Make the jupyter-lab 2.0.5 visible to you
- Deployed a version of jupyter 2.0.5 
- Then make the 2.0.5 version not visible to you ( either change it to restricted version, or if it is restricted version alway, then remove yourself from target users) 
-  check the tools page 
- The old version of 2.0.5 should be still visible to you and you can deploy a newer version.

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [X] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
