### PR TITLE
Revert kubernetes version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ djproxy==2.3.6
 elasticsearch-dsl==7.4.1
 gunicorn==22.0.0
 Jinja2==3.1.4
-kubernetes==31.0.0
+kubernetes==25.3.0
 MarkupSafe==2.1.5
 model-bakery==1.17.0
 moto[all]==5.0.18


### PR DESCRIPTION
Resolves authentication error with the Kubernetes API captured in Sentry https://ministryofjustice.sentry.io/issues/6152224508/?environment=dev&project=5606313&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0&utc=true

This error occurs in dev and when running locally with any version above 1.25.3.

Reverting back until a solution is found that allows us to upgrade.

