### PR TITLE
Remove bucket limit broadcast message

### DIFF
--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -97,7 +97,9 @@ class OIDCLoginRequiredMixin(LoginRequiredMixin):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context["broadcast_messages"] = settings.BROADCAST_MESSAGE.split("|")
+        context["broadcast_messages"] = (
+            settings.BROADCAST_MESSAGE.split("|") if settings.BROADCAST_MESSAGE else []
+        )
         context["settings"] = settings
         return context
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -93,8 +93,7 @@ CUSTOM_AUTH_CONNECTIONS: "auth0_nomis"
 AUTH0_NOMIS_GATEWAY_URL: "https://testing.com"
 
 
-BROADCAST_MESSAGE: >
-  AWS have increased the S3 bucket limit from one thousand to one million. | While this means that the restriction on creating new buckets has been lifted, we still recommend that you use buckets efficiently.
+BROADCAST_MESSAGE:
 
 GITHUB_VERSION: "2022-11-28"
 


### PR DESCRIPTION
Left broadcast message logic in place for now, but update to allow it to handle None values

