### PR TITLE
Add missing order_by to ensure duplicate values removed from filter

### DIFF
--- a/controlpanel/frontend/filters.py
+++ b/controlpanel/frontend/filters.py
@@ -15,9 +15,9 @@ class ReleaseFilter(django_filters.FilterSet):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.filters["chart_name"].extra["choices"] = Tool.objects.values_list(
-            "chart_name", "chart_name"
-        ).distinct()
+        self.filters["chart_name"].extra["choices"] = (
+            Tool.objects.values_list("chart_name", "chart_name").order_by().distinct()
+        )
         self.filters["chart_name"].field.widget.attrs = {"class": "govuk-select"}
         self.filters["is_restricted"].field.widget.choices = [
             ("all", "---------"),


### PR DESCRIPTION
Resolves minor bug found when testing version 2.17.0 in dev environment.

The use of `order_by` ensures duplicate values are removed from the chart filter options