### PR TITLE
ANPL-1172 add node18 to ECR & Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 593291632749.dkr.ecr.eu-west-1.amazonaws.com/node:18-buster AS jsdep
+FROM 593291632749.dkr.ecr.eu-west-1.amazonaws.com/node:18.12.1-slim AS jsdep
 COPY package.json package-lock.json ./
 COPY jest.config.js controlpanel/frontend/static /src/
 

--- a/doc/running.md
+++ b/doc/running.md
@@ -215,6 +215,13 @@ Before the first run (or after changes to static assets), you need to compile
 and collate the static assets.
 
 Static assets are compiled with Node.JS v18.12.0+
+
+Dockerfile uses Base image that has no Critical or High security vulnerabilities.
+
+amd64/node:18.12.1-slim
+- source: [dockerhub](https://github.com/nodejs/docker-node/blob/7bc9983852d4a0a8910f3865b199d78157d1440b/18/buster-slim/Dockerfile)
+
+
 ```sh
 npm install
 mkdir static


### PR DESCRIPTION
Added node18 docker image to ECR.
Added to Dockerfile

## :memo: Summary
image uploaded to ECR
link added to Dockerfile 

The changes in this PR are needed because ...
- we need node18 in ECR instead of quay.io
- upgraded node from 8 -> 18

Merging this PR will have the following side-effects:
- tested locally without any complications
- only side affects are vulnerabilities still present

## :mag: What should the reviewer concentrate on?
- pipeline should not fail
- test locally with node18 (possibly using nvm). package.json should not give errors.
- run babel build locally should not yield any errors and build correctly

## :technologist: How should the reviewer test these changes?
- test locally
- pipeline build gives no errors

## :books: Documentation status
- [ ] No changes to the documentation are required
- [X] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because 
