### PR TITLE
ANPL-1399 formatted

### DIFF
--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -228,7 +228,10 @@ def test_bucket_policy_on_creation(logs_bucket, s3):
     )
     statement = policy.get("Statement", [])
     assert len(statement) == 1
-    assert statement[0].get("Resource") == f"arn:aws:s3:::{bucket_name}"
+    assert statement[0].get("Resource") == [
+        f"arn:aws:s3:::{bucket_name}",
+        f"arn:aws:s3:::{bucket_name}/*",
+    ]
     assert (
         statement[0].get("Condition").get("Bool").get("aws:SecureTransport") == "false"
     )


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
Upon creating a bucket, make sure that tls restriction is applied to bucket policy

This PR ...
Added private function that injects bucket policy to force tls access only.

Merging this PR will have the following side-effects:

This PR does not affect existing buckets. Existing buckets have been changed to be restricted to use TLS
Moving forward, when buckets are created on AP, they will automatically include a policy that forces tls.

## :mag: What should the reviewer concentrate on?
upon creating a bucket from AP, it should have a deny for all non-tls requests

## :technologist: How should the reviewer test these changes?
- switch to dev env
- run test - should pass
- run localhost
- navigate to create bucket as normal
- upon creation, go to aws console and check the permissions tab for your new bucket. It should have Deny for all non tls connections.

## :books: Documentation status
- [X] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
