### PR TITLE
Update script to create tool deployments

### DIFF
--- a/controlpanel/cli/management/commands/create_tool_deployments.py
+++ b/controlpanel/cli/management/commands/create_tool_deployments.py
@@ -61,10 +61,10 @@ class Command(BaseCommand):
             self.stdout.write(f"Limits Memory: {limits_memory}")
             self.stdout.write(f"GPU: {gpu}")
 
+            # include retired/restricted releases so we still have a record of which users were
+            # using them. However they wont be displayed as an option to deploy if they have been
+            # retired or restricted
             tool_queryset = Tool.objects.filter(
-                Q(is_restricted=False) | Q(target_users=user), is_retired=False
-            )
-            tool_queryset = tool_queryset.filter(
                 image_tag=image_tag,
                 version=chart_version,
                 chart_name=chart_name,

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -92,7 +92,7 @@
   <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span>
-      Your previous deployment ({{ tool_form.deployment.tool.chart_name}}-{{ tool_form.deployment.tool.chart_version }}: {{ tool_form.deployment.tool.image_tag }})
+      Your previous deployment ({{ tool_form.deployment.tool.chart_name}}-{{ tool_form.deployment.tool.version }}: {{ tool_form.deployment.tool.image_tag }})
       has been retired. You will need to deploy a new version from the dropdown list.
     </strong>
   </div>


### PR DESCRIPTION
Previously it ignored tools that had been retired. A dry run in prod showed this would be a significant number. It would be better to still have a record of these tool deployments, so we can see how many users are using retired releases and potentially reach out to them.

Also fixes a bug in the template when shpowing a message about retired releases.