### PR TITLE
Call complete when revoking all access succeeds

### DIFF
--- a/controlpanel/api/tasks/handlers/s3.py
+++ b/controlpanel/api/tasks/handlers/s3.py
@@ -95,3 +95,5 @@ class S3BucketRevokeAllAccess(BaseModelTaskHandler):
 
             instance.current_user = task_user
             instance.revoke_bucket_access()
+
+        self.complete()

--- a/tests/api/tasks/test_s3.py
+++ b/tests/api/tasks/test_s3.py
@@ -121,7 +121,8 @@ def test_revoke_app_access(cluster, complete):
 @patch("controlpanel.api.models.UserS3Bucket.revoke_bucket_access", new=MagicMock())
 @patch("controlpanel.api.models.AppS3Bucket.revoke_bucket_access", new=MagicMock())
 @patch("controlpanel.api.models.PolicyS3Bucket.revoke_bucket_access", new=MagicMock())
-def test_revoke_all_access(users):
+@patch("controlpanel.api.tasks.handlers.base.BaseTaskHandler.complete")
+def test_revoke_all_access(complete, users):
     bucket = mommy.make("api.S3Bucket")
     user_access = mommy.make("api.UserS3Bucket", s3bucket=bucket)
     app_access = mommy.make("api.AppS3Bucket", s3bucket=bucket)
@@ -133,3 +134,4 @@ def test_revoke_all_access(users):
     user_access.revoke_bucket_access.assert_called_once()
     app_access.revoke_bucket_access.assert_called_once()
     policy_access.revoke_bucket_access.assert_called_once()
+    complete.assert_called_once()


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR fixes a bug that meant the revoke all access task was not marked as completed in the DB.

## :mag: What should the reviewer concentrate on?
- Code change/test change

## :technologist: How should the reviewer test these changes?
- Soft delete an s3 bucket, then check the /tasks page - the task to revoke all access should not appear

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
