### PR TITLE
Update justice auth flow to use client_secret and prompt login

### DIFF
--- a/controlpanel/frontend/views/auth.py
+++ b/controlpanel/frontend/views/auth.py
@@ -2,6 +2,7 @@
 
 # Third-party
 import sentry_sdk
+import structlog
 from authlib.integrations.django_client import OAuthError
 from django.conf import settings
 from django.contrib import messages
@@ -11,6 +12,8 @@ from django.views import View
 
 # First-party/Local
 from controlpanel.oidc import OIDCLoginRequiredMixin, oauth
+
+log = structlog.getLogger(__name__)
 
 
 class EntraIdAuthView(OIDCLoginRequiredMixin, View):
@@ -28,6 +31,7 @@ class EntraIdAuthView(OIDCLoginRequiredMixin, View):
             token = oauth.azure.authorize_access_token(self.request)
         except OAuthError as error:
             sentry_sdk.capture_exception(error)
+            log.error(error.description)
             token = None
         return token
 

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -220,13 +220,14 @@ AZURE_CODE_CHALLENGE_METHOD = os.environ.get("AZURE_CODE_CHALLENGE_METHOD", "S25
 AUTHLIB_OAUTH_CLIENTS = {
     "azure": {
         "client_id": os.environ.get("AZURE_CLIENT_ID"),
-        # TODO client_secret is not strictly required but would be better to use
+        "client_secret": os.environ.get("AZURE_CLIENT_SECRET"),
         "server_metadata_url": AZURE_OP_CONF_URL,
         "client_kwargs": {
             "scope": AZURE_RP_SCOPES,
             "response_type": "code",
-            "token_endpoint_auth_method": "none",
+            "token_endpoint_auth_method": "client_secret_post",
             "code_challenge_method": AZURE_CODE_CHALLENGE_METHOD,
+            "prompt": "login"
         },
 
     }


### PR DESCRIPTION
Use the client_secret created in Azure app registration, for better security. This is set as an env var, and will be read from a Kubernetes secret, which will be added manually elsewhere. Also update azure client settings to always prompt the user to complete the login process with their justice identity. This will avoid confusion if a user is already logged in to their Justice identity.

