### PR TITLE
removed rogue env var

### DIFF
--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -247,7 +247,7 @@ ADMINS = []
 MANAGERS = []
 
 # Whitelist values for the HTTP Host header, to prevent certain attacks
-ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split() if host]
+ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split() if host] + ["cpanel.cpanel"]
 
 
 # set this before adding the IP address below

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -247,7 +247,9 @@ ADMINS = []
 MANAGERS = []
 
 # Whitelist values for the HTTP Host header, to prevent certain attacks
-ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split() if host] + ["cpanel.cpanel"]
+ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split() if host] + [
+    "cpanel.cpanel"
+]
 
 
 # set this before adding the IP address below

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -502,7 +502,6 @@ ELASTICSEARCH = {
 AWS_DATA_ACCOUNT_ID = os.environ.get("AWS_DATA_ACCOUNT_ID")
 QUICKSIGHT_ACCOUNT_ID = os.environ.get("QUICKSIGHT_ACCOUNT_ID")
 QUICKSIGHT_ACCOUNT_REGION = os.environ.get("QUICKSIGHT_ACCOUNT_REGION")
-QUICKSIGHT_DOMAINS = os.environ.get("QUICKSIGHT_DOMAINS")
 QUICKSIGHT_ASSUMED_ROLE = os.environ.get("QUICKSIGHT_ASSUMED_ROLE")
 
 # The EKS OIDC provider, referenced in user policies to allow service accounts


### PR DESCRIPTION
Removes env var that was causing QUICKSIGHT_DOMAINS to be overridden
