### PR TITLE
Update grant/revoke database access

### DIFF
--- a/controlpanel/frontend/jinja2/table-detail.html
+++ b/controlpanel/frontend/jinja2/table-detail.html
@@ -39,7 +39,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">{{ permission.user }}</td>
           <td class="govuk-table__cell align-right no-wrap">
-            <form action="{{ url("revoke-table-permissions", kwargs={ "dbname": dbname, "tablename": table.Name, "user": permission.user }) }}" method="post">
+            <form action="{{ url("revoke-table-permissions", kwargs={ "dbname": dbname, "tablename": tablename, "user": permission.user }) }}" method="post">
               {{ csrf_input }}
               <button class="govuk-button cpanel-button--destructive js-confirm"
                       data-confirm-message="Are you sure you want to revoke access for user?">
@@ -55,7 +55,7 @@
     {% endif %}
 
 
-    <a class="govuk-button" href="{{ url('grant-table-permissions', kwargs={ "dbname": dbname, "tablename": table.Name}) }}">
+    <a class="govuk-button" href="{{ url('grant-table-permissions', kwargs={ "dbname": dbname, "tablename": tablename}) }}">
       Grant User Permissions
     </a>
   {% endif %}

--- a/controlpanel/frontend/jinja2/table-detail.html
+++ b/controlpanel/frontend/jinja2/table-detail.html
@@ -16,12 +16,12 @@
     </thead>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{ "Yes" if table.IsRegisteredWithLakeFormation else "No" }}</td>
+        <td class="govuk-table__cell">{{ "Yes" if table.is_registered_with_lake_formation else "No" }}</td>
       </tr>
     </tbody>
   </table>
 
-  {% if table.IsRegisteredWithLakeFormation %}
+  {% if table.is_registered_with_lake_formation %}
     <h2 class="govuk-heading-l">User Access</h1>
 
     {% if permissions %}

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -223,17 +223,17 @@ urlpatterns = [
     path("databases/", views.DatabasesListView.as_view(), name="list-databases"),
     path("databases/<str:dbname>/", views.TablesListView.as_view(), name="list-tables"),
     path(
-        "databases/<slug:dbname>/<slug:tablename>/grant/",
+        "databases/<str:dbname>/<slug:tablename>/grant/",
         views.TableGrantView.as_view(),
         name="grant-table-permissions",
     ),
     path(
-        "databases/<slug:dbname>/<slug:tablename>/<str:user>/revoke/",
+        "databases/<str:dbname>/<str:tablename>/<str:user>/revoke/",
         views.RevokeTableAccessView.as_view(),
         name="revoke-table-permissions",
     ),
     path(
-        "databases/<slug:dbname>/<slug:tablename>/",
+        "databases/<str:dbname>/<str:tablename>/",
         views.ManageTable.as_view(),
         name="manage-table",
     ),

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -221,7 +221,7 @@ urlpatterns = [
     path("accessibility/", views.Accessibility.as_view(), name="accessibility"),
     path("tasks/", views.TaskList.as_view(), name="list-tasks"),
     path("databases/", views.DatabasesListView.as_view(), name="list-databases"),
-    path("databases/<slug:dbname>/", views.TablesListView.as_view(), name="list-tables"),
+    path("databases/<str:dbname>/", views.TablesListView.as_view(), name="list-tables"),
     path(
         "databases/<slug:dbname>/<slug:tablename>/grant/",
         views.TableGrantView.as_view(),

--- a/controlpanel/frontend/views/databases.py
+++ b/controlpanel/frontend/views/databases.py
@@ -5,7 +5,7 @@ import structlog
 from django.conf import settings
 from django.contrib import messages
 from django.http.response import HttpResponseRedirect
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse
 from django.views.generic import TemplateView, View
 from django.views.generic.base import ContextMixin
 from django.views.generic.edit import FormView
@@ -245,7 +245,7 @@ class RevokeTableAccessView(
             messages.error(self.request, f"Could not revoke access for user {kwargs['user']}")
 
         return HttpResponseRedirect(
-            reverse_lazy(
+            reverse(
                 "manage-table",
                 kwargs={"dbname": self.kwargs["dbname"], "tablename": self.kwargs["tablename"]},
             )

--- a/controlpanel/frontend/views/databases.py
+++ b/controlpanel/frontend/views/databases.py
@@ -30,9 +30,7 @@ class DatabasesListView(
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
-
-        context_data["databases"] = self._get_database_list()
-
+        context_data["databases"] = self._get_database_list(settings.DPR_DATABASE_NAME)
         return context_data
 
     def _get_database_list(self, database_name=None):

--- a/controlpanel/frontend/views/databases.py
+++ b/controlpanel/frontend/views/databases.py
@@ -86,11 +86,11 @@ class GetTableDataMixin(ContextMixin):
             table_data.update(
                 {
                     "database_name": database["TargetDatabase"]["DatabaseName"],
-                    "region": database["TargetDatabase"]["Region"],
+                    "region": database["TargetDatabase"].get("Region"),
                     "catalog_id": database["TargetDatabase"]["CatalogId"],
                 }
             )
-            glue = AWSGlue(region_name=database["TargetDatabase"]["Region"])
+            glue = AWSGlue(region_name=database["TargetDatabase"].get("Region"))
 
         table = glue.get_table(
             database_name=table_data["database_name"],
@@ -104,7 +104,7 @@ class GetTableDataMixin(ContextMixin):
                 {
                     "database_name": table["TargetTable"]["DatabaseName"],
                     "table_name": table["TargetTable"]["Name"],
-                    "region": table["TargetTable"]["Region"],
+                    "region": table["TargetTable"].get("Region"),
                     "catalog_id": table["TargetTable"]["CatalogId"],
                 }
             )

--- a/controlpanel/frontend/views/databases.py
+++ b/controlpanel/frontend/views/databases.py
@@ -104,7 +104,7 @@ class GetTableDataMixin(ContextMixin):
                 {
                     "database_name": table["TargetTable"]["DatabaseName"],
                     "table_name": table["TargetTable"]["Name"],
-                    "region": table["TargetTable"].get("Region"),
+                    "region": table["TargetTable"]["Region"],
                     "catalog_id": table["TargetTable"]["CatalogId"],
                 }
             )
@@ -199,8 +199,7 @@ class TableGrantView(
 
         table_data = self.get_table_data()
 
-        # only grants access on the shared table, not the resource link. As it is assumed that
-        # all users will have DESCRIBE access to the resource link
+        # only grants access on the shared table, not the resource link
         try:
             lake_formation = AWSLakeFormation(region_name=table_data["region"])
             lake_formation.grant_table_permission(

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -586,8 +586,6 @@ for queue in PRE_DEFINED_QUEUES:
     }
 
 CELERY_IMPORTS = ["controlpanel.api.tasks.handlers"]
-DPR_DATABASE_NAME = os.environ.get("DPR_DATABASE_NAME")
-DPR_ACCOUNT_ID = os.environ.get("DPR_ACCOUNT_ID")
-DPR_ACCOUNT_REGION = os.environ.get("DPR_ACCOUNT_REGION")
+DPR_DATABASE_NAME = os.environ.get("DPR_DATABASE_NAME", None)
 
 S3_ARCHIVE_BUCKET_NAME = "dev-archive-folder"

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -587,5 +587,7 @@ for queue in PRE_DEFINED_QUEUES:
 
 CELERY_IMPORTS = ["controlpanel.api.tasks.handlers"]
 DPR_DATABASE_NAME = os.environ.get("DPR_DATABASE_NAME")
+DPR_ACCOUNT_ID = os.environ.get("DPR_ACCOUNT_ID")
+DPR_ACCOUNT_REGION = os.environ.get("DPR_ACCOUNT_REGION")
 
 S3_ARCHIVE_BUCKET_NAME = "dev-archive-folder"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Jinja2==3.1.4
 kubernetes==25.3.0
 MarkupSafe==2.1.5
 model-bakery==1.17.0
-moto[all]==5.0.9
+moto[all]==5.0.11
 mozilla-django-oidc==4.0.1
 psycopg2-binary==2.9.9
 PyNaCl==1.5.0

--- a/tests/api/fixtures/aws.py
+++ b/tests/api/fixtures/aws.py
@@ -54,6 +54,7 @@ def glue(aws_creds):
                     "CatalogId": "123",
                     "DatabaseName": "external_db",
                     "Name": "external_test_table",
+                    "Region": "eu-west-2",
                 },
             },
         )

--- a/tests/frontend/views/test_databases.py
+++ b/tests/frontend/views/test_databases.py
@@ -1,7 +1,3 @@
-# Standard library
-import json
-from unittest.mock import patch
-
 # Third-party
 import pytest
 from django.conf import settings


### PR DESCRIPTION
Updates granting/revoking of database tables

## :memo: Summary
This PR relates to https://github.com/ministryofjustice/analytical-platform/issues/4367

After initial testing, it became apparent that when granting permissions on shared tables, the boto calls need to occur on the source table/database. This PR updates the views to get details of the database/tables, and if they point to a 'target', use those details when managing permissions. Part of this means checking what region the shared tables live, and if this is different to the default AWS region, make sure to reinitialise the `glue` client for the correct region.

Also from initial testing we have learned that (in the data-prod account) the resource link that will be used to reference the shared tables will be visible to users via the "standard-database-access" permissions. Therefore there is no need to grant "DESCRIBE" access to the resource link. This reduces the number of boto3 permission updates required, so granting/revoking access now only occurs on the source table.

## :mag: What should the reviewer concentrate on?
- Most of the logic has been added to a mixin that is shared between the views that need to lookup tables
- Check general refactoring to make sure that nothing has been missed.
- Further unit tests should be added when possible, but for now I have updated only the existing tests

## :technologist: How should the reviewer test these changes?
- When running locally, run against the dev account
- To mimic having standard database access, you will need to copy the permissions from the `standard-database-access` policy in data prod, and assign them to your `dev_user_` role in the dev account
- In `analytical-platform-development` I have setup a database and tables to mimic "shared" tables. These live in eu-west-2 (the same region that DPR data will be shared to). The database is called `michael_dpr_testing` and has 3 tables to test with.
- I have then created a resource link to the database in `eu-west-1`. This is called `michael_dpr_testing_resource_link`. Use this as your env var `DPR_DATABASE_NAME`
- If you then run the server and visit http://localhost:8000/databases/ you should see this database, its tables, and test granting access
- NOTE: You should not be able to grant access to the the table `dpr_test_2` as I have purposely not registered within Lake Formation. I did this by assigning the IAMAllowedAllPrinciples` permission to it, so in Athena you will be able to see the table but not query it
- After granting some permissions to your user, log in to AWS athena as your dev user, (via the link on the My Tools page) and try to query the tables

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
