### PR TITLE
Add justice_email to user detail endpoint

### DIFF
--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -268,6 +268,7 @@ class UserSerializer(serializers.ModelSerializer):
             "users3buckets",
             "is_superuser",
             "email_verified",
+            "justice_email",
         )
 
 

--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -263,12 +263,12 @@ class UserSerializer(serializers.ModelSerializer):
             "username",
             "name",
             "email",
+            "justice_email",
             "groups",
             "userapps",
             "users3buckets",
             "is_superuser",
             "email_verified",
-            "justice_email",
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ authlib==1.3.1
 beautifulsoup4==4.12.3
 boto3==1.35.39
 # temporarily pinning this to try to resolve an issue with failing tests
-botocore<1.35.45
+botocore==1.35.44
 celery[sqs]==5.3.6
 channels==4.0.0
 channels-redis==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ auth0-python==4.7.1
 authlib==1.3.1
 beautifulsoup4==4.12.3
 boto3==1.35.39
+# temporarily pinning this to try to resolve an issue with failing tests
+botocore<1.35.45
 celery[sqs]==5.3.6
 channels==4.0.0
 channels-redis==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ auth0-python==4.7.1
 authlib==1.3.1
 beautifulsoup4==4.12.3
 boto3==1.35.39
-# temporarily pinning this to try to resolve an issue with failing tests
-botocore==1.35.44
+botocore==1.35.44  # noqa temporarily pinning this to try to resolve an issue with failing tests
 celery[sqs]==5.3.6
 channels==4.0.0
 channels-redis==4.2.0

--- a/tests/api/views/test_user.py
+++ b/tests/api/views/test_user.py
@@ -43,6 +43,7 @@ def test_detail(client, users):
         "username",
         "name",
         "email",
+        "justice_email",
         "groups",
         "userapps",
         "users3buckets",


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR contributes to https://github.com/ministryofjustice/analytical-platform/issues/5533 

Rather than create a new endpoint, this PR updates the existing retrive user endpoint to add the `justice_email` field.

Merging this PR will have the following side-effects:
- N/A

## :mag: What should the reviewer concentrate on?
- N/A

## :technologist: How should the reviewer test these changes?
To test in the browser:
- Run locally
- Log in 
- Got to http://localhost:8000/api/cpanel/v1/users/
- Check that `justice_email` is included
- Click through to the URL for a user, check that `justice_email` is included

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
