### PR TITLE
HotFix - Fixed the os importing issue

### DIFF
--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 from datetime import datetime
+import os
 from pathlib import Path
 from time import sleep
 


### PR DESCRIPTION

This PR  is to solve the `os import` issue , this error will be only triggered when a helm chart is failed to be deployed , it is related to send error to sentry

Merging this PR will have the following side-effects:
- No

## :mag: What should the reviewer concentrate on?
- import command 

## :technologist: How should the reviewer test these changes?
- deploy an helm chart

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [X] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
