### PR TITLE
Add feature flag for S3 folders

### DIFF
--- a/controlpanel/frontend/views/datasource.py
+++ b/controlpanel/frontend/views/datasource.py
@@ -2,6 +2,7 @@
 from itertools import chain
 
 # Third-party
+from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
@@ -159,8 +160,12 @@ class CreateDatasource(
         return reverse_lazy("manage-datasource", kwargs={"pk": self.object.pk})
 
     def form_valid(self, form):
+        if settings.features.s3_folders.enabled:
+            raise NotImplementedError("S3 folders not yet implemented")
+
         name = form.cleaned_data["name"]
         datasource_type = self.request.GET.get("type")
+
         try:
             with transaction.atomic():
                 self.object = S3Bucket.objects.create(

--- a/settings.yaml
+++ b/settings.yaml
@@ -6,6 +6,11 @@ enabled_features:
     _HOST_alpha: true
   redirect_legacy_api_urls:
     _DEFAULT: true
+  s3_folders:
+    _DEFAULT: false
+    _HOST_dev: false
+    _HOST_prod: false
+    _HOST_alpha: false
 
 
 AWS_SERVICE_URL:

--- a/tests/frontend/views/test_datasource.py
+++ b/tests/frontend/views/test_datasource.py
@@ -278,3 +278,15 @@ def test_bucket_creator_has_readwrite_and_admin_access(client, users):
     ub = user.users3buckets.all()[0]
     assert ub.access_level == UserS3Bucket.READWRITE
     assert ub.is_admin
+
+
+@patch("django.conf.settings.features.s3_folders")
+def test_create_s3_folder(s3_folders, client, users):
+    # TODO this test will be updated to assert correct behaviour when S3 folders have
+    #  been implemented.
+    s3_folders.enabled = True
+    for user_type, user_obj in users.items():
+        client.force_login(user_obj)
+
+        with pytest.raises(NotImplementedError):
+            create(client)


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR contributes to issue #ANPL-1589
<!-- Adding the issue number above will automatically link it to our Jira board -->

This PR adds a feature flag that we can use while implementing tasks to migrate to use S3 folders outlined in our epic https://dsdmoj.atlassian.net/browse/ANPL-1586

<!-- Give a brief description here. 
What changes have you made?
Is it a version bump, bugfix, documentation, major change, something else? -->

The changes in this PR are needed because it will allow us to work on the S3 folder migration tasks, without breaking the existing process in production.

Merging this PR will have the following side-effects:
- None, unless the feature flag is enabled early, in which case an error would be raised when trying to create a datasource

## :mag: What should the reviewer concentrate on?
- Format of the setting
- Smoke test to check that the feature is not enabled before it is ready

## :technologist: How should the reviewer test these changes?
- Run the code locally, creating a datasource should work as before (bucket is created)
- Run the code with the feature flag enabled, creating a datasource should raise an error
- Run the tests

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [x] Documentation will be added in the future when the S3 folder feature is implemented