### PR TITLE
Check for a 404 error when creating a bucket

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -782,9 +782,11 @@ class AWSBucket(AWSService):
         try:
             s3_client = self.boto3_session.client("s3")
             s3_client.head_bucket(Bucket=bucket_name)
-            return True
-        except botocore.exceptions.ClientError:
-            return False
+        except botocore.exceptions.ClientError as error:
+            if error.response["Error"]["Code"] == "404":
+                return False
+
+        return True
 
 
 class AWSPolicy(AWSService):


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary

This PR resolves [TODO add bug ticket now](https://github.com/ministryofjustice/analytical-platform/issues/5852)

If a 404 is returned, the bucket name is available and can be used. If another error is returned, it may mean that the bucket name is already in use, but we do not have access to it. In this case, we should not attempt to create a bucket with this name. See the note on: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/head_bucket.html

<!-- Adding the issue number above will automatically link the PR to the github issue,
and will close the issue on merging. Note this will only happen if the correct keyword
is used, such resolves/closes/fixes. See full list of keywords at
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
If the issue belongs to the current repo, add the number prefixed with e.g #1234.
If the issue belongs to another repo, add with Organization_name/Repository#... e.g.
ministryofjustice/data-platform#1234 -->

## :mag: What should the reviewer concentrate on?
- Error handling

## :technologist: How should the reviewer test these changes?
- See bug ticket

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
