### PR TITLE
Update GitHub actions workflow to trigger build/deploy only when releases

### DIFF
--- a/.github/workflows/test-and-push-docker-image.yaml
+++ b/.github/workflows/test-and-push-docker-image.yaml
@@ -5,6 +5,7 @@ name: Run tests and push Docker image on success
     branches: [main]
   pull_request:
   release:
+    types: [published]
 
 jobs:
   test-and-push:
@@ -38,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registries: 593291632749
-          
+
       - name: Prep Tags
         id: prep
         run: |


### PR DESCRIPTION

<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR resolves a bug where the actions workflow is triggered 3 times when a new release is created


Merging this PR will have the following side-effects:
- There is potential that the change does not work, and the workflow does not trigger when the release is created. If this occurs, we can revert the commit

## :mag: What should the reviewer concentrate on?
- Actions file chang

## :technologist: How should the reviewer test these changes?
- Create a new release, check it triggers the build and test workflow

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
