### PR TITLE
Initial implementation of archiving S3 folder contents

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -590,6 +590,27 @@ class AWSFolder(AWSService):
         except botocore.exceptions.ClientError:
             return False
 
+    def get_objects(self, bucket_name, folder_name):
+        bucket = self.boto3_session.resource("s3").Bucket(bucket_name)
+        return bucket.objects.filter(Prefix=f"{folder_name}/")
+
+    def archive_object(self, key, source_bucket_name=None, delete_original=True):
+        source_bucket_name = source_bucket_name or settings.S3_FOLDER_BUCKET_NAME
+        copy_source = {
+            'Bucket': source_bucket_name,
+            'Key': key
+        }
+        archive_bucket = self.boto3_session.resource("s3").Bucket(
+            settings.S3_ARCHIVE_BUCKET_NAME
+        )
+        new_key = f"{archive_bucket.name}/{key}"
+
+        archive_bucket.copy(copy_source, new_key)
+        print(f"Moved {key} to {new_key}")
+        if delete_original:
+            self.boto3_session.resource("s3").Object(source_bucket_name, key).delete()
+            print(f"deleted original: {source_bucket_name}/{key}")
+
 
 class AWSBucket(AWSService):
     def create(self, bucket_name, is_data_warehouse=False):

--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -606,10 +606,10 @@ class AWSFolder(AWSService):
         new_key = f"{archive_bucket.name}/{key}"
 
         archive_bucket.copy(copy_source, new_key)
-        print(f"Moved {key} to {new_key}")
+        log.info(f"Moved {key} to {new_key}")
         if delete_original:
             self.boto3_session.resource("s3").Object(source_bucket_name, key).delete()
-            print(f"deleted original: {source_bucket_name}/{key}")
+            log.info(f"deleted original: {source_bucket_name}/{key}")
 
 
 class AWSBucket(AWSService):

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -735,6 +735,17 @@ class S3Folder(S3Bucket):
         folder_path = f"{settings.S3_FOLDER_BUCKET_NAME}/{folder_name}"
         return super().exists(folder_path, bucket_owner), folder_path
 
+    def get_objects(self):
+        bucket_name, folder_name = self.bucket.name.split("/")
+        return self.aws_bucket_service.get_objects(
+            bucket_name=bucket_name, folder_name=folder_name,
+        )
+
+    def archive_object(self, key, source_bucket=None, delete_original=True):
+        self.aws_bucket_service.archive_object(
+            key=key, source_bucket_name=source_bucket, delete_original=delete_original,
+        )
+
 
 class RoleGroup(EntityResource):
     """

--- a/controlpanel/api/tasks/__init__.py
+++ b/controlpanel/api/tasks/__init__.py
@@ -2,9 +2,12 @@
 # First-party/Local
 from controlpanel.api.tasks.app import AppCreateAuth, AppCreateRole
 from controlpanel.api.tasks.s3bucket import (
+    S3BucketArchive,
+    S3BucketArchiveObject,
     S3BucketCreate,
     S3BucketGrantToApp,
     S3BucketGrantToUser,
+    S3BucketRevokeAllAccess,
     S3BucketRevokeAppAccess,
     S3BucketRevokeUserAccess,
 )

--- a/controlpanel/api/tasks/handlers/__init__.py
+++ b/controlpanel/api/tasks/handlers/__init__.py
@@ -2,6 +2,8 @@
 from controlpanel import celery_app
 from controlpanel.api.tasks.handlers.app import CreateAppAuthSettings, CreateAppAWSRole
 from controlpanel.api.tasks.handlers.s3 import (
+    ArchiveS3Bucket,
+    ArchiveS3Object,
     CreateS3Bucket,
     GrantAppS3BucketAccess,
     GrantUserS3BucketAccess,
@@ -18,3 +20,5 @@ create_app_auth_settings = celery_app.register_task(CreateAppAuthSettings())
 revoke_user_s3bucket_access = celery_app.register_task(S3BucketRevokeUserAccess())
 revoke_app_s3bucket_access = celery_app.register_task(S3BucketRevokeAppAccess())
 revoke_all_access_s3bucket = celery_app.register_task(S3BucketRevokeAllAccess())
+archive_s3bucket = celery_app.register_task(ArchiveS3Bucket)
+archive_s3_object = celery_app.register_task(ArchiveS3Object)

--- a/controlpanel/api/tasks/handlers/s3.py
+++ b/controlpanel/api/tasks/handlers/s3.py
@@ -1,4 +1,5 @@
 # Third-party
+import structlog
 from django.db.models.deletion import Collector
 
 # First-party/Local
@@ -6,6 +7,8 @@ from controlpanel.api import cluster, tasks
 from controlpanel.api.models import App, AppS3Bucket, S3Bucket, User, UserS3Bucket
 from controlpanel.api.models.access_to_s3bucket import AccessToS3Bucket
 from controlpanel.api.tasks.handlers.base import BaseModelTaskHandler, BaseTaskHandler
+
+log = structlog.getLogger(__name__)
 
 
 class CreateS3Bucket(BaseModelTaskHandler):
@@ -109,8 +112,6 @@ class ArchiveS3Bucket(BaseModelTaskHandler):
             tasks.S3BucketArchiveObject(
                 self.object, task_user, extra_data={"s3obj_key": s3obj.key}
             ).create_task()
-            print(f"Sent task to delete {s3obj.key}")
-        print("All archive tasks sent")
         self.complete()
 
 
@@ -120,6 +121,5 @@ class ArchiveS3Object(BaseModelTaskHandler):
 
     def handle(self, s3obj_key):
         # TODO update to use self.object.cluster to work with buckets
-        print(f"Archiving {s3obj_key}")
         cluster.S3Folder(self.object).archive_object(key=s3obj_key)
         self.complete()

--- a/controlpanel/api/tasks/s3bucket.py
+++ b/controlpanel/api/tasks/s3bucket.py
@@ -98,3 +98,34 @@ class S3BucketRevokeAppAccess(S3AccessMixin, TaskBase):
             self.entity.s3bucket.arn,
             self.entity.app.pk,
         ]
+
+
+class S3BucketArchive(TaskBase):
+    ENTITY_CLASS = "S3Bucket"
+    QUEUE_NAME = settings.S3_QUEUE_NAME
+
+    @property
+    def task_name(self):
+        return "archive_s3bucket"
+
+    @property
+    def task_description(self):
+        return "move contents of s3 datasource to the archive bucket"
+
+
+class S3BucketArchiveObject(TaskBase):
+    ENTITY_CLASS = "S3Bucket"
+    QUEUE_NAME = settings.S3_QUEUE_NAME
+
+    @property
+    def task_name(self):
+        return "archive_s3_object"
+
+    @property
+    def task_description(self):
+        return "move object to archive bucket"
+
+    def _get_args_list(self):
+        args = super()._get_args_list()
+        args.append(self.extra_data.get('s3obj_key'))
+        return args

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -565,3 +565,5 @@ for queue in PRE_DEFINED_QUEUES:
 CELERY_IMPORTS = [
     "controlpanel.api.tasks.handlers"
 ]
+
+S3_ARCHIVE_BUCKET_NAME = "dev-archive-folder"


### PR DESCRIPTION
Use tasks so that the contents are moved asynchronously. A tasks is fired for every individual object in order to utilise multiple workers to improve performance.
Adds methods to cluster, aws files to handle retrieving and archiving objects.

closes ministryofjustice/data-platform#1887

