### PR TITLE
Attempt to fix bug polling failed subprocess

### DIFF
--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -89,10 +89,16 @@ def _execute(*args, **kwargs):
             # The following lines will make sure the completion of helm command
             stdout = proc.stdout.read()
             stderr = proc.stderr.read()
-            log.warning(stderr)
-            log.warning(stdout)
-            if should_raise_error(stderr, stdout):
-                raise HelmError(stderr)
+            if stdout:
+                log.info(stdout)
+            if stderr:
+                log.error(stderr)
+                if should_raise_error(stderr, stdout):
+                    log.error("Raising error")
+                    raise HelmError(stderr)
+                log.info("Error safely ignored, ending subprocess")
+                return None
+
     except subprocess.CalledProcessError as proc_ex:
         # Subprocess specific exception handling should capture stderr too.
         log.error(proc_ex)
@@ -113,11 +119,13 @@ def _execute(*args, **kwargs):
             raise HelmError(ex)
     if proc.returncode:
         # The helm command returned a non-0 return code. Log all the things!
+        log.warning(f"Proc return code: {proc.returncode}")
         stdout = proc.stdout.read()
         stderr = proc.stderr.read()
         log.warning(stderr)
         log.warning(stdout)
         raise HelmError(stderr)
+    log.info(f"Returning the subprocess object {id(proc)}")
     return proc
 
 

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -204,11 +204,13 @@ class ToolDeployment(TimeStampedModel):
         """
         if self._subprocess:
             # poll subprocess and maybe parse any output to get status
-            log.info("Polling helm subprocess")
+            log.info(f"Polling status of helm subprocess: {id(self._subprocess)}")
             status = self._poll()
             if status:
                 log.info(status)
                 return status
+
+        log.info("No subprocess to poll, checking deployment status")
         return cluster.ToolDeployment(self.user, self.tool).get_status(
             id_token or self.user.get_id_token(), deployment=deployment
         )

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -230,6 +230,9 @@ class ToolDeployment(TimeStampedModel):
         if self._subprocess.poll() is None:
             return cluster.TOOL_DEPLOYING
         if self._subprocess.returncode:
+            log.error(
+                f"Subprocess {id(self._subprocess)} returncode: {self._subprocess.returncode}"
+            )
             log.error(self._subprocess.stdout.read().strip())
             log.error(self._subprocess.stderr.read().strip())
             return cluster.TOOL_DEPLOY_FAILED


### PR DESCRIPTION
There is a bug (or maybe it was intended) where the background workers all pick up the same deployment messages. The first one to receive it will get on with deploying, wheres as the others all get an error because the deployment is already in progress. We have previously updated the code to check this error and ignore it if it is a "good" error, but this failed subprocess is then used to check the status of the deploy - which reports a failure.

This PR makes a further change so that when the deploy process fails, we return None. This should then result in the status being checked directly from the deployment, rather than the failed subprocess.

I've also increased logging to try to help with debugging if issues persist. 

I think this should be a temporary measure, I have an idea for a change that should be more robust, by stoping multiple workers trying to deploy the same tool.