### PR TITLE
Fix/database opt in

### DIFF
--- a/tests/frontend/views/test_databases.py
+++ b/tests/frontend/views/test_databases.py
@@ -14,8 +14,16 @@ orig = botocore.client.BaseClient._make_api_call
 
 # Mocked botocore _make_api_call function
 def mock_make_api_call(self, operation_name, kwarg):
-    if operation_name == "CreateLakeFormationOptIn":
-        return {}
+    op_names = [
+        {"CreateLakeFormationOptIn": {}},
+        {"DeleteLakeFormationOptIn": {}},
+        {"ListLakeFormationOptIns": {"LakeFormationOptInsInfoList": []}},
+    ]
+
+    for operation in op_names:
+        if operation_name in operation:
+            return operation[operation_name]
+
     # If we don't want to patch the API call
     return orig(self, operation_name, kwarg)
 


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR fixes an issue that could be caused by trying to opt in the database more than once on a single user.


## :mag: What should the reviewer concentrate on?
- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Pull down branch
- set DPR_DATABASE_NAME to jstott_aug_hybrid_db_rl in .env
- Grant permissions on both databases
- Check hybrid access mode in LakeFormation console under permissions
- Revoke access to one database and check that database is still there in hybrid access mode
- Revoke access to the other database and check there are no opt ins in hybrid access mode
- Check you can query what you have access to in athena

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
