### PR TITLE
Update create user to expect users from Entra

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -249,7 +249,7 @@ class User(EntityResource):
 
     @property
     def iam_role_name(self):
-        return f"{settings.ENV}_user_{self.user.username.lower()}"
+        return f"{settings.ENV}_user_{self.user.slug.lower()}"
 
     def _run_helm_install_command(self, helm_chart_item):
         values = []
@@ -977,9 +977,9 @@ class ToolDeployment:
         Extracted from `install()` method for clarity.
         """
         values = {
-            "username": self.user.username.lower(),
+            "username": self.user.slug.lower(),
             # XXX backwards compatibility
-            "Username": self.user.username.lower(),
+            "Username": self.user.slug.lower(),
             "aws.iamRole": self.user.iam_role_name,
             "toolsDomain": settings.TOOLS_DOMAIN,
         }

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -249,7 +249,7 @@ class User(EntityResource):
 
     @property
     def iam_role_name(self):
-        return f"{settings.ENV}_user_{self.user.slug.lower()}"
+        return f"{settings.ENV}_user_{self.user.username.lower()}"
 
     def _run_helm_install_command(self, helm_chart_item):
         values = []
@@ -977,9 +977,9 @@ class ToolDeployment:
         Extracted from `install()` method for clarity.
         """
         values = {
-            "username": self.user.slug.lower(),
+            "username": self.user.username.lower(),
             # XXX backwards compatibility
-            "Username": self.user.slug.lower(),
+            "Username": self.user.username.lower(),
             "aws.iamRole": self.user.iam_role_name,
             "toolsDomain": settings.TOOLS_DOMAIN,
         }

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -126,6 +126,17 @@ class User(AbstractUser):
 
         return self.userapps.filter(is_admin=True).exists()
 
+    @property
+    def is_github_user(self):
+        """
+        Determin if the user was created via the github connection. We can use this to limit what
+        actions non-github users do within the AP.
+        This has been added specifically to allow CICA users to authenticate with EntraID in order
+        to access QuickSight in the AP. This is a temporary change, that should be removed once auth
+        with Entra is fully implemented.
+        """
+        return self.auth0_id.startswith("github|")
+
     def is_app_admin(self, app_id):
         return (
             self.userapps.filter(
@@ -161,7 +172,7 @@ class User(AbstractUser):
 
     def save(self, *args, **kwargs):
         existing = User.objects.filter(pk=self.pk).first()
-        if not existing:
+        if not existing and self.is_github_user:
             cluster.User(self).create()
 
         already_superuser = existing and existing.is_superuser

--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -129,7 +129,7 @@ class User(AbstractUser):
     @property
     def is_github_user(self):
         """
-        Determin if the user was created via the github connection. We can use this to limit what
+        Determine if the user was created via the github connection. We can use this to limit what
         actions non-github users do within the AP.
         This has been added specifically to allow CICA users to authenticate with EntraID in order
         to access QuickSight in the AP. This is a temporary change, that should be removed once auth

--- a/controlpanel/api/rules.py
+++ b/controlpanel/api/rules.py
@@ -47,8 +47,13 @@ def is_app_admin(user, obj):
     return False
 
 
-add_perm("api.list_app", is_authenticated)
-add_perm("api.create_app", is_authenticated)
+@predicate
+def is_github_user(user):
+    return user.is_github_user
+
+
+add_perm("api.list_app", is_authenticated & is_github_user)
+add_perm("api.create_app", is_authenticated & is_github_user)
 add_perm("api.retrieve_app", is_authenticated & is_app_admin)
 add_perm("api.update_app", is_authenticated & is_app_admin)
 add_perm("api.destroy_app", is_authenticated & is_superuser)
@@ -126,8 +131,8 @@ def is_database_admin(user):
     return user.is_database_admin
 
 
-add_perm("api.list_s3bucket", is_authenticated)
-add_perm("api.create_s3bucket", is_authenticated)
+add_perm("api.list_s3bucket", is_authenticated & is_github_user)
+add_perm("api.create_s3bucket", is_authenticated & is_github_user)
 add_perm("api.retrieve_s3bucket", is_authenticated & has_bucket_access)
 add_perm("api.update_s3bucket", is_authenticated & has_bucket_write_access)
 add_perm("api.destroy_s3bucket", is_authenticated & is_bucket_admin)
@@ -167,7 +172,7 @@ add_perm("api.destroy_tool_release", is_authenticated & is_superuser)
 add_perm("api.update_tool_release", is_authenticated & is_superuser)
 
 
-add_perm("api.list_apps3bucket", is_authenticated)
+add_perm("api.list_apps3bucket", is_authenticated & is_github_user)
 add_perm("api.create_apps3bucket", is_authenticated & is_superuser)
 add_perm(
     "api.retrieve_apps3bucket",
@@ -180,14 +185,14 @@ add_perm(
 add_perm("api.destroy_apps3bucket", is_authenticated & is_superuser)
 
 
-add_perm("api.list_users3bucket", is_authenticated)
+add_perm("api.list_users3bucket", is_authenticated & is_github_user)
 add_perm("api.create_users3bucket", is_authenticated & is_bucket_admin)
 add_perm("api.retrieve_users3bucket", is_authenticated & is_bucket_admin)
 add_perm("api.update_users3bucket", is_authenticated & is_bucket_admin)
 add_perm("api.destroy_users3bucket", is_authenticated & is_bucket_admin)
 
 
-add_perm("api.list_tool", is_authenticated)
+add_perm("api.list_tool", is_authenticated & is_github_user)
 add_perm("api.create_tool", is_authenticated & is_superuser)
 add_perm("api.retrieve_tool", is_authenticated & is_superuser)
 add_perm("api.update_tool", is_authenticated & is_superuser)
@@ -216,6 +221,7 @@ def is_owner(user, obj):
     return False
 
 
+# TODO these are not used and should be removed
 add_perm("api.list_deployment", is_authenticated)
 add_perm("api.create_deployment", is_authenticated)
 add_perm("api.retrieve_deployment", is_authenticated & is_owner)
@@ -223,8 +229,8 @@ add_perm("api.update_deployment", is_authenticated & is_owner)
 add_perm("api.destroy_deployment", is_authenticated & is_owner)
 
 
-add_perm("api.list_parameter", is_authenticated)
-add_perm("api.create_parameter", is_authenticated)
+add_perm("api.list_parameter", is_authenticated & is_github_user)
+add_perm("api.create_parameter", is_authenticated & is_github_user)
 add_perm("api.retrieve_parameter", is_authenticated & is_owner)
 add_perm("api.update_parameter", is_authenticated & is_owner)
 add_perm("api.destroy_parameter", is_authenticated & is_owner)

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -99,11 +99,13 @@
         "href": url("admin:index"),
       },
       {
+        "hide": not request.user.is_github_user,
         "text": "Analytical tools",
         "href": url("list-tools"),
         "active": page_name == "tools",
       },
       {
+        "hide": not request.user.is_github_user,
         "text": "Warehouse data",
         "href": url("list-warehouse-datasources"),
         "active": page_name == "warehouse-datasource-list",
@@ -115,6 +117,7 @@
         "active": page_name == "webapp-datasource-list",
       },
       {
+        "hide": not request.user.is_github_user,
         "text": "Webapps",
         "href": url("list-apps"),
         "active": page_name == "webapps",
@@ -126,6 +129,7 @@
         "active": page_name == "databases",
       },
       {
+        "hide": not request.user.is_github_user,
         "text": "Parameters",
         "href": url("list-parameters"),
         "active": page_name == "parameters",

--- a/controlpanel/frontend/views/__init__.py
+++ b/controlpanel/frontend/views/__init__.py
@@ -139,6 +139,10 @@ class IndexView(OIDCLoginRequiredMixin, TemplateView):
         if settings.features.justice_auth.enabled and not request.user.justice_email:
             return super().get(request, *args, **kwargs)
 
+        # this is temporary change for users authorising via Entra, specifically CICA users
+        if not request.user.is_github_user:
+            return HttpResponseRedirect(reverse("help"))
+
         # Redirect to the tools page.
         return HttpResponseRedirect(reverse("list-tools"))
 

--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -34,7 +34,8 @@ class OIDCSubAuthenticationBackend(OIDCAuthenticationBackend):
             "email": claims.get(settings.OIDC_FIELD_EMAIL),
             "name": self.normalise_name(claims.get(settings.OIDC_FIELD_NAME)),
         }
-        if user_details["email"].endswith("justice.gov.uk"):
+        email_domain = user_details["email"].split("@")[-1]
+        if email_domain in settings.JUSTICE_EMAIL_DOMAINS:
             user_details["justice_email"] = user_details["email"]
 
         return User.objects.create(**user_details)

--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -28,12 +28,25 @@ class OIDCSubAuthenticationBackend(OIDCAuthenticationBackend):
     """
 
     def create_user(self, claims):
-        return User.objects.create(
-            pk=claims.get("sub"),
-            username=claims.get(settings.OIDC_FIELD_USERNAME),
-            email=claims.get(settings.OIDC_FIELD_EMAIL),
-            name=claims.get(settings.OIDC_FIELD_NAME),
-        )
+        user_details = {
+            "pk": claims.get("sub"),
+            "username": claims.get(settings.OIDC_FIELD_USERNAME),
+            "email": claims.get(settings.OIDC_FIELD_EMAIL),
+            "name": self.normalise_name(claims.get(settings.OIDC_FIELD_NAME)),
+        }
+        if user_details["email"].endswith("justice.gov.uk"):
+            user_details["justice_email"] = user_details["email"]
+
+        return User.objects.create(**user_details)
+
+    def normalise_name(self, name):
+        """
+        Normalise name to be in the format "Firstname Lastname"
+        """
+        if "," in name:
+            parts = [part.strip() for part in name.split(",")]
+            name = " ".join(reversed(parts))
+        return name
 
     def update_user(self, user, claims):
         # Update the non-key information to sync the user's info
@@ -44,8 +57,9 @@ class OIDCSubAuthenticationBackend(OIDCAuthenticationBackend):
         if user.email != claims.get(settings.OIDC_FIELD_EMAIL):
             user.email = claims.get(settings.OIDC_FIELD_EMAIL)
             user.save()
-        if user.name != claims.get(settings.OIDC_FIELD_NAME):
-            user.name = claims.get(settings.OIDC_FIELD_NAME)
+        normalised_name = self.normalise_name(claims.get(settings.OIDC_FIELD_NAME))
+        if user.name != normalised_name:
+            user.name = normalised_name
             user.save()
         return user
 

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -198,6 +198,8 @@ OIDC_FIELD_NAME = "name"
 OIDC_FIELD_USERNAME = "nickname"
 OIDC_STORE_ID_TOKEN = True
 
+JUSTICE_EMAIL_DOMAINS = ["justice.gov.uk", "cica.justice.gov.uk"]
+
 # Auth0
 AUTH0 = {
     "client_id": OIDC_RP_CLIENT_ID,

--- a/tests/api/filters/test_app_filter.py
+++ b/tests/api/filters/test_app_filter.py
@@ -6,8 +6,8 @@ from rest_framework.test import APITestCase
 
 class AppFilterTest(APITestCase):
     def setUp(self):
-        self.superuser = baker.make("api.User", is_superuser=True)
-        self.app_admin = baker.make("api.User", is_superuser=False)
+        self.superuser = baker.make("api.User", auth0_id="github|superuser", is_superuser=True)
+        self.app_admin = baker.make("api.User", auth0_id="github|user", is_superuser=False)
         self.app_1 = baker.make("api.App", name="App 1")
         self.app_2 = baker.make("api.App", name="App 2")
         baker.make("api.UserApp", user=self.app_admin, app=self.app_1, is_admin=True)

--- a/tests/api/filters/test_users3bucket_filter.py
+++ b/tests/api/filters/test_users3bucket_filter.py
@@ -10,9 +10,9 @@ from controlpanel.api.models import UserS3Bucket
 
 class UserS3BucketFilterTest(APITestCase):
     def setUp(self):
-        self.superuser = baker.make("api.User", is_superuser=True)
-        self.normal_user = baker.make("api.User", is_superuser=False)
-        self.other_user = baker.make("api.User", is_superuser=False)
+        self.superuser = baker.make("api.User", auth0_id="github|superuser", is_superuser=True)
+        self.normal_user = baker.make("api.User", auth0_id="github|user", is_superuser=False)
+        self.other_user = baker.make("api.User", auth0_id="github|other_user", is_superuser=False)
 
         self.s3bucket_1 = baker.make("api.S3Bucket", name="test-bucket-1")
         self.s3bucket_2 = baker.make("api.S3Bucket", name="test-bucket-2")

--- a/tests/api/models/test_user.py
+++ b/tests/api/models/test_user.py
@@ -118,3 +118,24 @@ def test_set_quicksight_access(users, enable):
             policy=cluster.User.QUICKSIGHT_POLICY_NAME,
             attach=enable,
         )
+
+
+@pytest.mark.parametrize(
+    "auth0_id, expected",
+    [
+        ("github|user_1", True),
+        ("github|user_2", True),
+        ("entra|user_1", False),
+        ("other|user_2", False),
+    ],
+)
+def test_user_is_github_user(auth0_id, expected):
+    user = User(auth0_id=auth0_id)
+    assert user.is_github_user == expected
+
+
+def test_non_github_user_not_provisioned():
+    user = User.objects.create(auth0_id="not_github|user_1")
+    with patch.object(cluster.User, "create") as mock_create:
+        user.save()
+        mock_create.assert_not_called()

--- a/tests/api/views/test_user.py
+++ b/tests/api/views/test_user.py
@@ -30,7 +30,7 @@ def ExtendedAuth0():
 def test_list(client, users):
     response = client.get(reverse("user-list"))
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.data["results"]) == 5
+    assert len(response.data["results"]) == 6
 
 
 def test_detail(client, users):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ def users(
             is_database_admin=True,
         ),
         "quicksight_user": quicksight_user,
+        "non_tool_user": baker.make("api.User"),
     }
 
 

--- a/tests/frontend/views/test_app.py
+++ b/tests/frontend/views/test_app.py
@@ -46,7 +46,7 @@ def github_api_token():
 def users(users):
     users.update(
         {
-            "app_admin": baker.make("api.User", username="app_admin"),
+            "app_admin": baker.make("api.User", auth0_id="github|user", username="app_admin"),
         }
     )
     return users

--- a/tests/frontend/views/test_app_variables.py
+++ b/tests/frontend/views/test_app_variables.py
@@ -14,7 +14,7 @@ NUM_APPS = 3
 def users(users):
     users.update(
         {
-            "owner": baker.make("api.User", username="owner"),
+            "owner": baker.make("api.User", auth0_id="github|user", username="owner"),
         }
     )
     return users

--- a/tests/frontend/views/test_datasource.py
+++ b/tests/frontend/views/test_datasource.py
@@ -23,8 +23,12 @@ def enable_db_for_all_tests(db):
 def users(users):
     users.update(
         {
-            "bucket_viewer": baker.make("api.User", username="bucket_viewer"),
-            "bucket_admin": baker.make("api.User", username="bucket_admin"),
+            "bucket_viewer": baker.make(
+                "api.User", auth0_id="github|bucket_viewer", username="bucket_viewer"
+            ),
+            "bucket_admin": baker.make(
+                "api.User", auth0_id="github|bucket_admin", username="bucket_admin"
+            ),
         }
     )
     return users

--- a/tests/frontend/views/test_index.py
+++ b/tests/frontend/views/test_index.py
@@ -84,6 +84,17 @@ class TestGetAsNormalUser:
         assert response.status_code == 302
         assert response.url == reverse("list-tools")
 
+    def test_not_tool_user(self, client, users):
+        user = users["non_tool_user"]
+        user.justice_email = "email@example.com"
+        user.save()
+        client.force_login(user)
+
+        response = client.get("/")
+
+        assert response.status_code == 302
+        assert response.url == reverse("help")
+
 
 class TestPost:
 

--- a/tests/frontend/views/test_parameter.py
+++ b/tests/frontend/views/test_parameter.py
@@ -12,7 +12,7 @@ from rest_framework import status
 def users(users):
     users.update(
         {
-            "owner": baker.make("api.User", username="owner"),
+            "owner": baker.make("api.User", auth0_id="github|user", username="owner"),
         }
     )
     return users

--- a/tests/frontend/views/test_secrets.py
+++ b/tests/frontend/views/test_secrets.py
@@ -36,7 +36,7 @@ def github_api_token():
 def users(users):
     users.update(
         {
-            "app_admin": baker.make("api.User", username="app_admin"),
+            "app_admin": baker.make("api.User", auth0_id="github|user", username="app_admin"),
         }
     )
     return users

--- a/tests/frontend/views/test_user.py
+++ b/tests/frontend/views/test_user.py
@@ -112,7 +112,7 @@ def test_permission(client, users, view, user, expected_status):
 @pytest.mark.parametrize(
     "view,user,expected_count",
     [
-        (list, "superuser", 5),
+        (list, "superuser", 6),
     ],
 )
 def test_list(client, users, view, user, expected_count):

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,11 +1,12 @@
 # Standard library
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 # Third-party
 import pytest
+from django.conf import settings
 
 # First-party/Local
-from controlpanel.oidc import StateMismatchHandler
+from controlpanel.oidc import OIDCSubAuthenticationBackend, StateMismatchHandler
 
 
 @pytest.mark.parametrize(
@@ -24,3 +25,27 @@ def test_success_url(users, email, success_url):
     view.request = request
     view.user = user
     assert view.success_url == success_url
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "email, name, expected_name, expected_justice_email",
+    [
+        ("email@exmaple.com", "User, Test", "Test User", None),
+        ("email@exmaple.com", "Test User", "Test User", None),
+        ("email@justice.gov.uk", "User, Test", "Test User", "email@justice.gov.uk"),
+        ("email@justice.gov.uk", "Test User", "Test User", "email@justice.gov.uk"),
+    ],
+)
+def test_create_user(email, name, expected_name, expected_justice_email):
+    with patch("controlpanel.api.cluster.User.create"):
+        user = OIDCSubAuthenticationBackend().create_user(
+            {
+                "sub": "123",
+                settings.OIDC_FIELD_USERNAME: "testuser",
+                settings.OIDC_FIELD_EMAIL: email,
+                settings.OIDC_FIELD_NAME: name,
+            }
+        )
+        assert user.name == expected_name
+        assert user.justice_email == expected_justice_email


### PR DESCRIPTION
This PR resolves relates to https://github.com/ministryofjustice/analytical-platform/issues/6237

To enable CICA users to access the CP, we will enable a new connection in Auth0 with EntraID.
This updates the code we use to create a user from the ID token to normalize their name, and store their email as the justice_email, to avoid them having to reauth to capture it.

Tooling and all AP functionality other than QuickSight have been disabled for users that are not created via GitHub.
In future, to enable tooling for users coming via Entra, I think we would need have to update the helm charts so that we do not rely on their username, as those created from Entra are not compatible.

Another side effect is that we have a unique restriction on the `justice_email` field on the user model. This means if you auth via entra and your justice email is already stored against your normal "alpha" user, upon login a 500 error is raised as a user will already exist with that justice email address. To get around this in testing we will need to remove the `justice_email` from your alpha user before authing with entra.

## :technologist: How should the reviewer test these changes?
- In Auth0 requires the connection with entra (`justicedigital-panda-awsidentitycenter`) to be set up and enabled for the Control Panel EKS app in Auth0. This is currently set up in dev.
- If you have a `justice_email` set against your current alpha user created by logging in with GitHub, remove it
- Log out and go to the login screen
- Type in your justice email in field below the "or" on the login page
- You should then be logged in and created as a new user and redirected to the "help" page
- A superuser will then need to enable the user as a QuickSight user in order to allow them to access QS

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [x] Documentation will be added in the future because ... (unclear what and how we want to document these changes as they are so specific to CICA currently)
