### PR TITLE
🔗 Add links to DDT and FMD

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,29 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.12.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:5f3e2005aad161ce3ff7700b2603f11935348c039f9166960efd050d69cd3014",
+      "integrity": "sha256:5f3e2005aad161ce3ff7700b2603f11935348c039f9166960efd050d69cd3014"
+    },
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "1.2.0",
+      "resolved": "ghcr.io/devcontainers/features/kubectl-helm-minikube@sha256:ff50f0f68095dc2dadeb9bfd7e509b21b9fcfe012d708b303c55f7bedfa462d0",
+      "integrity": "sha256:ff50f0f68095dc2dadeb9bfd7e509b21b9fcfe012d708b303c55f7bedfa462d0"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.6.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:71590121aaf7b2040f3e1e2dfc4bb9a1389277fd5a88a7199094542b82ce5340",
+      "integrity": "sha256:71590121aaf7b2040f3e1e2dfc4bb9a1389277fd5a88a7199094542b82ce5340"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.6.5",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:f5e1557b5745bcc3aa8f12eaa1084b8d63952d73e776c406214d65f593aae6d8",
+      "integrity": "sha256:f5e1557b5745bcc3aa8f12eaa1084b8d63952d73e776c406214d65f593aae6d8"
+    },
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40",
+      "integrity": "sha256:53233b394572638b1853a96a5e9d2adc3bae459eb2038a77584330282c82bf40"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "./features/src/postgresql": {},
     "./features/src/redis": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/aws:0": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {}
   },
   "postCreateCommand": "bash scripts/devcontainer/post-create.sh",

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -135,6 +135,18 @@
         "active": page_name == "groups",
       },
       {
+        "text": "Data Discovery Tool",
+        "href": "https://data-discovery-tool.analytical-platform.service.justice.gov.uk/",
+        "active": page_name == "data-discovery-tool",
+        "attributes": [["target", "_blank"]]
+      },
+      {
+        "text": "Find MoJ data",
+        "href": "https://find-moj-data.service.justice.gov.uk/",
+        "active": page_name == "find-moj-data",
+        "attributes": [["target", "_blank"]]
+      },
+      {
         "text": "Training",
         "href": "https://moj-analytical-services.github.io/ap-tools-training/",
         "active": page_name == "training",


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/analytical-platform/issues/6165
- Adds link to Data Discovery Tool and Find MoJ data

<img width="1920" alt="Screenshot 2024-12-04 at 17 36 57" src="https://github.com/user-attachments/assets/588d8a35-d20f-468d-957a-2cfe08bdb132">

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 