### PR TITLE
Remove the broadcast message about NGINX image

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -93,11 +93,7 @@ CUSTOM_AUTH_CONNECTIONS: "auth0_nomis"
 AUTH0_NOMIS_GATEWAY_URL: "https://testing.com"
 
 
-BROADCAST_MESSAGE: >
-  We are currently rolling out additional releases to Analytical Platform Tooling (Jupyter
-  Lab All Spark, Jupyter Lab Data Science, and RStudio) that enables a new proxy (referred
-  to as CDE NGINX). If you experience a 502 Bad Gateway when trying to open a tool, please
-  deploy the CDE NGINX variant.
+BROADCAST_MESSAGE: ""
 
 
 GITHUB_VERSION: "2022-11-28"


### PR DESCRIPTION
Enough time has passed that it seems reasonable to remove this now. Also means we will no longer
have to refer to "CDE NGINX" in new releases, as these will now be the default version of the auth proxy.

![image](https://github.com/user-attachments/assets/456b5d9c-3708-4a29-b06d-c36fec4c0292)

