### PR TITLE
Bugfix/grant app s3 access

### DIFF
--- a/controlpanel/api/tasks/handlers/base.py
+++ b/controlpanel/api/tasks/handlers/base.py
@@ -51,7 +51,7 @@ class BaseModelTaskHandler(BaseTaskHandler):
             # added back to the queue as could be due to a race condition
             raise exc
 
-    def run(self, obj_pk, task_user_pk, *args, **kwargs):
+    def run(self, obj_pk, task_user_pk=None, *args, **kwargs):
         """
         Default method that a celery Task object requires to be defined, and will be
         called by the worker when a message is received by the queue. This will look up

--- a/controlpanel/api/validators.py
+++ b/controlpanel/api/validators.py
@@ -48,7 +48,7 @@ class ValidatorS3Bucket(object):
 # An S3 bucket name starts with a label, it can have more than one label
 # separated by a dot.
 validate_s3_bucket_labels = RegexValidator(
-    regex="^([a-z][a-z0-9-]*[a-z0-9])(.[a-z][a-z0-9-]*[a-z0-9])*$",
+    regex="^([a-z][a-z0-9-]*[a-z0-9])(\\.[a-z][a-z0-9-]*[a-z0-9])*\\Z",
     message="is invalid, check AWS S3 bucket names restrictions (for example, "
     "can only contains letters, digits, dots and hyphens)",
 )

--- a/controlpanel/frontend/views/apps_mng.py
+++ b/controlpanel/frontend/views/apps_mng.py
@@ -100,6 +100,7 @@ class AppManager:
                 app=app,
                 s3bucket=bucket_data["existing_datasource_id"],
                 access_level="readonly",
+                current_user=user,
             )
 
     def _add_app_to_users(self, app, user):

--- a/tests/api/test_validators.py
+++ b/tests/api/test_validators.py
@@ -116,3 +116,11 @@ def test_validate_github_repository_url(url, error):
 def test_invalid_s3_bucket_names(name, error):
     with pytest.raises(error):
         validators.validate_s3_bucket_labels(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["example-bucket", "examplebucket", "example.bucket"],
+)
+def test_valid_s3_bucket_names(name):
+    assert validators.validate_s3_bucket_labels(name) is None

--- a/tests/api/test_validators.py
+++ b/tests/api/test_validators.py
@@ -102,3 +102,17 @@ def test_validate_github_repository_url(url, error):
         with pytest.raises(ValidationError) as exc:
             validators.validate_github_repository_url(url)
             assert exc.value.args[0] == error
+
+
+@pytest.mark.parametrize(
+    "name, error",
+    [
+        ("example_bucket", ValidationError),
+        ("ExampleBucket", ValidationError),
+        ("example-bucket-", ValidationError),
+    ],
+    ids=["underscore", "capitalised", "ending_hyphen"],
+)
+def test_invalid_s3_bucket_names(name, error):
+    with pytest.raises(error):
+        validators.validate_s3_bucket_labels(name)


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR relates to https://github.com/ministryofjustice/analytical-platform/issues/5511

The bugs are described in the above ticket.

To resolve the S3 bucket name bug, I have fixed the regex that was used to ensure that it matches against the entire string.

To resolve the S3 app access bug, I have made sure that when an existing S3 bucket is linked to an app, that the current user arg is passed to the related task as expected.

## :mag: What should the reviewer concentrate on?
- Bug fixes

## :technologist: How should the reviewer test these changes?
- Follow steps in the bug ticket linked above
- Unit tests will run successfully

## :books: Documentation status
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
