### PR TITLE
Added button on user page that will re-initialise a users kubernetes namespace

### DIFF
--- a/controlpanel/api/slack.py
+++ b/controlpanel/api/slack.py
@@ -9,7 +9,7 @@ def notify_superuser_created(username, by_username=None):
     message = CREATE_SUPERUSER_MESSAGE.format(username=username)
     if by_username:
         message = f"{message} by `{by_username}`"
-    send_notification(message)
+    # send_notification(message)
 
 
 def send_notification(message):

--- a/controlpanel/api/slack.py
+++ b/controlpanel/api/slack.py
@@ -9,7 +9,7 @@ def notify_superuser_created(username, by_username=None):
     message = CREATE_SUPERUSER_MESSAGE.format(username=username)
     if by_username:
         message = f"{message} by `{by_username}`"
-    # send_notification(message)
+    send_notification(message)
 
 
 def send_notification(message):

--- a/controlpanel/frontend/jinja2/user-detail.html
+++ b/controlpanel/frontend/jinja2/user-detail.html
@@ -13,6 +13,14 @@
 <span class="govuk-caption-xl">User</span>
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
+<h2 class="govuk-heading-m">
+  Date Registered
+</h2>
+
+<p class="govuk-body">
+  {{ user.date_joined.strftime('%d-%m-%Y') }}
+</p>
+
 {% if unused %}
 <div class="govuk-grid-row">
   <div class="govuk-column-two-thirds">
@@ -53,7 +61,7 @@
           "value": "True",
           "text": "Super Admin",
           "checked": user.is_superuser
-        },
+        }
       ]
     }) }}
     <button class="govuk-button govuk-button--secondary">

--- a/controlpanel/frontend/jinja2/user-detail.html
+++ b/controlpanel/frontend/jinja2/user-detail.html
@@ -153,23 +153,21 @@
 </section>
 {% endif %}
 
-{% if request.user.has_perm('api.reset_mfa') %}
+{% if request.user.has_perm('api.add_superuser') %}
 <section class="cpanel-section">
-  <form action="{{ url('reset-mfa', kwargs={ "pk": user.auth0_id }) }}" method="post">
+  <h2 class="govuk-heading-m">
+    Reinitialise User's Namespace
+  </h2>
+
+  <p class="govuk-hint">
+    Re-initialises a user's kubernetes namespace if they have been pruned but still exist in control panel. This will fail if the user's namespace already exists.
+  </p>
+
+  <form action="{{ url('reinit-user', kwargs={ "pk": user.auth0_id }) }}" method="post">
     {{ csrf_input }}
-    {% call govukFieldset({
-      "legend": {
-        "text": "Reset MFA",
-        "classes": "govuk-fieldset__legend--m",
-      },
-      "describedBy": "reset-hint"
-    }) %}
-      <span id="reset-hint" class="govuk-hint">
-        Reset the user's multi-factor authentication settings, forcing them to
-        reconfigure.
-      </span>
-      <button class="govuk-button govuk-button--secondary">Reset MFA</button>
-    {%- endcall %}
+    <button class="govuk-button govuk-button--secondary js-confirm" data-confirm-message="Are you sure you want to reinitialise this user?">
+      Reinitialise User
+    </button>
   </form>
 </section>
 {% endif %}

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -76,6 +76,7 @@ urlpatterns = [
     path("users/<str:pk>/delete/", views.UserDelete.as_view(), name="delete-user"),
     path("users/<str:pk>/bedrock/", views.EnableBedrockUser.as_view(), name="set-bedrock-user"),
     path("users/<str:pk>/quicksight/", views.SetQuicksightAccess.as_view(), name="set-quicksight"),
+    path("users/<str:pk>/reinituser/", views.ReinitialiseUser.as_view(), name="reinit-user"),
     path(
         "users/<str:pk>/database-admin/",
         views.EnableDatabaseAdmin.as_view(),

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -93,6 +93,7 @@ from controlpanel.frontend.views.tool import RestartTool, ToolList
 from controlpanel.frontend.views.user import (
     EnableBedrockUser,
     EnableDatabaseAdmin,
+    ReinitialiseUser,
     ResetMFA,
     SetQuicksightAccess,
     SetSuperadmin,

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -90,15 +90,18 @@ class UserDetail(OIDCLoginRequiredMixin, PermissionRequiredMixin, DetailView):
         return context
 
 
-class SetSuperadmin(OIDCLoginRequiredMixin, PermissionRequiredMixin, UpdateView):
-    fields = ["is_superuser"]
-    http_method_names = ["post"]
-    model = User
+class SetSuperadmin(OIDCLoginRequiredMixin, PermissionRequiredMixin, View):
     permission_required = "api.add_superuser"
+    http_method_names = ["post"]
 
-    def get_success_url(self):
-        messages.success(self.request, "Successfully updated superadmin status")
-        return reverse_lazy("manage-user", kwargs={"pk": self.object.auth0_id})
+    def post(self, request, *args, **kwargs):
+        user = get_object_or_404(User, pk=kwargs["pk"])
+        is_superuser = "is_superuser" in request.POST
+        user.is_superuser = is_superuser
+        user.is_staff = is_superuser
+        user.save()
+        messages.success(self.request, "Successfully updated super admin status")
+        return HttpResponseRedirect(reverse_lazy("manage-user", kwargs={"pk": user.auth0_id}))
 
 
 class EnableBedrockUser(PolicyAccessMixin, UpdateView):

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -128,7 +128,7 @@ class ReinitialiseUser(OIDCLoginRequiredMixin, PermissionRequiredMixin, View):
         cluster_user = ClusterUser(user)
 
         try:
-            cluster_user._init_user()
+            cluster_user.create()
             messages.success(self.request, "Reinitialised user successfully")
             return HttpResponseRedirect(reverse_lazy("manage-user", kwargs={"pk": user.auth0_id}))
         except Exception:

--- a/controlpanel/frontend/views/user.py
+++ b/controlpanel/frontend/views/user.py
@@ -132,7 +132,7 @@ class ReinitialiseUser(OIDCLoginRequiredMixin, PermissionRequiredMixin, View):
             messages.success(self.request, "Reinitialised user successfully")
             return HttpResponseRedirect(reverse_lazy("manage-user", kwargs={"pk": user.auth0_id}))
         except Exception:
-            messages.error(self.request, f"Failed to reinitialise user")
+            messages.error(self.request, "Failed to reinitialise user")
             return HttpResponseRedirect(reverse_lazy("manage-user", kwargs={"pk": user.auth0_id}))
 
 

--- a/tests/frontend/views/test_user.py
+++ b/tests/frontend/views/test_user.py
@@ -56,6 +56,11 @@ def set_quicksight(client, users, *args):
     return client.post(reverse("set-quicksight", kwargs=kwargs))
 
 
+def reinitialise_user(client, users, *args):
+    kwargs = {"pk": users["other_user"].auth0_id}
+    return client.post(reverse("reinit-user", kwargs=kwargs))
+
+
 def set_database_admin(client, users, *args):
     data = {
         "is_database_admin": True,
@@ -90,6 +95,9 @@ def set_database_admin(client, users, *args):
         (set_database_admin, "superuser", status.HTTP_302_FOUND),
         (set_database_admin, "normal_user", status.HTTP_403_FORBIDDEN),
         (set_database_admin, "other_user", status.HTTP_403_FORBIDDEN),
+        (reinitialise_user, "superuser", status.HTTP_302_FOUND),
+        (reinitialise_user, "normal_user", status.HTTP_403_FORBIDDEN),
+        (reinitialise_user, "other_user", status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_permission(client, users, view, user, expected_status):


### PR DESCRIPTION
This PR gives a superuser the ability to re-initialise a user's kubernetes namespace. This is as a result of [this](https://github.com/ministryofjustice/data-platform-support/issues/913) support issue.

## :mag: What should the reviewer concentrate on?
- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Pull down this branch
- Delete your own namespace in the development cluster by running `aws-vault exec admin-dev-sso -- kubectl delete namespace <yournamespace>`
- Navigate to your user from the home page
- click the re-initialise user button
- If successful, check your namespace has been rebuilt by running `aws-vault exec admin-dev-sso -- kubectl get namespace <yournamespace>`

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
