### PR TITLE
🔧  Add condition for `vscode` 'Open' button

### DIFF
--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -245,9 +245,9 @@ class ToolList(OIDCLoginRequiredMixin, PermissionRequiredMixin, ListView):
         tools_info = self._retrieve_detail_tool_info(
             user, context["tools"], charts_info
         )
-        if 'vscode' in tools_info:
-            url = tools_info['vscode']['url']
-            tools_info['vscode']['url'] = f"{url}/?folder=/home/analyticalplatform/workspace"
+        if 'visual-studio-code' in tools_info:
+            url = tools_info['visual-studio-code']['url']
+            tools_info['visual-studio-code']['url'] = f"{url}?folder=/home/analyticalplatform/workspace"
 
         self._add_deployed_charts_info(tools_info, user, id_token, charts_info)
         context["tools_info"] = tools_info

--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -245,6 +245,10 @@ class ToolList(OIDCLoginRequiredMixin, PermissionRequiredMixin, ListView):
         tools_info = self._retrieve_detail_tool_info(
             user, context["tools"], charts_info
         )
+        if 'vscode' in tools_info:
+            url = tools_info['vscode']['url']
+            tools_info['vscode']['url'] = f"{url}/?folder=/home/analyticalplatform/workspace"
+
         self._add_deployed_charts_info(tools_info, user, id_token, charts_info)
         context["tools_info"] = tools_info
         return context


### PR DESCRIPTION
The purpose of this PR is to add the following: 
`?folder=/home/analyticalplatform/workspace` to the URL which is opened by the user in the Tools page. 

An example of this would be:
`https://jacobwoffenden-vscode.tools.analytical-platform.service.justice.gov.uk/?folder=/home/analyticalplatform/workspace`

This means the user is sent straight to their workspace, rather than having to navigate to the folder.