### PR TITLE
Add broadcast message related to 502 errors

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -95,7 +95,7 @@ AUTH0_NOMIS_GATEWAY_URL: "https://testing.com"
 
 BROADCAST_MESSAGE: >
   We are currently rolling out additional releases to Analytical Platform Tooling (Jupyter
-  Lab All Spark, Jupyter Lab Data Science, and RStudio) that enabled a new proxy (referred
+  Lab All Spark, Jupyter Lab Data Science, and RStudio) that enables a new proxy (referred
   to as CDE NGINX). If you experience a 502 Bad Gateway when trying to open a tool, please
   deploy the CDE NGINX variant.
 


### PR DESCRIPTION
To notify users to upgrade to CDE NGINX images if they are encountering 502 errors. 

For more context see [our tracking issue](https://github.com/ministryofjustice/data-platform-support/issues/1036)

![image](https://github.com/user-attachments/assets/0fe129a3-5e7d-469c-8f20-b70cd55bf421)

