### PR TITLE
Only allow superusers access to the User detail api endpoint

### DIFF
--- a/controlpanel/api/permissions.py
+++ b/controlpanel/api/permissions.py
@@ -66,6 +66,9 @@ class S3BucketPermissions(RulesBasePermissions):
 class UserPermissions(RulesBasePermissions):
     resource = "user"
 
+    def has_object_permission(self, request, view, obj):
+        return request.user.is_superuser
+
 
 class AppS3BucketPermissions(RulesBasePermissions):
     resource = "apps3bucket"

--- a/tests/api/permissions/test_user_permissions.py
+++ b/tests/api/permissions/test_user_permissions.py
@@ -80,12 +80,14 @@ def auth0():
         (user_update, "superuser", status.HTTP_200_OK),
         (user_list, "normal_user", status.HTTP_403_FORBIDDEN),
         (user_detail, "normal_user", status.HTTP_403_FORBIDDEN),
-        (user_own_detail, "normal_user", status.HTTP_200_OK),
+        (user_own_detail, "superuser", status.HTTP_200_OK),
+        (user_own_detail, "normal_user", status.HTTP_403_FORBIDDEN),
         (user_delete, "normal_user", status.HTTP_403_FORBIDDEN),
         (user_delete_self, "normal_user", status.HTTP_403_FORBIDDEN),
         (user_create, "normal_user", status.HTTP_403_FORBIDDEN),
         (user_update, "normal_user", status.HTTP_403_FORBIDDEN),
-        (user_update_self, "normal_user", status.HTTP_200_OK),
+        (user_update_self, "superuser", status.HTTP_200_OK),
+        (user_update_self, "normal_user", status.HTTP_403_FORBIDDEN),
     ],
 )
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR resolves a bug that could allow a normal user to update their status to superuser, via the API endpoint.

The changes ensures that only superusers have permission to update user details via the API.  

## :mag: What should the reviewer concentrate on?
- Permission check changes
- Tests

## :technologist: How should the reviewer test these changes?
- Unit tests have been updated and will run as part of CI
- Run locally, login as a normal user, and try to access your user detail API endpoint

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
