### PR TITLE
:wrench: Add `GetObjectTagging` to `READ_ACTIONS` 

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -37,6 +37,7 @@ def iam_arn(resource, account=settings.AWS_DATA_ACCOUNT_ID):
 
 READ_ACTIONS = [
     "s3:GetObject",
+    "s3:GetObjectTagging",
     "s3:GetObjectAcl",
     "s3:GetObjectVersion",
     "s3:GetObjectVersionAcl",


### PR DESCRIPTION
Updating in relation to [this](https://github.com/ministryofjustice/data-platform-support/issues/904) Issue but this has occurred on numerous occasions in the last year.

Further work to be done to test/apply to all users.