### PR TITLE
ANPL-1540 add management command to write email addresses for a auth0…

### DIFF
--- a/controlpanel/cli/management/commands/get_customer_emails_csv.py
+++ b/controlpanel/cli/management/commands/get_customer_emails_csv.py
@@ -1,0 +1,31 @@
+# Standard library
+import csv
+from datetime import datetime
+
+# Third-party
+from django.core.management import BaseCommand
+
+# First-party/Local
+from controlpanel.api import auth0
+
+
+class Command(BaseCommand):
+    help = "Writes a CSV with all customer emails for an auth0 group"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "group_name",
+            type=str,
+            help="input: The auth0 group name to get customers emails for"
+        )
+
+    def handle(self, *args, **options):
+        group_name = options["group_name"]
+        auth_instance = auth0.ExtendedAuth0()
+        group_id = auth_instance.groups.get_group_id(group_name)
+        timestamp = datetime.now().strftime("%d-%m-%Y_%H%M")
+        with open(f"{group_name}_customers_{timestamp}.csv", "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["Email"])
+            for customer in auth_instance.groups.get_group_members(group_id):
+                writer.writerow([customer["email"]])


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR contributes to issue #ANPL-1540
<!-- Adding the issue number above will automatically link it to our Jira board -->

This PR adds a management command to create a CSV of all email addresses for a given auth0 group. It is not possible to generate this in auth0 currently. I added this management command after Segmentation Tool owner Susan Baron requested the emails of all users for the app. There are 800+ users so the quickest way to do this was with a short script using existing auth0 API methods, and thought it would be useful to add to a management command in case we need to run this again.

In future it would be better to expose this to the customer so they could generate the CSV themselves - perhaps utilising the task queue as the process can be time consuming. Implementation requires further discussion/thinking about.


Merging this PR will have the following side-effects:
- N/a

## :mag: What should the reviewer concentrate on?
- Management command

## :technologist: How should the reviewer test these changes?
- Ensure you have correct Auth0 env vars set for the dev tenant
- Find a group in auth0 dev tenant with some customers to test with (or create a new app in Control Panel and add some emails)
- Run the management command: `python manage.py get_customer_emails <group_name>`
- Check the CSV looks correct
- Delete the CSV

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [x] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see #ANPL-...)
