### PR TITLE
Fix app_old_url to use . in webapp-detail.html

### DIFF
--- a/controlpanel/frontend/jinja2/webapp-detail.html
+++ b/controlpanel/frontend/jinja2/webapp-detail.html
@@ -12,7 +12,7 @@
 {% set page_name = "webapps" %}
 {% set page_title = app.name %}
 {% set app_domain = settings.APP_DOMAIN %}
-{% set app_old_url = "https://" + app.slug + "/" + settings.APP_DOMAIN_BEFORE_MIGRATION %}
+{% set app_old_url = "https://" + app.slug + "." + settings.APP_DOMAIN_BEFORE_MIGRATION %}
 {% set feature_enabled = settings.features.app_migration.enabled %}
 
 {% set app_admins_html %}


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR closes #ANPL-1693
<!-- Adding the issue number above will automatically link it to our Jira board -->

The changes in this PR are needed because the old app url displayed on webapp detail is incorrect.

Merging this PR will have the following side-effects:
- None, although the old app url will be redundant anyway once the alpha cluster is shut down

## :mag: What should the reviewer concentrate on?
- Template change
- 
## :technologist: How should the reviewer test these changes?
- Can run locally to check or check when deployed to dev

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
