### PR TITLE
Switch reset session link back to previous format

### DIFF
--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
 {% set page_title = "Login Failure" %}
-{% set signout_url = url("oidc_logout") %}
-
 
 {% block content %}
 <div class="govuk-grid-row" id="reset-container">
@@ -28,7 +26,7 @@
 
         <p>
             It might have timed out in which case you can
-            <a href={{ signout_url }}>
+            <a href="{{ auth0_logout_url }}?returnTo={{ request.scheme }}%3A%2F%2F{{ request.get_host() }}%2Foidc%2Flogout%2F">
                 reset your session
             </a>
             , and login again.

--- a/controlpanel/frontend/views/login_fail.py
+++ b/controlpanel/frontend/views/login_fail.py
@@ -10,6 +10,8 @@ class LoginFail(TemplateView):
         context = super().get_context_data(**kwargs)
         context["environment"] = settings.ENV 
         context["EKS"] = settings.EKS
+        context["auth0_logout_url"] = settings.AUTH0["logout_url"]
+
         if self.request.user.is_authenticated and hasattr(self.request.user, "migration_state"):
             is_migrated = self.request.user.migration_state == User.COMPLETE
         else:


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR contributes to issue #ANPL-982.
<!-- Adding the issue number above will automatically link it to our Jira board -->

This PR uses the previous format of the reset session link, but fixes it so that it will work on dev/local as well as production.
<!-- Give a brief description here. 
What changes have you made?
Is it a version bump, bugfix, documentation, major change, something else? -->

The changes in this PR are needed because the previous fix did not work when users were also logged into an app.
<!-- Why should this PR be merged? -->

Merging this PR will have the following side-effects:
<!-- Users who could previously could only do Y will now also be able to do Z -->
- The following logout URLs have been added to the dev Auth0 tenant:
  - `https://controlpanel.services.dev.analytical-platform.service.justice.gov.uk/oidc/logout/`
  - `http://localhost:8000/oidc/logout/`
which brings the logout URL list into line with the list on the production tenant. The full list can be found in Settings / Advanced from the Auth0 dashboard.

## :mag: What should the reviewer concentrate on?
- Check that this works locally and on dev.

## :technologist: How should the reviewer test these changes?
- See previous PR #1041.
- We should also test this against the case spotted by one of our users. This requires us to be logged into an app, so we will have to test this after deploying to our production cluster. I propose that we test this out at the end of a working day to minimise any impact.

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
