### PR TITLE
Remove conditional to build "edge" tag

### DIFF
--- a/.github/workflows/test-and-push-docker-image.yaml
+++ b/.github/workflows/test-and-push-docker-image.yaml
@@ -48,11 +48,6 @@ jobs:
           TAG=noop
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             TAG=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            TAG=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$TAG" ]; then
-              TAG=edge
-            fi
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
             TAG="sha-${GITHUB_SHA::8}"
           elif [ "${{ github.event_name }}" = "push" ]; then


### PR DESCRIPTION
Removing the building of an image to use the "edge" tag - for the same reasons outlined in https://github.com/ministryofjustice/analytics-platform-control-panel/pull/1348