### PR TITLE
Generate python package upgrade

### DIFF
--- a/controlpanel/api/auth0.py
+++ b/controlpanel/api/auth0.py
@@ -104,11 +104,9 @@ class ExtendedAuth0(Auth0):
         )
 
     def _access_token(self, audience):
-        get_token = authentication.GetToken(self.domain)
+        get_token = authentication.GetToken(self.domain, client_id=self.client_id)
         try:
-            token = get_token.client_credentials(
-                self.client_id, self.client_secret, audience
-            )
+            token = get_token.client_credentials(audience)
         except exceptions.Auth0Error as error:
             error_detail = (
                 f"Access token error: {self.client_id}, {self.domain}, {error}"

--- a/controlpanel/api/auth0.py
+++ b/controlpanel/api/auth0.py
@@ -6,13 +6,13 @@ from pathlib import Path
 # Third-party
 import structlog
 import yaml
-from auth0.v3 import authentication, exceptions
-from auth0.v3.management import Auth0
-from auth0.v3.management.clients import Clients
-from auth0.v3.management.connections import Connections
-from auth0.v3.management.device_credentials import DeviceCredentials
-from auth0.v3.management.rest import RestClient
-from auth0.v3.management.users import Users
+from auth0 import authentication, exceptions
+from auth0.management import Auth0
+from auth0.management.clients import Clients
+from auth0.management.connections import Connections
+from auth0.management.device_credentials import DeviceCredentials
+from auth0.rest import RestClient
+from auth0.management.users import Users
 from django.conf import settings
 from jinja2 import Environment
 from rest_framework.exceptions import APIException
@@ -27,7 +27,7 @@ PER_PAGE = 50
 # This is the maximum they'll allow for group/members API
 PER_PAGE_FOR_GROUP_MEMBERS = 25
 
-# The default value for timeout in auth0.v3.management is 5 seconds which will
+# The default value for timeout in auth0.management is 5 seconds which will
 # get ReadTimeOut error quite easily on Auth0 dev tenant when Control panel
 # initialises the connection with it. In order to avoid this, a longer timeout
 # is defined below as the default value for this app. This value will be passed

--- a/controlpanel/api/auth0.py
+++ b/controlpanel/api/auth0.py
@@ -104,7 +104,11 @@ class ExtendedAuth0(Auth0):
         )
 
     def _access_token(self, audience):
-        get_token = authentication.GetToken(self.domain, client_id=self.client_id)
+        get_token = authentication.GetToken(
+            self.domain,
+            client_id=self.client_id,
+            client_secret=self.client_secret
+        )
         try:
             token = get_token.client_credentials(audience)
         except exceptions.Auth0Error as error:

--- a/controlpanel/api/models/app.py
+++ b/controlpanel/api/models/app.py
@@ -3,7 +3,7 @@ import json
 import uuid
 
 # Third-party
-from auth0.v3.exceptions import Auth0Error
+from auth0.exceptions import Auth0Error
 from django.conf import settings
 from django.db import models
 from django_extensions.db.fields import AutoSlugField

--- a/controlpanel/cli/management/commands/clear_up_auth0_resources.py
+++ b/controlpanel/cli/management/commands/clear_up_auth0_resources.py
@@ -3,7 +3,7 @@ import csv
 from datetime import datetime
 
 # Third-party
-from auth0.v3.exceptions import Auth0Error
+from auth0.exceptions import Auth0Error
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 

--- a/controlpanel/cli/management/commands/export_auth0_log.py
+++ b/controlpanel/cli/management/commands/export_auth0_log.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from time import time
 
 from controlpanel.api import auth0
-from auth0.v3.management.logs import Logs
+from auth0.management.logs import Logs
 
 
 class Command(BaseCommand):

--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -17,7 +17,7 @@ from django.views.generic.detail import DetailView, SingleObjectMixin
 from django.views.generic.edit import CreateView, DeleteView, FormMixin, UpdateView
 from django.views.generic.list import ListView
 from rules.contrib.views import PermissionRequiredMixin
-from auth0.v3.management.rest import Auth0Error
+from auth0.rest import Auth0Error
 
 # First-party/Local
 from controlpanel.api import auth0, cluster

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@ beautifulsoup4==4.12.2
 boto3==1.26.143
 celery[sqs]==5.3.1
 channels==4.0.0
-channels-redis==4.1.0
+channels-redis==4.0.0
 daphne==4.0.0
 Django==4.2.7
 django-crequest==2018.5.11
 django-extensions==3.2.3
 django-filter==22.1
 django-prometheus==2.1.0
-django-redis==5.3.0
+django-redis==5.4.0
 django-simple-history==3.3.0
 django-structlog==2.2.0
 djangorestframework==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 asgiref==3.6.0
-auth0-python==3.13.0
+auth0-python==4.5.0
 beautifulsoup4==4.12.2
 boto3==1.26.143
 celery[sqs]==5.3.1
 channels==4.0.0
-channels-redis==4.0.0
+channels-redis==4.1.0
 daphne==4.0.0
-Django==4.2.1
+Django==4.2.7
 django-crequest==2018.5.11
-django-extensions==3.2.1
+django-extensions==3.2.3
 django-filter==22.1
 django-prometheus==2.1.0
 django-redis==5.3.0
@@ -33,6 +33,6 @@ python-jose==3.3.0
 pyyaml==6.0
 rules==3.3
 sentry-sdk==1.14.0
-slackclient==2.8.1
-urllib3==1.26.16
+slackclient==2.9.4
+urllib3==1.26.18
 uvicorn[standard]==0.20.0

--- a/tests/api/test_auth0.py
+++ b/tests/api/test_auth0.py
@@ -15,7 +15,7 @@ from controlpanel.api import auth0
 @pytest.fixture()
 def ExtendedAuth0():
     with patch(
-        "auth0.v3.authentication.GetToken.client_credentials"
+        "auth0.authentication.GetToken.client_credentials"
     ) as client_credentials:
         client_credentials.return_value = {"access_token": "access_token_testing"}
         yield auth0.ExtendedAuth0()

--- a/tests/api/test_auth0.py
+++ b/tests/api/test_auth0.py
@@ -6,7 +6,7 @@ from unittest.mock import call, patch
 import mock
 import pytest
 from django.conf import settings
-from auth0.v3 import exceptions
+from auth0 import exceptions
 
 # First-party/Local
 from controlpanel.api import auth0

--- a/tests/api/views/test_customer.py
+++ b/tests/api/views/test_customer.py
@@ -3,7 +3,7 @@ import uuid
 from unittest.mock import patch
 
 # Third-party
-from auth0.v3.management.rest import Auth0Error
+from auth0.rest import Auth0Error
 from bs4 import BeautifulSoup
 from model_mommy import mommy
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from tests.api.fixtures.helm_mojanalytics_index import HELM_MOJANALYTICS_INDEX
 @pytest.fixture()
 def ExtendedAuth0():
     with patch(
-        "auth0.v3.authentication.GetToken.client_credentials"
+        "auth0.authentication.GetToken.client_credentials"
     ) as client_credentials:
         client_credentials.return_value = {"access_token": "access_token_testing"}
         yield auth0.ExtendedAuth0()


### PR DESCRIPTION
This PR is for upgrading the python packages raised by the dependantbot,  only one cannot be upgrade , it is channel-redis,  the new version will cause an exception 
```
TypeError: __init__() got an unexpected keyword argument 'timeout'
```
I was thinking it is due to the lower version of `redis` python package, but checked we are using the latest one (only checked my local)