### PR TITLE
Update homepage messaging about authenticating with justice identity

### DIFF
--- a/controlpanel/api/admin.py
+++ b/controlpanel/api/admin.py
@@ -34,13 +34,17 @@ class UserAdmin(admin.ModelAdmin):
         "username",
         "auth0_id",
         "email",
+        "justice_email",
         "is_superuser",
         "migration_state",
         "last_login",
     )
     actions = [make_migration_pending]
     exclude = ("password",)
-    list_filter = ("migration_state",)
+    list_filter = [
+        "migration_state",
+        ("justice_email", admin.EmptyFieldListFilter),
+    ]
     search_fields = (
         "username",
         "email",

--- a/controlpanel/frontend/jinja2/justice_email.html
+++ b/controlpanel/frontend/jinja2/justice_email.html
@@ -9,18 +9,22 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Authenticate with your Justice identity</h1>
-      <p class="govuk-body-l">As part of upcoming work to offer new tools and services, all Analytical Platform will need to authenticate with their Justice identity so that we can store your @justice.gov.uk email address.</p>
-      <p class="govuk-body">You will need to complete authentication by 30th April 2024. If you do not currently have a @justice.gov.uk email address, <a href="#" class="govuk-link">see our guidance on requesting one.</a></p>
+      <p class="govuk-body-l">We're planning some changes to how you log into the Analytical Platform. We are transitioning from using GitHub to Microsoft 365 (i.e. your @justice.gov.uk email address & password). </p>
+      <p class="govuk-body">For now all you need to do is click the button below to authenticate via Microsoft 365. This is a one-time operation which will link your current Analytical Platform account information to your @justice.gov.uk email address. This means you'll keep all your current permissions, and there's nothing extra you need to do.</p>
+      <p class="govuk-body">You will then continue to log in to the Control Panel via your GitHub account as usual. You can read further information about these changes in the <a href="https://mojdt.slack.com/archives/C4PF7QAJZ/p1712592546423129">#analytical-platform-support</a> Slack channel.</p>
+      <p class="govuk-body"></p>
       <div class="govuk-button-group">
         <form method="POST" action=".">
           {{ csrf_input }}
           <button type="submit" class="govuk-button" data-module="govuk-button">
             Authenticate with Justice identity
           </button>
-          <a class="govuk-button govuk-button--secondary" href="{{ url('list-tools') }}">
-            Skip for now
-          </a>
         </form>
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        <h3 class="govuk-heading-s">If you don't have a @justice.govuk account don't worry</h3>
+        <p class="govuk-body"><a href="https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=7404ac3137b723005f7cd1b543990e3e">You can request one here</a>. Please raise a request for an account as soon as you can. It can take a week or more to get fully set up with the correct access.</p>
+        <p class="govuk-body"><a class="govuk-link" href="{{ url('list-tools') }}">Click here to access the Control Panel while you wait for your account.</a>
+</p>
       </div>
     </div>
   </div>

--- a/controlpanel/frontend/jinja2/justice_email.html
+++ b/controlpanel/frontend/jinja2/justice_email.html
@@ -21,10 +21,11 @@
           </button>
         </form>
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-        <h3 class="govuk-heading-s">If you don't have a @justice.govuk account don't worry</h3>
+        <h3 class="govuk-heading-s">If you don't have a Microsoft 365 account</h3>
         <p class="govuk-body"><a href="https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=7404ac3137b723005f7cd1b543990e3e">You can request one here</a>. Please raise a request for an account as soon as you can. It can take a week or more to get fully set up with the correct access.</p>
-        <p class="govuk-body"><a class="govuk-link" href="{{ url('list-tools') }}">Click here to access the Control Panel while you wait for your account.</a>
-</p>
+        <p class="govuk-body"><a class="govuk-link" href="{{ url('list-tools') }}">Click here to access the Control Panel while you wait for your account.</a></p>
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        <p class="govuk-body">If you have any questions or need assistance, please reach out to us on <a href="https://moj.enterprise.slack.com/archives/C06TC4KKKUL">#analytical-platform-github-identity-migration</a> Slack channel.</p>
       </div>
     </div>
   </div>

--- a/controlpanel/frontend/jinja2/justice_email.html
+++ b/controlpanel/frontend/jinja2/justice_email.html
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Authenticate with your Justice identity</h1>
-      <p class="govuk-body-l">We're planning some changes to how you log into the Analytical Platform. We are transitioning from using GitHub to your Microsoft email (<code>@justice.gov.uk</code>, <code>@publicguardian.gov.uk</code>, etc).</p>
+      <p class="govuk-body-l">We're planning some changes to how you log into the Analytical Platform. We are transitioning from using GitHub to your Microsoft email (@justice.gov.uk, @publicguardian.gov.uk, etc).</p>
       <p class="govuk-body">For now all you need to do is click the button below to authenticate via Microsoft 365. This is a one-time operation which will link your current Analytical Platform account information to your Microsoft email address. This means you'll keep all your current permissions, and there's nothing extra you need to do.</p>
       <p class="govuk-body">You will continue to log in to the Control Panel via your GitHub account as usual for now. You can read further information about these changes in the <a href="https://mojdt.slack.com/archives/C4PF7QAJZ/p1712592546423129">#analytical-platform-support</a> Slack channel.</p>
       <p class="govuk-body"></p>

--- a/controlpanel/frontend/jinja2/justice_email.html
+++ b/controlpanel/frontend/jinja2/justice_email.html
@@ -9,9 +9,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Authenticate with your Justice identity</h1>
-      <p class="govuk-body-l">We're planning some changes to how you log into the Analytical Platform. We are transitioning from using GitHub to Microsoft 365 (i.e. your @justice.gov.uk email address & password). </p>
-      <p class="govuk-body">For now all you need to do is click the button below to authenticate via Microsoft 365. This is a one-time operation which will link your current Analytical Platform account information to your @justice.gov.uk email address. This means you'll keep all your current permissions, and there's nothing extra you need to do.</p>
-      <p class="govuk-body">You will then continue to log in to the Control Panel via your GitHub account as usual. You can read further information about these changes in the <a href="https://mojdt.slack.com/archives/C4PF7QAJZ/p1712592546423129">#analytical-platform-support</a> Slack channel.</p>
+      <p class="govuk-body-l">We're planning some changes to how you log into the Analytical Platform. We are transitioning from using GitHub to your Microsoft email (<code>@justice.gov.uk</code>, <code>@publicguardian.gov.uk</code>, etc).</p>
+      <p class="govuk-body">For now all you need to do is click the button below to authenticate via Microsoft 365. This is a one-time operation which will link your current Analytical Platform account information to your Microsoft email address. This means you'll keep all your current permissions, and there's nothing extra you need to do.</p>
+      <p class="govuk-body">You will continue to log in to the Control Panel via your GitHub account as usual for now. You can read further information about these changes in the <a href="https://mojdt.slack.com/archives/C4PF7QAJZ/p1712592546423129">#analytical-platform-support</a> Slack channel.</p>
       <p class="govuk-body"></p>
       <div class="govuk-button-group">
         <form method="POST" action=".">


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
Update the messaging to users about authenticating with their Justice identity. Screenshot of the page at time marked ready for review:

![image](https://github.com/ministryofjustice/analytics-platform-control-panel/assets/15347726/216d4d7c-af0e-4e94-9260-e727e5b4f79d)

Some of the text has been taken from our comms to users via slack https://mojdt.slack.com/archives/C4PF7QAJZ/p1712592546423129

Also updates the admin so that it is easy for us to track which users have completed the authentication, by filtering on the `justice_email` db field.

## :mag: What should the reviewer concentrate on?
-  Text changes

## :technologist: How should the reviewer test these changes?
- Log in to Control Panel, you will be prompted by the page 

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
