### PR TITLE
ANPL-1379 added wrapped to limit string length for helm

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -610,7 +610,7 @@ class ToolDeployment:
         )
 
     def escape_namespace_len(self, name: str) -> str:
-        return name[:53]
+        return name[:settings.MAX_RELEASE_NAME_LEN]
 
     def _delete_legacy_release(self):
         """

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -510,3 +510,4 @@ structlog.configure(
 
 # volume name for the EFS directory for user homes
 EFS_VOLUME = os.environ.get("EFS_VOLUME")
+MAX_RELEASE_NAME_LEN = 53

--- a/tests/api/models/test_tool.py
+++ b/tests/api/models/test_tool.py
@@ -17,17 +17,17 @@ def test_deploy_for_generic(helm, tool, users):
 
     # simulate release with old naming scheme installed
     old_release_name = f"{tool.chart_name}-{user.username}"
-    helm.list_releases.return_value = [old_release_name[:53]]
+    helm.list_releases.return_value = [old_release_name[:settings.MAX_RELEASE_NAME_LEN]]
 
     tool_deployment = ToolDeployment(tool, user)
     tool_deployment.save()
 
     # uninstall tool with old naming scheme
-    helm.delete.assert_called_with(user.k8s_namespace, old_release_name[:53])
+    helm.delete.assert_called_with(user.k8s_namespace, old_release_name[:settings.MAX_RELEASE_NAME_LEN])
 
     # install new release
     helm.upgrade_release.assert_called_with(
-        f"{tool.chart_name}-{user.slug}"[:53],
+        f"{tool.chart_name}-{user.slug}"[:settings.MAX_RELEASE_NAME_LEN],
         f"mojanalytics/{tool.chart_name}",
         "--version",
         tool.version,


### PR DESCRIPTION
Fix for error raised by helm namespace being too long (greater than 53 chars)

## :memo: Summary
PR limits the number of characters that can be used.

The changes in this PR are needed because ...
code on namespace to limit char count and change in unit tests

Merging this PR will have the following side-effects:
- This PR will not any of the existing deployments but new deployments will not throw any errors
- deployments will have {chart-name}-{user.slug}. Only the user slug will be trimmed. As long as this is unique then it should be ok.

## :mag: What should the reviewer concentrate on?
- use unit tests to test out different permutations of user.slug
- users with same surname maybe interesting
- check that old deployments are depleted before the new one is created

## :technologist: How should the reviewer test these changes?
- new deployment
- relaunch existing deployment

## :books: Documentation status
- [X] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
