### PR TITLE
Try unpinning botocore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ auth0-python==4.7.2
 authlib==1.3.2
 beautifulsoup4==4.12.3
 boto3==1.35.39
-botocore==1.35.44  # noqa temporarily pinning this to try to resolve an issue with failing tests
 celery[sqs]==5.4.0
 channels==4.2.0
 channels-redis==4.2.1
@@ -35,7 +34,7 @@ python-dotenv==1.0.1
 pyyaml==6.0.2
 rules==3.3
 sentry-sdk==2.19.2
+setuptools==75.6.0
 slackclient==2.9.4
 urllib3==2.3.0
 uvicorn[standard]==0.32.1
-setuptools==75.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.8.1
 auth0-python==4.7.2
 authlib==1.3.2
 beautifulsoup4==4.12.3
-boto3==1.35.39
+boto3==1.36.18
 celery[sqs]==5.4.0
 channels==4.2.0
 channels-redis==4.2.1


### PR DESCRIPTION
There was a bug in a version of `botocore` that resulted in tests failing. To get around this, we pinned `botocore` to a working version. However this has now been resolved, and since pinning both `boto3` and `botocore` causes issues with dependabot ([like this](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/1458)) this PR unpins `botocore`, and updates `boto3` so that we get latest compatible versions of both.