### PR TITLE
ANPL-1399 TLS restriction for buckets created on AP

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -102,6 +102,15 @@ BASE_S3_ACCESS_STATEMENT = {
     },
 }
 
+BUCKET_TLS_STATEMENT = {
+    "Sid": "DenyInsecureTransport",
+    "Action": "s3:*",
+    "Effect": "Deny",
+    "Principal": "*",
+    "Resource": "arn:aws:s3:::{bucket_arn}",
+    "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+}
+
 BASE_S3_ACCESS_POLICY = {
     "Version": "2012-10-17",
     "Statement": [
@@ -400,7 +409,17 @@ class AWSBucket(AWSService):
                 "RestrictPublicBuckets": True,
             },
         )
+
+        self._apply_tls_restrictions(s3_client, bucket_name)
         return bucket
+
+    def _apply_tls_restrictions(self, client, bucket_name):
+        """it assumes that this is a new bucket with no policies & creates it"""
+        tls_statement = deepcopy(BUCKET_TLS_STATEMENT)
+        arn: str = tls_statement["Resource"].format(bucket_arn=bucket_name)
+        tls_statement["Resource"] = arn
+        bucket_policy = dict(Version="2012-10-17", Statement=[tls_statement])
+        client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
 
     def _tag_bucket(self, boto_bucket, tags):
         """

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -265,6 +265,21 @@ def logs_bucket(s3):
     )
 
 
+def test_bucket_policy_on_creation(logs_bucket, s3):
+    bucket_name = f"bucket-{id(MagicMock())}"
+    aws.AWSBucket().create_bucket(bucket_name, is_data_warehouse=True)
+
+    policy = json.loads(
+        s3.meta.client.get_bucket_policy(Bucket=bucket_name).get("Policy")
+    )
+    statement = policy.get("Statement", [])
+    assert len(statement) == 1
+    assert statement[0].get("Resource") == f"arn:aws:s3:::{bucket_name}"
+    assert (
+        statement[0].get("Condition").get("Bool").get("aws:SecureTransport") == "false"
+    )
+
+
 def test_create_bucket(logs_bucket, s3):
     bucket_name = f"bucket-{id(MagicMock())}"
     bucket = s3.Bucket(bucket_name)


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
Upon creating a bucket, make sure that tls restriction is applied to bucket policy

This PR ...
Added private function that injects bucket policy to force tls access only.

Merging this PR will have the following side-effects:
- This PR does not affect existing buckets. Existing buckets have been changed to be restricted to use TLS
- Moving forward, when buckets are created on AP, they will automatically include a policy that forces tls.

## :mag: What should the reviewer concentrate on?
- upon creating a bucket from AP, it should have a deny for all non-tls requests


## :technologist: How should the reviewer test these changes?
- switch to dev env
- run test - should pass
- run localhost
- navigate to create bucket as normal
- upon creation, go to aws console and check the permissions tab for your new bucket. It should have Deny for all non tls connections.

## :books: Documentation status
- [X] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
