### PR TITLE
Fix a few bugs related to tool releases

### DIFF
--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -508,17 +508,22 @@ class ResetHomeDirectoryForm(forms.Form):
 class ToolReleaseForm(forms.ModelForm):
     target_users_list = forms.CharField(required=False)
 
-    def get_target_users(self):
-        """
-        Returns a collection of User instances of those users who are marked as
-        having access to the restricted release.
-        """
-        target_list = self.data.get("target_users_list", "")
-        if target_list:
-            usernames = set([username.strip().lower() for username in target_list.split(",")])
-            return User.objects.filter(username__in=usernames)
-        else:
-            return []
+    def clean_target_users_list(self):
+        target_users_list = self.cleaned_data["target_users_list"]
+        if not target_users_list:
+            return target_users_list
+
+        target_users_list = set(
+            [username.strip().lower() for username in target_users_list.split(",")]
+        )
+
+        found_users = User.objects.filter(username__in=target_users_list)
+        not_found_users = set(target_users_list) - set(
+            found_users.values_list("username", flat=True)
+        )
+        if not_found_users:
+            raise ValidationError(f"Users not found: {', '.join(not_found_users)}")
+        return found_users
 
     def clean_chart_name(self):
         """

--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -782,6 +782,7 @@ class ToolDeploymentForm(forms.Form):
             )
             .exclude(is_retired=True)
             .order_by("-chart_name", "-image_tag", "-version", "-created")
+            .distinct()
         )
 
     @property

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -92,7 +92,7 @@
   <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span>
-      Your previous deployment ({{ tool_form.deployment.tool.chart_name}}-{{ tool_form.deployment.tool.version }}: {{ tool_form.deployment.tool.image_tag }})
+      Your previous deployment ({{ tool_form.deployment.tool.description }})
       has been retired. You will need to deploy a new version from the dropdown list.
     </strong>
   </div>

--- a/controlpanel/frontend/views/release.py
+++ b/controlpanel/frontend/views/release.py
@@ -79,7 +79,7 @@ class ReleaseDetail(OIDCLoginRequiredMixin, PermissionRequiredMixin, UpdateView)
         Ensure the object is updated as expected (for the beta-users).
         """
         self.object = form.save()
-        target_list = form.get_target_users()
+        target_list = form.cleaned_data["target_users_list"]
         if target_list:
             self.object.target_users.set(target_list)
         else:
@@ -104,7 +104,7 @@ class ReleaseCreate(OIDCLoginRequiredMixin, PermissionRequiredMixin, CreateView)
         Ensure the object is created as expected (with the beta-users).
         """
         self.object = form.save()
-        target_list = form.get_target_users()
+        target_list = form.cleaned_data["target_users_list"]
         if target_list:
             self.object.target_users.set(target_list)
         messages.success(self.request, "Successfully created new release")

--- a/controlpanel/frontend/views/tool.py
+++ b/controlpanel/frontend/views/tool.py
@@ -22,28 +22,6 @@ class ToolList(OIDCLoginRequiredMixin, PermissionRequiredMixin, TemplateView):
     permission_required = "api.list_tool"
     template_name = "tool-list.html"
 
-    # def _add_deployed_charts_info(self, tools_info, user, id_token):
-    #     # TODO this is left in place simply to determine the status of a tool. Not sure if it is
-    #     # necessary or worth it  we could store the status of the tool on the ToolDeployment model
-    #     # instead
-    #     deployments = cluster.ToolDeployment.get_deployments(user, id_token)
-    #     # build an index using the chart name as the key for easy lookup later
-    #     deployments = {deployment.metadata.labels["app"]: deployment for deployment in deployments}  # noqa
-    #     for tool_deployment in user.tool_deployments.active():
-    #         deployment = deployments.get(tool_deployment.tool.chart_name)
-    #         tool = tool_deployment.tool
-    #         tools_info[tool_deployment.tool_type]["deployment"] = {
-    #             "tool_id": tool.id,
-    #             "chart_name": tool.chart_name,
-    #             "chart_version": tool.version,
-    #             "image_tag": tool.image_tag,
-    #             "description": tool.description,
-    #             "status": tool_deployment.get_status(id_token=id_token, deployment=deployment),
-    #             "is_deprecated": tool.is_deprecated,
-    #             "deprecated_message": tool.get_deprecated_message,
-    #             "is_retired": tool.is_retired,
-    #         }
-
     def get_context_data(self, *args, **kwargs):
         """
         Retrieve information about tools and arrange them for the

--- a/tests/frontend/views/test_release.py
+++ b/tests/frontend/views/test_release.py
@@ -3,10 +3,25 @@ from unittest import mock
 
 # Third-party
 import pytest
+from django.urls import reverse
 from pytest_django.asserts import assertQuerySetEqual
 
 # First-party/Local
+from controlpanel.api.models.tool import Tool
 from controlpanel.frontend.views import release
+
+
+@pytest.fixture
+def release_data(users):
+    return {
+        "name": "test-release",
+        "version": "1.0",
+        "image_tag": "1.1",
+        "chart_name": "rstudio",
+        "description": "test",
+        "target_users_list": f"{users['normal_user'].username}, {users['superuser'].username}",
+        "values": '{"client_id": "id", "client_secret": "secret"}',
+    }
 
 
 def test_release_detail_context_data():
@@ -52,3 +67,122 @@ def test_release_list_get_context_data(rf, data, count):
     assert "releases" in context
     assertQuerySetEqual(context["releases"], context["filter"].qs.distinct())
     assert context["releases"].count() == count
+
+
+@pytest.mark.django_db
+def test_release_create_success(client, users, release_data):
+    """
+    Ensure the release is created successfully.
+    """
+    client.force_login(users["superuser"])
+    url = reverse("create-tool-release")
+    response = client.get(url)
+    assert response.status_code == 200
+
+    response = client.post(
+        url,
+        data=release_data,
+    )
+    assert response.status_code == 302
+    assert response.url == reverse("list-tool-releases")
+
+    response = client.get(reverse("list-tool-releases"))
+    assert b"test-release" in response.content
+
+    tool = Tool.objects.get(
+        name=release_data["name"],
+        version=release_data["version"],
+        image_tag=release_data["image_tag"],
+        description=release_data["description"],
+    )
+    target_users_list = release_data.pop("target_users_list")
+    assert tool.target_users.count() == 2
+    assert set(tool.target_users.values_list("username", flat=True)) == set(
+        target_users_list.split(", ")
+    )
+
+
+@pytest.mark.django_db
+def test_release_create_failure(client, users, release_data):
+    """
+    Ensure the release is not created if target users not valid
+    """
+    client.force_login(users["superuser"])
+    url = reverse("create-tool-release")
+    response = client.get(url)
+    assert response.status_code == 200
+
+    release_data["target_users_list"] = "invaliduser"
+
+    response = client.post(
+        url,
+        data=release_data,
+    )
+    assert response.status_code == 200
+    assert "target_users_list" in response.context_data["form"].errors
+
+
+@pytest.mark.django_db
+def test_release_update_success(client, users, release_data):
+    """
+    Ensure the release can be updated successfully.
+    """
+    client.force_login(users["superuser"])
+    url = reverse("create-tool-release")
+    response = client.get(url)
+    assert response.status_code == 200
+
+    target_users_list = release_data.pop("target_users_list")
+
+    response = client.post(
+        url,
+        data=release_data,
+    )
+    tool = Tool.objects.get(
+        name=release_data["name"],
+        version=release_data["version"],
+        image_tag=release_data["image_tag"],
+        description=release_data["description"],
+    )
+    assert response.status_code == 302
+    assert tool.target_users.count() == 0
+
+    release_data["target_users_list"] = target_users_list
+    response = client.post(
+        reverse("manage-tool-release", kwargs={"pk": tool.pk}),
+        data=release_data,
+    )
+    assert response.status_code == 302
+    assert tool.target_users.count() == 2
+    assert set(tool.target_users.values_list("username", flat=True)) == set(
+        target_users_list.split(", ")
+    )
+
+
+@pytest.mark.django_db
+def test_release_update_failure(client, users, release_data):
+    """
+    Ensure the release update fails when the target users are not valid
+    """
+    client.force_login(users["superuser"])
+    url = reverse("create-tool-release")
+    response = client.get(url)
+    assert response.status_code == 200
+
+    response = client.post(
+        url,
+        data=release_data,
+    )
+    tool = Tool.objects.get(
+        name=release_data["name"],
+        version=release_data["version"],
+        image_tag=release_data["image_tag"],
+        description=release_data["description"],
+    )
+    release_data["target_users_list"] = "invaliduser"
+    response = client.post(
+        reverse("manage-tool-release", kwargs={"pk": tool.pk}),
+        data=release_data,
+    )
+    assert response.status_code == 200
+    assert "target_users_list" in response.context_data["form"].errors


### PR DESCRIPTION
Came across a few bugs related to tools which this PR resolves:

- Duplicate tool releases are displayed as options to users on the Your Tools page
- Message displayed about a tool being retired was unclear so has been updated to use the tool description
- Further changes to the bug when entering a username in the "target users" section of a tool release - this refactors the form so that an error message will be displayed if the username is not valid