### PR TITLE
Added button to export admin list as CSV

### DIFF
--- a/controlpanel/frontend/jinja2/webapp-admin-list.html
+++ b/controlpanel/frontend/jinja2/webapp-admin-list.html
@@ -12,12 +12,17 @@
   {% if request.user.has_perm('api.list_app') %}
   {{ app_list(apps, request.user) }}
 
-    {% if request.user.has_perm('api.create_app') %}
-    <p class="govuk-body">
-      <a class="govuk-button" href="{{ url('create-app') }}">
-        Register an app
-      </a>
-    </p>
+    {% if request.user.has_perm('api.is_superuser') %}
+    <h2 class="govuk-heading-l">Export app admins</h2>
+    <p class="govuk-body">Export a list of app admins to a CSV file.</p>
+
+    <form action="{{ url("app-admin-csv") }}" method="post">
+      {{ csrf_input }}
+      <button class="govuk-button js-confirm"
+              data-confirm-message="Are you sure you want to export a list of app admins?">
+              Export Admins
+      </button>
+    </form>
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/controlpanel/frontend/jinja2/webapp-admin-list.html
+++ b/controlpanel/frontend/jinja2/webapp-admin-list.html
@@ -7,22 +7,20 @@
 
 {% block content %}
 {% set num_apps = apps|length %}
-<h1 class="govuk-heading-xl">{{ page_title }}</h1>
+  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
+
+  <h2 class="govuk-heading-l">Export app admins</h2>
+  <p class="govuk-body">Export a list of app admins to a CSV file.</p>
+
+  <form action="{{ url("app-admin-csv") }}" method="post">
+    {{ csrf_input }}
+    <button class="govuk-button js-confirm"
+            data-confirm-message="Are you sure you want to export a list of app admins?">
+            Export Admins
+    </button>
+  </form>
 
   {% if request.user.has_perm('api.list_app') %}
   {{ app_list(apps, request.user) }}
-
-    {% if request.user.has_perm('api.is_superuser') %}
-    <h2 class="govuk-heading-l">Export app admins</h2>
-    <p class="govuk-body">Export a list of app admins to a CSV file.</p>
-
-    <form action="{{ url("app-admin-csv") }}" method="post">
-      {{ csrf_input }}
-      <button class="govuk-button js-confirm"
-              data-confirm-message="Are you sure you want to export a list of app admins?">
-              Export Admins
-      </button>
-    </form>
-    {% endif %}
   {% endif %}
 {% endblock %}

--- a/controlpanel/frontend/urls.py
+++ b/controlpanel/frontend/urls.py
@@ -88,6 +88,7 @@ urlpatterns = [
     path("webapp-data/", views.WebappBucketList.as_view(), name="list-webapp-datasources"),
     path("webapps/", views.AppList.as_view(), name="list-apps"),
     path("webapps/all/", views.AdminAppList.as_view(), name="list-all-apps"),
+    path("webapps/all/admin-csv", views.AppAdminCSV.as_view(), name="app-admin-csv"),
     path("webapps/new/", views.CreateApp.as_view(), name="create-app"),
     path("webapps/<int:pk>/", views.AppDetail.as_view(), name="manage-app"),
     path("webapps/<int:pk>/delete/", views.DeleteApp.as_view(), name="delete-app"),

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -14,6 +14,7 @@ from controlpanel.frontend.views.app import (
     AddAdmin,
     AddCustomers,
     AdminAppList,
+    AppAdminCSV,
     AppDetail,
     AppList,
     CreateApp,

--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -77,7 +77,6 @@ class AdminAppList(AppList):
 
 
 class AppAdminCSV(OIDCLoginRequiredMixin, PermissionRequiredMixin, View):
-    context_object_name = "apps"
     permission_required = "api.is_superuser"
 
     def post(self, request, *args, **kwargs):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,7 +2,7 @@ black==24.10.0
 django-debug-toolbar==4.4.6
 flake8==7.0.0
 ipdb==0.13.13
-ipython==8.27.0
+ipython==8.29.0
 isort==5.13.2
 pandas==2.2.0
 pre-commit==3.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4==4.12.3
 boto3==1.35.39
 botocore==1.35.44  # noqa temporarily pinning this to try to resolve an issue with failing tests
 celery[sqs]==5.3.6
-channels==4.0.0
+channels==4.1.0
 channels-redis==4.2.0
 daphne==4.1.2
 Django==5.1.2
@@ -34,7 +34,7 @@ python-dotenv==1.0.1
 python-jose==3.3.0
 pyyaml==6.0.1
 rules==3.3
-sentry-sdk==2.5.1
+sentry-sdk==2.17.0
 slackclient==2.9.4
 urllib3==2.2.3
 uvicorn[standard]==0.28.0

--- a/tests/frontend/views/test_app.py
+++ b/tests/frontend/views/test_app.py
@@ -363,7 +363,7 @@ def test_admin_csv(client, app, users):
     client.force_login(users["superuser"])
     response = admin_csv(client, app)
     content = response.content.decode("utf-8")
-    assert "App Name,Username,Email" in content
+    assert "App Name,Admins,Emails" in content
     assert app.name in content
 
 


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR is linked to ministryofjustice/analytical-platform#3378

This PR adds a button on the admin webapps page to export a list of apps and their admins as a CSV file

The changes in this PR are needed because this has been requested before


## :mag: What should the reviewer concentrate on?

- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Pull down branch
- Create some dummy webapps
- Go to all webapps page
- click button at bottom of page
- check CSV contents as are expected

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
