### PR TITLE
Releases page improvements

### DIFF
--- a/controlpanel/frontend/filters.py
+++ b/controlpanel/frontend/filters.py
@@ -1,0 +1,27 @@
+# Third-party
+import django_filters
+
+# First-party/Local
+from controlpanel.api.models.tool import Tool
+
+
+class ReleaseFilter(django_filters.FilterSet):
+    chart_name = django_filters.ChoiceFilter()
+    is_restricted = django_filters.BooleanFilter(label="Restricted release?")
+
+    class Meta:
+        model = Tool
+        fields = ["chart_name", "is_restricted"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filters["chart_name"].extra["choices"] = Tool.objects.values_list(
+            "chart_name", "chart_name"
+        ).distinct()
+        self.filters["chart_name"].field.widget.attrs = {"class": "govuk-select"}
+        self.filters["is_restricted"].field.widget.choices = [
+            ("all", "All"),
+            ("true", "Yes"),
+            ("false", "No"),
+        ]
+        self.filters["is_restricted"].field.widget.attrs = {"class": "govuk-select"}

--- a/controlpanel/frontend/filters.py
+++ b/controlpanel/frontend/filters.py
@@ -20,7 +20,7 @@ class ReleaseFilter(django_filters.FilterSet):
         ).distinct()
         self.filters["chart_name"].field.widget.attrs = {"class": "govuk-select"}
         self.filters["is_restricted"].field.widget.choices = [
-            ("all", "All"),
+            ("all", "---------"),
             ("true", "Yes"),
             ("false", "No"),
         ]

--- a/controlpanel/frontend/jinja2/release-list.html
+++ b/controlpanel/frontend/jinja2/release-list.html
@@ -24,7 +24,6 @@
           <label class="govuk-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
           {{ field }}
         </p>
-
       {% endfor %}
 
       <button class="govuk-button" type="submit">Apply filters</button>
@@ -48,7 +47,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-  {% for release in filter.qs %}
+  {% for release in releases %}
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
         <a href="{{ url('manage-tool-release', kwargs={ "pk": release.pk }) }}">

--- a/controlpanel/frontend/jinja2/release-list.html
+++ b/controlpanel/frontend/jinja2/release-list.html
@@ -11,29 +11,35 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Name</th>
-      <th class="govuk-table__header">Chart</th>
-      <th class="govuk-table__header">Version</th>
+      <th class="govuk-table__header">Chart Version</th>
+      <th class="govuk-table__header">Image tag</th>
       <th class="govuk-table__header">Description</th>
-      <th class="govuk-table__header">Is Restricted Release?</th>
+      <th class="govuk-table__header">Created</th>
+      <th class="govuk-table__header">Restricted Release?</th>
       <th class="govuk-table__header">
         <span class="govuk-visually-hidden">Actions</span>
       </th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-  {% for release in releases%}
+  {% for release in releases %}
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
         <a href="{{ url('manage-tool-release', kwargs={ "pk": release.pk }) }}">
           {{ release.name }}<br/>
         </a>
       </td>
-      <td class="govuk-table__cell">{{ release.chart_name}}</td>
       <td class="govuk-table__cell">
         {{ release.version }}
       </td>
       <td class="govuk-table__cell">
+        {{ release.image_tag }}
+      </td>
+      <td class="govuk-table__cell">
         {{ release.description }}
+      </td>
+      <td class="govuk-table__cell no-wrap">
+        {{ release.created.strftime('%d-%m-%Y') }}
       </td>
       <td class="govuk-table__cell">
         {{ release.is_restricted }}
@@ -41,7 +47,7 @@
       <td class="govuk-table__cell">
         <a href="{{ url('manage-tool-release', kwargs={ "pk": release.pk }) }}"
            class="govuk-button govuk-button--secondary">
-          Manage Release 
+          Manage Release
         </a>
       </td>
     </tr>

--- a/controlpanel/frontend/jinja2/release-list.html
+++ b/controlpanel/frontend/jinja2/release-list.html
@@ -19,15 +19,20 @@
   <div class="moj-filter__options">
 
     <form method="get">
-      {% for field in filter.form %}
-        <p>
-          <label class="govuk-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-          {{ field }}
-        </p>
-      {% endfor %}
+      <p class="govuk-body">
+        {% for field in filter.form %}
+          <span class="govuk-!-padding-right-6">
+            {{ field.label_tag() }}
+            {{ field }}
+          </span>
+        {% endfor %}
+      </p>
 
-      <button class="govuk-button" type="submit">Apply filters</button>
-      <a class="govuk-button govuk-button--secondary" href="{{ url('list-tool-releases') }}">Clear</a>
+
+      <div class="govuk-button-group">
+        <button class="govuk-button" type="submit">Apply filters</button>
+        <a class="govuk-button govuk-button--secondary" href="{{ url('list-tool-releases') }}">Clear</a>
+      </div>
     </form>
   </div>
 </div>

--- a/controlpanel/frontend/jinja2/release-list.html
+++ b/controlpanel/frontend/jinja2/release-list.html
@@ -7,6 +7,32 @@
 {% block content %}
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
+<div class="moj-filter">
+  <div class="moj-filter__header">
+
+    <div class="moj-filter__header-title">
+      <h2 class="govuk-heading-m">Filter</h2>
+    </div>
+
+  </div>
+
+  <div class="moj-filter__options">
+
+    <form method="get">
+      {% for field in filter.form %}
+        <p>
+          <label class="govuk-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {{ field }}
+        </p>
+
+      {% endfor %}
+
+      <button class="govuk-button" type="submit">Apply filters</button>
+      <a class="govuk-button govuk-button--secondary" href="{{ url('list-tool-releases') }}">Clear</a>
+    </form>
+  </div>
+</div>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
@@ -22,7 +48,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-  {% for release in releases %}
+  {% for release in filter.qs %}
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
         <a href="{{ url('manage-tool-release', kwargs={ "pk": release.pk }) }}">

--- a/controlpanel/frontend/views/release.py
+++ b/controlpanel/frontend/views/release.py
@@ -23,11 +23,12 @@ class ReleaseList(OIDCLoginRequiredMixin, PermissionRequiredMixin, ListView):
     model = Tool
     permission_required = "api.list_tool_release"
     template_name = "release-list.html"
-    ordering = ["name", "version", "created"]
+    ordering = ["name", "-version", "-created"]
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context["filter"] = ReleaseFilter(self.request.GET, queryset=self.get_queryset())
+        context[self.context_object_name] = context["filter"].qs.distinct()
         return context
 
 

--- a/controlpanel/frontend/views/release.py
+++ b/controlpanel/frontend/views/release.py
@@ -8,6 +8,7 @@ from rules.contrib.views import PermissionRequiredMixin
 
 # First-party/Local
 from controlpanel.api.models import Tool
+from controlpanel.frontend.filters import ReleaseFilter
 from controlpanel.frontend.forms import ToolReleaseForm
 from controlpanel.oidc import OIDCLoginRequiredMixin
 
@@ -21,9 +22,13 @@ class ReleaseList(OIDCLoginRequiredMixin, PermissionRequiredMixin, ListView):
     context_object_name = "releases"
     model = Tool
     permission_required = "api.list_tool_release"
-    queryset = Tool.objects.all()
     template_name = "release-list.html"
-    ordering = ["name", "version"]
+    ordering = ["name", "version", "created"]
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["filter"] = ReleaseFilter(self.request.GET, queryset=self.get_queryset())
+        return context
 
 
 class ReleaseDelete(OIDCLoginRequiredMixin, PermissionRequiredMixin, DeleteView):

--- a/tests/frontend/views/test_release.py
+++ b/tests/frontend/views/test_release.py
@@ -1,6 +1,10 @@
 # Standard library
 from unittest import mock
 
+# Third-party
+import pytest
+from pytest_django.asserts import assertQuerySetEqual
+
 # First-party/Local
 from controlpanel.frontend.views import release
 
@@ -22,3 +26,29 @@ def test_release_detail_context_data():
     v.object = mock_object
     result = v.get_context_data()
     assert result["target_users"] == "aldo, nicholas"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "data, count",
+    [
+        ({}, 2),
+        ({"chart_name": "rstudio"}, 1),
+        ({"chart_name": "jupyter-lab"}, 1),
+        ({"is_restricted": "true"}, 0),
+        ({"is_restricted": "false"}, 2),
+    ],
+)
+def test_release_list_get_context_data(rf, data, count):
+    """
+    Note: ToolRelease objects are created in data migration api/migrations/0010_DATA_add_tools.py
+    """
+    view = release.ReleaseList()
+    view.request = rf.get("/releases/", data=data)
+    view.object_list = view.get_queryset()
+    context = view.get_context_data()
+
+    assert "filter" in context
+    assert "releases" in context
+    assertQuerySetEqual(context["releases"], context["filter"].qs.distinct())
+    assert context["releases"].count() == count


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR updates the fields displayed and adds a filter form to the Release list page:

<img width="1796" alt="image" src="https://github.com/user-attachments/assets/f874bc54-5fd6-4154-be2e-9472438ca5b0">

The changes in this PR are needed to help make the release list page more user friendly. This page is a superuser only page, but as more releases have been added has become harder for us to use to create a new release.
<!-- Why should this PR be merged? -->

## :mag: What should the reviewer concentrate on?
- Changes to fields displayed
- Filter options

## :technologist: How should the reviewer test these changes?
- Run locally
- Create some releases - dont worry about using real details, it is just to create some objects to list
- Try the filtering on the release list page

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
