### PR TITLE
Initial implementation to enable Quicksight

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -579,6 +579,16 @@ class AWSRole(AWSService):
         policy.revoke_folder_access(root_folder_path=root_folder_path)
         policy.put()
 
+    def list_attached_policies(self, role_name):
+        try:
+            role = self.boto3_session.resource("iam").Role(role_name)
+            return list(role.attached_policies.all())
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchEntity":
+                log.warning(f"Role '{role_name}' doesn't exist")
+                return []
+            raise e
+
 
 class AWSFolder(AWSService):
     @staticmethod

--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -510,7 +510,13 @@ class AWSRole(AWSService):
                 raise e
 
         for policy in remove_policies or []:
-            role.detach_policy(PolicyArn=iam_arn(f"policy/{policy}"))
+            try:
+                role.detach_policy(PolicyArn=iam_arn(f"policy/{policy}"))
+            except botocore.exceptions.ClientError as e:
+                if e.response["Error"]["Code"] == "NoSuchEntity":
+                    log.warning(f"Policy {policy}: Not attached, skipping")
+                    continue
+                raise e
 
     def list_role_names(self, prefix="/"):
         roles = self.boto3_session.resource("iam").roles.filter(PathPrefix=prefix).all()

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -192,7 +192,7 @@ class User(EntityResource):
 
     READ_INLINE_POLICIES = f"{settings.ENV}-read-user-roles-inline-policies"
     BEDROCK_POLICY_NAME = "analytical-platform-bedrock-integration"
-    QUICKSIGHT_POLICY_NAME = "analytical-platform-quicksight-user"
+    QUICKSIGHT_POLICY_NAME = f"{settings.ENV}-quicksight-author-access"
 
     ATTACH_POLICIES = [
         READ_INLINE_POLICIES,

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -382,9 +382,6 @@ class User(EntityResource):
     def is_quicksight_enabled(self):
         return self.has_policy_attached(self.QUICKSIGHT_POLICY_NAME)
 
-    def set_quicksight_access(self, action):
-        return self.update_policy_attachment(policy=self.QUICKSIGHT_POLICY_NAME, action=action)
-
     def update_policy_attachment(self, policy, action):
         match action:
             case "attach":

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -372,12 +372,11 @@ class User(EntityResource):
         else:
             self.aws_role_service.remove_policy(self.iam_role_name, bedrock_policy)
 
-    def list_attached_policy_names(self):
-        policies = self.aws_role_service.list_attached_policies(self.iam_role_name)
-        return [policy.policy_name for policy in policies]
-
     def has_policy_attached(self, policy_name):
-        return policy_name in self.list_attached_policy_names()
+        for policy in self.aws_role_service.list_attached_policies(self.iam_role_name):
+            if policy_name == policy.policy_name:
+                return True
+        return False
 
     def update_policy_attachment(self, policy, action):
         match action:

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -371,13 +371,10 @@ class User(EntityResource):
                 return True
         return False
 
-    def update_policy_attachment(self, policy, action):
-        match action:
-            case "attach":
-                return self.aws_role_service.attach_policy(self.iam_role_name, [policy])
-            case "remove":
-                return self.aws_role_service.remove_policy(self.iam_role_name, [policy])
-        return "Invalid action"
+    def update_policy_attachment(self, policy, attach: bool):
+        if not attach:
+            return self.aws_role_service.remove_policy(self.iam_role_name, [policy])
+        return self.aws_role_service.attach_policy(self.iam_role_name, [policy])
 
 
 class App(EntityResource):

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -365,13 +365,6 @@ class User(EntityResource):
                 return False
         return True
 
-    def set_bedrock_access(self):
-        bedrock_policy = [self.BEDROCK_POLICY_NAME]
-        if self.user.is_bedrock_enabled:
-            self.aws_role_service.attach_policy(self.iam_role_name, bedrock_policy)
-        else:
-            self.aws_role_service.remove_policy(self.iam_role_name, bedrock_policy)
-
     def has_policy_attached(self, policy_name):
         for policy in self.aws_role_service.list_attached_policies(self.iam_role_name):
             if policy_name == policy.policy_name:

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -379,9 +379,6 @@ class User(EntityResource):
     def has_policy_attached(self, policy_name):
         return policy_name in self.list_attached_policy_names()
 
-    def is_quicksight_enabled(self):
-        return self.has_policy_attached(self.QUICKSIGHT_POLICY_NAME)
-
     def update_policy_attachment(self, policy, action):
         match action:
             case "attach":

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -133,6 +133,14 @@ class User(AbstractUser):
             != 0
         )
 
+    @property
+    def is_quicksight_enabled(self):
+        return cluster.User(self).is_quicksight_enabled()
+
+    def set_quicksight_access(self, enable):
+        action = "attach" if enable else "remove"
+        return cluster.User(self).set_quicksight_access(action=action)
+
     def reset_mfa(self):
         auth0.ExtendedAuth0().users.reset_mfa(self.auth0_id)
 

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -140,20 +140,18 @@ class User(AbstractUser):
         )
 
     def set_quicksight_access(self, enable):
-        action = "attach" if enable else "remove"
         return cluster.User(self).update_policy_attachment(
             policy=cluster.User.QUICKSIGHT_POLICY_NAME,
-            action=action,
+            attach=enable,
         )
 
     def reset_mfa(self):
         auth0.ExtendedAuth0().users.reset_mfa(self.auth0_id)
 
     def set_bedrock_access(self):
-        action = "attach" if self.is_bedrock_enabled else "remove"
         return cluster.User(self).update_policy_attachment(
             policy=cluster.User.BEDROCK_POLICY_NAME,
-            action=action,
+            attach=self.is_bedrock_enabled,
         )
 
     def save(self, *args, **kwargs):

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -139,7 +139,10 @@ class User(AbstractUser):
 
     def set_quicksight_access(self, enable):
         action = "attach" if enable else "remove"
-        return cluster.User(self).set_quicksight_access(action=action)
+        return cluster.User(self).update_policy_attachment(
+            policy=cluster.User.QUICKSIGHT_POLICY_NAME,
+            action=action,
+        )
 
     def reset_mfa(self):
         auth0.ExtendedAuth0().users.reset_mfa(self.auth0_id)

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -135,7 +135,9 @@ class User(AbstractUser):
 
     @property
     def is_quicksight_enabled(self):
-        return cluster.User(self).is_quicksight_enabled()
+        return cluster.User(self).has_policy_attached(
+            policy_name=cluster.User.QUICKSIGHT_POLICY_NAME
+        )
 
     def set_quicksight_access(self, enable):
         action = "attach" if enable else "remove"

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -150,7 +150,11 @@ class User(AbstractUser):
         auth0.ExtendedAuth0().users.reset_mfa(self.auth0_id)
 
     def set_bedrock_access(self):
-        cluster.User(self).set_bedrock_access()
+        action = "attach" if self.is_bedrock_enabled else "remove"
+        return cluster.User(self).update_policy_attachment(
+            policy=cluster.User.BEDROCK_POLICY_NAME,
+            action=action,
+        )
 
     def save(self, *args, **kwargs):
         existing = User.objects.filter(pk=self.pk).first()

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -97,6 +97,12 @@ class User(AbstractUser):
     def slug(self):
         return sanitize_dns_label(self.username)
 
+    @property
+    def is_quicksight_enabled(self):
+        return cluster.User(self).has_policy_attached(
+            policy_name=cluster.User.QUICKSIGHT_POLICY_NAME
+        )
+
     @cached_property
     def show_webapp_data_link(self):
         """
@@ -133,18 +139,6 @@ class User(AbstractUser):
             != 0
         )
 
-    @property
-    def is_quicksight_enabled(self):
-        return cluster.User(self).has_policy_attached(
-            policy_name=cluster.User.QUICKSIGHT_POLICY_NAME
-        )
-
-    def set_quicksight_access(self, enable):
-        return cluster.User(self).update_policy_attachment(
-            policy=cluster.User.QUICKSIGHT_POLICY_NAME,
-            attach=enable,
-        )
-
     def reset_mfa(self):
         auth0.ExtendedAuth0().users.reset_mfa(self.auth0_id)
 
@@ -152,6 +146,12 @@ class User(AbstractUser):
         return cluster.User(self).update_policy_attachment(
             policy=cluster.User.BEDROCK_POLICY_NAME,
             attach=self.is_bedrock_enabled,
+        )
+
+    def set_quicksight_access(self, enable):
+        return cluster.User(self).update_policy_attachment(
+            policy=cluster.User.QUICKSIGHT_POLICY_NAME,
+            attach=enable,
         )
 
     def save(self, *args, **kwargs):

--- a/controlpanel/frontend/jinja2/user-detail.html
+++ b/controlpanel/frontend/jinja2/user-detail.html
@@ -93,6 +93,36 @@
 </section>
 {% endif %}
 
+{% if request.user.has_perm('api.add_superuser') %}
+<section class="cpanel-section">
+  <form action="{{ url('set-quicksight', kwargs={ "pk": user.auth0_id }) }}" method="post">
+    {{ csrf_input }}
+    {{ govukCheckboxes({
+      "name": "is_quicksight_enabled",
+      "fieldset": {
+        "legend": {
+          "text": "Enable Quicksight",
+          "classes": "govuk-fieldset__legend--m",
+        },
+      },
+      "hint": {
+        "text": "Toggle access to Quicksight for a user."
+      },
+      "items": [
+        {
+          "value": "True",
+          "text": "Quicksight Enabled",
+          "checked": user.is_quicksight_enabled
+        },
+      ]
+    }) }}
+    <button class="govuk-button govuk-button--secondary">
+      Save changes
+    </button>
+  </form>
+</section>
+{% endif %}
+
 {% if request.user.has_perm('api.reset_mfa') %}
 <section class="cpanel-section">
   <form action="{{ url('reset-mfa', kwargs={ "pk": user.auth0_id }) }}" method="post">

--- a/controlpanel/frontend/jinja2/user-detail.html
+++ b/controlpanel/frontend/jinja2/user-detail.html
@@ -98,7 +98,7 @@
   <form action="{{ url('set-quicksight', kwargs={ "pk": user.auth0_id }) }}" method="post">
     {{ csrf_input }}
     {{ govukCheckboxes({
-      "name": "is_quicksight_enabled",
+      "name": "enable_quicksight",
       "fieldset": {
         "legend": {
           "text": "Enable Quicksight",

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -75,9 +75,7 @@ urlpatterns = [
     path("users/<str:pk>/", views.UserDetail.as_view(), name="manage-user"),
     path("users/<str:pk>/delete/", views.UserDelete.as_view(), name="delete-user"),
     path("users/<str:pk>/bedrock/", views.EnableBedrockUser.as_view(), name="set-bedrock"),
-    path(
-        "users/<str:pk>/quicksight/", views.EnableQuicksightAccess.as_view(), name="set-quicksight"
-    ),
+    path("users/<str:pk>/quicksight/", views.SetQuicksightAccess.as_view(), name="set-quicksight"),
     path("users/<str:pk>/edit/", views.SetSuperadmin.as_view(), name="set-superadmin"),
     path("users/<str:pk>/reset-mfa/", views.ResetMFA.as_view(), name="reset-mfa"),
     path("warehouse-data/", views.BucketList.as_view(), name="list-warehouse-datasources"),

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -75,6 +75,9 @@ urlpatterns = [
     path("users/<str:pk>/", views.UserDetail.as_view(), name="manage-user"),
     path("users/<str:pk>/delete/", views.UserDelete.as_view(), name="delete-user"),
     path("users/<str:pk>/bedrock/", views.EnableBedrockUser.as_view(), name="set-bedrock"),
+    path(
+        "users/<str:pk>/quicksight/", views.EnableQuicksightAccess.as_view(), name="set-quicksight"
+    ),
     path("users/<str:pk>/edit/", views.SetSuperadmin.as_view(), name="set-superadmin"),
     path("users/<str:pk>/reset-mfa/", views.ResetMFA.as_view(), name="reset-mfa"),
     path("warehouse-data/", views.BucketList.as_view(), name="list-warehouse-datasources"),

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -75,6 +75,7 @@ from controlpanel.frontend.views.task import TaskList
 from controlpanel.frontend.views.tool import RestartTool, ToolList
 from controlpanel.frontend.views.user import (
     EnableBedrockUser,
+    EnableQuicksightAccess,
     ResetMFA,
     SetSuperadmin,
     UserDelete,

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -75,8 +75,8 @@ from controlpanel.frontend.views.task import TaskList
 from controlpanel.frontend.views.tool import RestartTool, ToolList
 from controlpanel.frontend.views.user import (
     EnableBedrockUser,
-    EnableQuicksightAccess,
     ResetMFA,
+    SetQuicksightAccess,
     SetSuperadmin,
     UserDelete,
     UserDetail,

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -4,8 +4,11 @@ from datetime import datetime, timedelta
 # Third-party
 from django.contrib import messages
 from django.forms import BaseModelForm
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
+from django.views import View
+from django.views.generic import FormView
 from django.views.generic.base import RedirectView
 from django.views.generic.detail import DetailView, SingleObjectMixin
 from django.views.generic.edit import DeleteView, UpdateView
@@ -109,6 +112,16 @@ class EnableBedrockUser(OIDCLoginRequiredMixin, PermissionRequiredMixin, UpdateV
     def get_success_url(self):
         messages.success(self.request, "Successfully updated bedrock status")
         return reverse_lazy("manage-user", kwargs={"pk": self.object.auth0_id})
+
+
+class EnableQuicksightAccess(OIDCLoginRequiredMixin, PermissionRequiredMixin, View):
+    permission_required = "api.add_superuser"
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        user = get_object_or_404(User, pk=kwargs["pk"])
+        user.set_quicksight_access(enable=request.POST.get("is_quicksight_enabled", False))
+        return HttpResponseRedirect(reverse_lazy("manage-user", kwargs={"pk": user.auth0_id}))
 
 
 class ResetMFA(

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -120,7 +120,7 @@ class EnableQuicksightAccess(OIDCLoginRequiredMixin, PermissionRequiredMixin, Vi
 
     def post(self, request, *args, **kwargs):
         user = get_object_or_404(User, pk=kwargs["pk"])
-        user.set_quicksight_access(enable=request.POST.get("is_quicksight_enabled", False))
+        user.set_quicksight_access(enable="enable_quicksight" in request.POST)
         return HttpResponseRedirect(reverse_lazy("manage-user", kwargs={"pk": user.auth0_id}))
 
 

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -114,13 +114,14 @@ class EnableBedrockUser(OIDCLoginRequiredMixin, PermissionRequiredMixin, UpdateV
         return reverse_lazy("manage-user", kwargs={"pk": self.object.auth0_id})
 
 
-class EnableQuicksightAccess(OIDCLoginRequiredMixin, PermissionRequiredMixin, View):
+class SetQuicksightAccess(OIDCLoginRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "api.add_superuser"
     http_method_names = ["post"]
 
     def post(self, request, *args, **kwargs):
         user = get_object_or_404(User, pk=kwargs["pk"])
         user.set_quicksight_access(enable="enable_quicksight" in request.POST)
+        messages.success(self.request, "Successfully updated Quicksight access")
         return HttpResponseRedirect(reverse_lazy("manage-user", kwargs={"pk": user.auth0_id}))
 
 

--- a/tests/api/models/test_user.py
+++ b/tests/api/models/test_user.py
@@ -106,3 +106,15 @@ def test_bulk_migration_update(users):
     User.bulk_migration_update(usernames, new_state)
     user = User.objects.get(username="bob")
     assert user.migration_state == new_state
+
+
+@pytest.mark.parametrize("enable", [True, False], ids=["enable", "disable"])
+def test_set_quicksight_access(users, enable):
+
+    user = users["other_user"]
+    with patch.object(cluster.User, "update_policy_attachment") as mock_update_policy_attachment:
+        user.set_quicksight_access(enable=enable)
+        mock_update_policy_attachment.assert_called_once_with(
+            policy=cluster.User.QUICKSIGHT_POLICY_NAME,
+            attach=enable,
+        )

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -1121,3 +1121,16 @@ def test_revoke_access_doesnt_remove_prefixes(s3_access_policy):
         ]
         != []
     )  # noqa
+
+
+def test_list_attached_policies_returns_empty_list():
+    assert aws.AWSRole().list_attached_policies("no-role") == []
+
+
+def test_list_attached_policies_returns_list_of_policies(iam, roles, test_policy):
+    iam.Role("test_user_normal-user").attach_policy(PolicyArn=test_policy["Arn"])
+
+    policies = aws.AWSRole().list_attached_policies(role_name="test_user_normal-user")
+
+    assert len(policies) == 1
+    assert policies[0].arn == test_policy["Arn"]

--- a/tests/frontend/views/test_user.py
+++ b/tests/frontend/views/test_user.py
@@ -51,6 +51,11 @@ def set_bedrock(client, users, *args):
     return client.post(reverse("set-bedrock", kwargs=kwargs), data)
 
 
+def set_quicksight(client, users, *args):
+    kwargs = {"pk": users["other_user"].auth0_id}
+    return client.post(reverse("set-bedrock", kwargs=kwargs))
+
+
 @pytest.mark.parametrize(
     "view,user,expected_status",
     [
@@ -71,6 +76,9 @@ def set_bedrock(client, users, *args):
         (set_bedrock, "superuser", status.HTTP_302_FOUND),
         (set_bedrock, "normal_user", status.HTTP_403_FORBIDDEN),
         (set_bedrock, "other_user", status.HTTP_403_FORBIDDEN),
+        (set_quicksight, "superuser", status.HTTP_302_FOUND),
+        (set_quicksight, "normal_user", status.HTTP_403_FORBIDDEN),
+        (set_quicksight, "other_user", status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_permission(client, users, view, user, expected_status):

--- a/tests/frontend/views/test_user.py
+++ b/tests/frontend/views/test_user.py
@@ -112,15 +112,15 @@ def test_grant_superuser_access(client, users, slack):
 
 
 @pytest.mark.parametrize(
-    "data, action",
+    "data, attach",
     [
-        ({"enable_quicksight": True}, "attach"),
-        ({}, "remove"),
+        ({"enable_quicksight": True}, True),
+        ({}, False),
     ],
-    ids=["enable", "disable"],
+    ids=["attach", "remove"],
 )
 @patch("controlpanel.api.models.user.cluster.User.update_policy_attachment")
-def test_enable_quicksight_access(update_policy_attachment, data, action, client, users):
+def test_enable_quicksight_access(update_policy_attachment, data, attach, client, users):
     request_user = users["superuser"]
     user = users["other_user"]
     url = reverse("set-quicksight", kwargs={"pk": user.auth0_id})
@@ -131,5 +131,5 @@ def test_enable_quicksight_access(update_policy_attachment, data, action, client
     assert response.status_code == status.HTTP_302_FOUND
     update_policy_attachment.assert_called_once_with(
         policy=cluster.User.QUICKSIGHT_POLICY_NAME,
-        action=action,
+        attach=attach,
     )


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR contributes to https://github.com/ministryofjustice/analytical-platform/issues/4370

The IAM policy that is attached needs to be added in terraform, and the name updated in the cluster.py file before this can be deployed to production.

This PR allows a superuser to grant another user access to Quicksight as an author.
It also refactors how Bedrock access is granted.

The changes in this PR are needed because we are going to need to onboard some additional Quicksight users in the coming weeks.

Merging this PR will have the following side-effects:
- None - changes only affect superusers, who will have additional powers to grant other users Quicksight access

## :mag: What should the reviewer concentrate on?
- Additions to enable Quicksight
- Refactoring of Bedrock granting access

## :technologist: How should the reviewer test these changes?
- Run the project locally
- Login as a Superuser
- Go to the "Manage User" superuser page
- Grant access to Quicksight using the checkbox and submit button
- In AWS IAM, check that the quicksight policy has been attached
- In control panel, remove Quicksight access using the checkbox and submit button
- In AWS IAM, check that the quicksight policy has been removed

## :books: Documentation status
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
