### PR TITLE
Feature/vscode tool add

### DIFF
--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -22,7 +22,9 @@ class Tool(TimeStampedModel):
     # Defines how a matching chart name is put into a named tool bucket.
     # E.g. jupyter-* charts all end up in the jupyter-lab bucket.
     # chart name match: tool bucket
-    TOOL_BOX_CHART_LOOKUP = {"jupyter": "jupyter-lab", "rstudio": "rstudio"}
+    TOOL_BOX_CHART_LOOKUP = {"jupyter": "jupyter-lab",
+                             "rstudio": "rstudio",
+                             "vscode": "vscode"}
 
     description = models.TextField(blank=True)
     chart_name = models.CharField(max_length=100, blank=False)

--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -456,6 +456,7 @@ class ToolReleaseForm(forms.ModelForm):
             "airflow-sqlite",
             "jupyter-",
             "rstudio",
+            "vscode"
         ]
         value = self.cleaned_data["chart_name"]
         is_valid = False
@@ -478,6 +479,7 @@ class ToolReleaseForm(forms.ModelForm):
             "airflow-sqlite",
             "jupyter-lab",
             "rstudio",
+            "vscode"
         ]
         value = self.cleaned_data.get("tool_domain")
         if value and value not in valid_names:

--- a/controlpanel/frontend/jinja2/release-create.html
+++ b/controlpanel/frontend/jinja2/release-create.html
@@ -45,7 +45,7 @@
       },
       "classes": "govuk-!-width-two-thirds",
       "hint": {
-        "text": 'Helm chart name. Use only variations of: airflow-sqlite, jupyter-* or rstudio'
+        "text": 'Helm chart name. Use only variations of: airflow-sqlite, jupyter-*, rstudio or vscode'
       },
       "name": "chart_name",
       "attributes": {
@@ -95,7 +95,7 @@
       },
       "classes": "govuk-!-width-two-thirds",
       "hint": {
-        "text": 'If the chart name is non-standard, use this value in the domain name for the tool. Use only one of: airflow-sqlite, jupyter-lab or rstudio.'
+        "text": 'If the chart name is non-standard, use this value in the domain name for the tool. Use only one of: airflow-sqlite, jupyter-lab, rstudio or vscode.'
       },
       "name": "tool_domain",
       "attributes": {

--- a/tests/frontend/test_forms.py
+++ b/tests/frontend/test_forms.py
@@ -56,6 +56,15 @@ def test_tool_release_form_check_release_name():
     assert f.is_valid()
     data = {
         "name": "Test Release",
+        "chart_name": "vscode",
+        "version": "1.2.3",
+        "values": {"foo": "bar"},
+        "is_restricted": False,
+    }
+    f = forms.ToolReleaseForm(data)
+    assert f.is_valid()
+    data = {
+        "name": "Test Release",
         "chart_name": "invalid-chartname",
         "version": "1.2.3",
         "values": {"foo": "bar"},
@@ -87,6 +96,16 @@ def test_tool_release_form_check_tool_domain():
         "values": {"foo": "bar"},
         "is_restricted": False,
         "tool_domain": "jupyter-lab",
+    }
+    f = forms.ToolReleaseForm(data)
+    assert f.is_valid()
+    data = {
+        "name": "Test Release",
+        "chart_name": "vscode",
+        "version": "1.2.3",
+        "values": {"foo": "bar"},
+        "is_restricted": False,
+        "tool_domain": "vscode",
     }
     f = forms.ToolReleaseForm(data)
     assert f.is_valid()


### PR DESCRIPTION
Merging this PR will add VSCode as an additional Analytical Tool

## :memo: Summary
The following PR adds the ability to specify VSCode as a useable IDE, as well as specify VSCode in the create new tool release form.
The changes in this PR are needed because it adds VSCode as an option in the Analytical Tooling list


## :mag: What should the reviewer concentrate on?
- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Add VSCode as a new tool release via the Create new tool release form
- Add a block similar to the following in ~/Library/Caches/helm/repository/mojanalytics-index.yaml
```
vscode:
  - apiVersion: v1
    appVersion: 'VSCode: 1.0.0'
    created: "2024-02-05T11:11:33.698997588Z"
    description: Visual Studio Code with Auth0 authentication proxy
    digest: 2a5a3c7106bc4549aaac1fb1ed1d901b3ba45253f8fa74a37f3f999588e1e004
    icon: https://avatars3.githubusercontent.com/u/8361145?s=200&v=4?sanitize=true
    maintainers:
    - name: ministryofjustice
    name: vscode
    urls:
    - http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com/vscode-1.0.0.tgz
    version: 1.0.0
```
- Check the analytical tools page and see if Visual Studio Code is an option

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
