### PR TITLE
Lower email before checking justice domain

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -1510,7 +1510,7 @@ class AWSIdentityStore(AWSService):
 
         name, address = user_email.split("@")
 
-        if address not in settings.JUSTICE_EMAIL_DOMAINS:
+        if address.lower() not in settings.JUSTICE_EMAIL_DOMAINS:
             raise ValueError("Expecting justice email")
 
         if "." not in name:

--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -33,11 +33,8 @@ class OIDCSubAuthenticationBackend(OIDCAuthenticationBackend):
             "username": claims.get(settings.OIDC_FIELD_USERNAME),
             "email": claims.get(settings.OIDC_FIELD_EMAIL),
             "name": self.normalise_name(claims.get(settings.OIDC_FIELD_NAME)),
+            "justice_email": self.get_justice_email(claims.get(settings.OIDC_FIELD_EMAIL)),
         }
-        email_domain = user_details["email"].split("@")[-1]
-        if email_domain in settings.JUSTICE_EMAIL_DOMAINS:
-            user_details["justice_email"] = user_details["email"]
-
         return User.objects.create(**user_details)
 
     def normalise_name(self, name):
@@ -48,6 +45,15 @@ class OIDCSubAuthenticationBackend(OIDCAuthenticationBackend):
             parts = [part.strip() for part in name.split(",")]
             name = " ".join(reversed(parts))
         return name
+
+    def get_justice_email(self, email):
+        """
+        Check if the email uses a justice domain and return it if it does, otherwise return None
+        """
+        email_domain = email.split("@")[-1].lower()
+        if email_domain in settings.JUSTICE_EMAIL_DOMAINS:
+            return email
+        return None
 
     def update_user(self, user, claims):
         # Update the non-key information to sync the user's info

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -1195,6 +1195,7 @@ def test_get_embed_url(quicksight_service):
         ("Carol.Vor@justice.gov.uk", "Carol", "Vor"),
         ("Ronnie.Hotdogs4@justice.gov.uk", "Ronnie", "Hotdogs"),
         ("Ci.Ca@cica.gov.uk", "Ci", "Ca"),
+        ("Ci.Ca@CICA.GOV.UK", "Ci", "Ca"),
     ],
 )
 def test_get_name_from_email(email, expected_forename, expected_surname):

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -31,10 +31,12 @@ def test_success_url(users, email, success_url):
 @pytest.mark.parametrize(
     "email, name, expected_name, expected_justice_email",
     [
-        ("email@exmaple.com", "User, Test", "Test User", None),
-        ("email@exmaple.com", "Test User", "Test User", None),
+        ("email@example.com", "User, Test", "Test User", None),
+        ("email@example.com", "Test User", "Test User", None),
         ("email@justice.gov.uk", "User, Test", "Test User", "email@justice.gov.uk"),
         ("email@justice.gov.uk", "Test User", "Test User", "email@justice.gov.uk"),
+        ("email@cica.gov.uk", "Test User", "Test User", "email@cica.gov.uk"),
+        ("email@CICA.GOV.UK", "Test User", "Test User", "email@CICA.GOV.UK"),
     ],
 )
 def test_create_user(email, name, expected_name, expected_justice_email):
@@ -49,3 +51,17 @@ def test_create_user(email, name, expected_name, expected_justice_email):
         )
         assert user.name == expected_name
         assert user.justice_email == expected_justice_email
+
+
+@pytest.mark.parametrize(
+    "email, expected",
+    [
+        ("email@example.com", None),
+        ("email@justice.gov.uk", "email@justice.gov.uk"),
+        ("email@JUSTICE.GOV.UK", "email@JUSTICE.GOV.UK"),
+        ("email@cica.gov.uk", "email@cica.gov.uk"),
+        ("email@CICA.GOV.UK", "email@CICA.GOV.UK"),
+    ],
+)
+def test_get_justice_email(email, expected):
+    assert OIDCSubAuthenticationBackend().get_justice_email(email) == expected


### PR DESCRIPTION
Lowercase the email address before checking if the domain is from an expected Justice domain. Continue to store the email in original case.
Move the code to check the email to a function, to allow easier unit testing.
Update all tests associated with checking the justice domain, to add in cases where email received is in uppercase.