### PR TITLE
Database access cleanup

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -334,11 +334,7 @@ class GrantAccessForm(forms.Form):
 
 class TableGrantAccessForm(forms.Form):
     access_level = forms.ChoiceField(
-        choices=[
-            ("readonly", "Read Only"),
-            ("readwrite", "Read/Write"),
-            ("admin", "Admin"),
-        ],
+        choices=[("readonly", "Read Only")],
         required=True,
     )
     entity_id = forms.CharField(max_length=128)
@@ -356,8 +352,6 @@ class TableGrantAccessForm(forms.Form):
 
         permissions = {
             "readonly": {"resource_link": ["DESCRIBE"], "table": ["SELECT"]},
-            "readwrite": {"resource_link": ["DESCRIBE"], "table": ["SELECT"]},
-            "admin": {"resource_link": ["DESCRIBE"], "table": ["SELECT"]},
         }
 
         cleaned_data = super().clean()

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -115,7 +115,7 @@
         "hide": not request.user.is_superuser and not request.user.is_database_admin,
         "text": "Databases",
         "href": url("list-databases"),
-        "active": page_name == "list-databases",
+        "active": page_name == "databases",
       },
       {
         "hide": not request.user.is_superuser,

--- a/controlpanel/frontend/jinja2/databases-list.html
+++ b/controlpanel/frontend/jinja2/databases-list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 
+{% set page_name = "databases" %}
 {% set page_title = "All Databases" %}
 
 {% block content %}

--- a/controlpanel/frontend/jinja2/includes/table-access-level-options.html
+++ b/controlpanel/frontend/jinja2/includes/table-access-level-options.html
@@ -1,0 +1,22 @@
+{% from "radios/macro.html" import govukRadios %}
+
+{% macro table_access_level_options() %}
+  {{ govukRadios({
+    "name": "access_level",
+    "fieldset": {
+      "legend": {
+        "text": "Data access level",
+        "classes": "govuk-fieldset__legend--m",
+      },
+    },
+    "hint": {
+      "html": "<strong>NOTE:</strong> Making a user an admin will allow them to confer access rights on additional users." if not hide_admin else "",
+    },
+    "items": [
+      {
+        "value": "readonly",
+        "text": "Read only (Select, Describe)",
+      }
+    ]
+  }) }}
+{% endmacro %}

--- a/controlpanel/frontend/jinja2/includes/table-access-level-options.html
+++ b/controlpanel/frontend/jinja2/includes/table-access-level-options.html
@@ -9,9 +9,6 @@
         "classes": "govuk-fieldset__legend--m",
       },
     },
-    "hint": {
-      "html": "<strong>NOTE:</strong> Making a user an admin will allow them to confer access rights on additional users." if not hide_admin else "",
-    },
     "items": [
       {
         "value": "readonly",

--- a/controlpanel/frontend/jinja2/table-access-grant.html
+++ b/controlpanel/frontend/jinja2/table-access-grant.html
@@ -1,6 +1,6 @@
 {% from "radios/macro.html" import govukRadios %}
 {% from "user/macro.html" import user_name %}
-{% from "includes/data-access-level-options.html" import data_access_level_options with context %}
+{% from "includes/table-access-level-options.html" import table_access_level_options with context %}
 {% from "includes/datasource-access-form.html" import data_access_paths_textarea %}
 
 {% extends "base.html" %}
@@ -24,7 +24,7 @@
     </div>
 
     <div class="govuk-form-group panel panel-border-narrow js-hidden" id="data-access-level-panel">
-      {{ data_access_level_options() }}
+      {{ table_access_level_options() }}
     </div>
 
     <div class="govuk-form-group">

--- a/controlpanel/frontend/jinja2/table-access-grant.html
+++ b/controlpanel/frontend/jinja2/table-access-grant.html
@@ -5,7 +5,7 @@
 
 {% extends "base.html" %}
 
-{% set page_title = "Grant user access to table" %}
+{% set page_title = "Grant user access to " + tablename %}
 
 {% block content %}
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>

--- a/controlpanel/frontend/jinja2/table-detail.html
+++ b/controlpanel/frontend/jinja2/table-detail.html
@@ -11,13 +11,11 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Name</th>
         <th scope="col" class="govuk-table__header">Registered in Lake Formation</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{ table.Name }}</td>
         <td class="govuk-table__cell">{{ "Yes" if table.IsRegisteredWithLakeFormation else "No" }}</td>
       </tr>
     </tbody>
@@ -52,6 +50,8 @@
         </tr>
         {% endfor %}
     </table>
+    {% else %}
+      <p class="govuk-body">No users have access to this table.</p>
     {% endif %}
 
 

--- a/controlpanel/frontend/jinja2/tables-list.html
+++ b/controlpanel/frontend/jinja2/tables-list.html
@@ -11,7 +11,7 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Name</th>
+        <th scope="col" class="govuk-table__header">Table Name</th>
         <th scope="col" class="govuk-table__header">Actions</th>
       </tr>
     </thead>


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR tidies up granting access to tables registered in Lake Formation. Makes some pages and headings more descriptive and reduces the number of options when granting access.

## :mag: What should the reviewer concentrate on?
- Quick check only (for e.g. version bump

## :technologist: How should the reviewer test these changes?
- Pull down changes and run control panel
- Check database flow and make sure it still works

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
