### PR TITLE
Fix/quicksight-access-bug

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -690,7 +690,7 @@ class QuicksightAccessForm(forms.Form):
         if permission_name in quicksight_access and not self.user.has_perm(f"api.{codename}"):
             identity_store.add_user_to_group(self.user.justice_email, group)
             self.user.user_permissions.add(permission)
-        elif self.user.has_perm(f"api.{codename}"):
+        elif permission_name not in quicksight_access and self.user.has_perm(f"api.{codename}"):
             identity_store.delete_group_membership(self.user.justice_email, group)
             self.user.user_permissions.remove(permission)
 

--- a/tests/frontend/views/test_user.py
+++ b/tests/frontend/views/test_user.py
@@ -235,7 +235,7 @@ def test_enable_quicksight_access_legacy(
         (
             "quicksight_compute_reader",
             {"enable_quicksight": ["quicksight_compute_reader"]},
-            ["Mock-Reader-Id", "Mock-Azure-Holding-Id"],
+            ["insert-membership-id", "Mock-Azure-Holding-Id"],
             ["quicksight_compute_reader", "azure_holding"],
             2,
         ),
@@ -263,6 +263,11 @@ def test_quicksight_form_add_to_groups(
 
     test_user = users[user]
     get_user_id.return_value = test_user.identity_center_id
+
+    for i in range(len(group_membership_calls)):
+        if group_membership_calls[i] == "insert-membership-id":
+            group_membership_calls[i] = test_user.group_membership_id
+
     get_group_membership_id.side_effect = group_membership_calls
 
     request_user = users["superuser"]


### PR DESCRIPTION
This PR fixes a bug where clicking the save changes button would remove quicksight access despite none of the tick boxes changing state. Amended tests to capture this fix.

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
