### PR TITLE
ANPL-1702 Hotfix: replace the queue name with env var

### DIFF
--- a/controlpanel/celery.py
+++ b/controlpanel/celery.py
@@ -43,7 +43,7 @@ def worker_health_check(self):
 # ensures worker picks and runs tasks from all queues rather than just default queue
 # alternative is to run the worker and pass queue name to -Q flag
 app.conf.task_queues = [
-    Queue("iam_queue"),
-    Queue("auth_queue"),
-    Queue("s3_queue"),
+    Queue(settings.IAM_QUEUE_NAME),
+    Queue(settings.AUTH_QUEUE_NAME),
+    Queue(settings.S3_QUEUE_NAME),
 ]


### PR DESCRIPTION
Hot fix as the summary says ( got exceptions on dev env)

🤦‍♀️ ,    I did run the celery with sqs option on,  but forgot remove the redis `BROKER_URL` from `.env` file,  and I didn't spotted it from the output of celery worker and only checked the queue names displayed changed to new names 


Merging this PR will have the following side-effects:
- No

## :mag: What should the reviewer concentrate on?
- codes

## :technologist: How should the reviewer test these changes?
- run celery work with sqs option on

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [X] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
