### PR TITLE
Add link to managed Airflow instance on Tools page

### DIFF
--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -110,17 +110,24 @@
 <div class="govuk-grid-row tool sse-listener" data-tool-name="airflow">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      Airflow is available as an AWS managed service<br>
+      <a href="{{ user_guidance_base_url }}/tools/airflow/#airflow-2" target="_blank" rel="noopener">Airflow</a> is available as an AWS managed service<br>
     </p>
   </div>
   <div class="govuk-grid-column-one-third">
     <button class="govuk-button govuk-button--secondary govuk-!-margin-right-1 govuk-!-margin-top-0 tool-action"
       data-action-name="open"
-      onclick="window.open('{{ managed_airflow_url }}', '_blank');"
+      onclick="window.open('{{ managed_airflow_dev_url }}', '_blank');"
       rel="noopener"
       target="_blank">
-        Open
+        Open dev
     </button>
+    <button class="govuk-button govuk-button--secondary govuk-!-margin-right-1 govuk-!-margin-top-0 tool-action"
+    data-action-name="open prod"
+    onclick="window.open('{{ managed_airflow_prod_url }}', '_blank');"
+    rel="noopener"
+    target="_blank">
+      Open prod
+  </button>
   </div>
 </div>
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4">

--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -137,12 +137,17 @@ class ToolList(OIDCLoginRequiredMixin, PermissionRequiredMixin, ListView):
 
         context = super().get_context_data(*args, **kwargs)
         context["id_token"] = id_token
+        context["user_guidance_base_url"] = settings.USER_GUIDANCE_BASE_URL
         context["aws_service_url"] = settings.AWS_SERVICE_URL
 
-        args_airflow_url = urlencode({
-        "destination": f"mwaa/home?region={settings.AIRFLOW_REGION}#/environments/{settings.AIRFLOW_ENVIRONMENT}/sso",
+        args_airflow_dev_url = urlencode({
+        "destination": f"mwaa/home?region={settings.AIRFLOW_REGION}#/environments/dev/sso",
         })
-        context["managed_airflow_url"] = f"{settings.AWS_SERVICE_URL}/?{args_airflow_url}"
+        args_airflow_prod_url = urlencode({
+        "destination": f"mwaa/home?region={settings.AIRFLOW_REGION}#/environments/prod/sso",
+        })
+        context["managed_airflow_dev_url"] = f"{settings.AWS_SERVICE_URL}/?{args_airflow_dev_url}"
+        context["managed_airflow_prod_url"] = f"{settings.AWS_SERVICE_URL}/?{args_airflow_prod_url}"
 
         # Arrange tools information
         tools_info = self._retrieve_detail_tool_info(user, context["tools"])

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -512,7 +512,6 @@ LOGS_BUCKET_NAME = os.environ.get('LOGS_BUCKET_NAME', 'moj-analytics-s3-logs')
 
 # -- Airflow
 AIRFLOW_REGION = os.environ.get("AIRFLOW_REGION", "eu-west-1")
-AIRFLOW_ENVIRONMENT = "prod" if ENV == "alpha" else "dev"
 
 AIRFLOW_SECRET_KEY = os.environ.get('AIRFLOW_SECRET_KEY')
 AIRFLOW_FERNET_KEY = os.environ.get('AIRFLOW_FERNET_KEY')


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR completes issue #ANPL-1080.
<!-- Adding the issue number above will automatically link it to our Jira board -->

This PR adds a further block to the Tools page, in the style of existing tools. The user can click the "Open" button to access the new managed Airflow instance.
<!-- Give a brief description here. 
What changes have you made?
Is it a version bump, bugfix, documentation, major change, something else? -->

The changes in this PR are needed because users need a way of accessing Airflow. For consistency with the old Airflow setup, placing a link on the Tools page makes most sense. The layout was suggested by the Data Engineering team in [this Slack thread](https://asdslack.slack.com/archives/C035HSJ6RMG/p1655807646883429).
<!-- Why should this PR be merged? -->

~~**Note that PR moj-analytical-services/analytical-platform-flux#1032 needs to be merged in order for the correct link to appear on prod.**~~ No longer applicable following refactor.

Merging this PR will have the following side-effects: None <!-- Users who could previously could only do Y will now also be able to do Z -->

## :mag: What should the reviewer concentrate on?
- What do you think of the layout, shown in screenshot below? Should I add the "Version" and "Status" labels for consistency with other Tools? (In which case we would have to manually bump the version if any changes from "Airflow 2" occur, and we'd have to work out how to check the Airflow page status.)

![AirflowTool](https://user-images.githubusercontent.com/25640708/179191425-ddca39a3-3da6-491d-93d4-716f09e29bba.png)

## :technologist: How should the reviewer test these changes?
- Deploy Control Panel locally using the guide in `doc/running.md`, then navigate to the Tools page.
- Check that the link to Airflow works. A local deployment of Control Panel should take you to the dev Airflow instance. (No need to set any env variables; this is the default.)
- If you set the MANAGED_AIRFLOW_URL to the value intended for prod (export MANAGED_AIRFLOW_URL="https://eu-west-1.console.aws.amazon.com/mwaa/home?region=eu-west-1#environments/prod/sso"
) and restart your local Control Panel, the env var should be picked up and the "Open" button should open the prod Airflow instance instead.

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
