### PR TITLE
Feature/uninstall retired releases

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,8 +21,7 @@
     "vscode": {
       "extensions": [
         "EditorConfig.EditorConfig",
-        "GitHub.vscode-github-actions",
-        "GitHub.vscode-codeql"
+        "GitHub.vscode-github-actions"
       ]
     }
   }

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -1052,7 +1052,8 @@ class ToolDeployment:
         try:
             return helm.delete(self.k8s_namespace, self.release_name)
         except helm.HelmError as error:
-            # TODO make this less generic
+            # TODO make this less generic - catch when release not found, so nothing to uninstall
+            # possibly catch when in progress also
             raise ToolDeploymentError(error)
 
     def restart(self, id_token):

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -1051,10 +1051,12 @@ class ToolDeployment:
     def uninstall(self):
         try:
             return helm.delete(self.k8s_namespace, self.release_name)
+        except helm.HelmReleaseNotFound as error:
+            raise error
         except helm.HelmError as error:
-            # TODO make this less generic - catch when release not found, so nothing to uninstall
-            # possibly catch when in progress also
-            raise ToolDeploymentError(error)
+            # this will catch any helm error and reraise as generic ToolDeploymentError, may want
+            # to be more specific in the future based on errors that occur in testing
+            raise ToolDeploymentError() from error
 
     def restart(self, id_token):
         k8s = KubernetesClient(id_token=id_token)

--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -961,35 +961,6 @@ class ToolDeployment:
     def escape_namespace_len(self, name: str) -> str:
         return name[: settings.MAX_RELEASE_NAME_LEN]
 
-    def _delete_legacy_release(self):
-        """
-        At some point the naming scheme for RStudio
-        changed. This cause upgrade problems when
-        an old release with the old release name is
-        present.
-
-        We're going to temporarily check/uninstall
-        releases with the old name before installing
-        the new release with the correct name.
-
-        We can remove this once every user is on new naming
-        scheme for RStudio.
-        """
-        old_release_name = f"{self.chart_name}-{self.user.slug}"
-        old_release_name = self.escape_namespace_len(old_release_name)
-
-        if self.old_chart_name:
-            # If an old_chart_name has been passed into the deployment, it
-            # means the currently deployed instance of the tool is from a
-            # different chart to the one for this tool. Therefore, it's
-            # the old_chart_name that we should use for the old release
-            # that needs deleting.
-            old_release_name = f"{self.old_chart_name}-{self.user.slug}"
-            old_release_name = self.escape_namespace_len(old_release_name)
-
-        if old_release_name in helm.list_releases(old_release_name, self.k8s_namespace):
-            helm.delete(self.k8s_namespace, old_release_name)
-
     def _set_values(self, **kwargs):
         """
         Return the list of `--set KEY=VALUE` helm upgrade arguments
@@ -1027,10 +998,6 @@ class ToolDeployment:
         return set_values
 
     def install(self, **kwargs):
-        # TODO remove as should no longer be necessary as we uninstall the previous release before
-        # installing the new one
-        # self._delete_legacy_release()
-
         try:
             set_values = self._set_values(**kwargs)
 

--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -100,7 +100,7 @@ def _execute(*args, **kwargs):
         # Subprocess specific exception handling should capture stderr too.
         log.error(proc_ex)
         log.error(proc_ex.stderr.read())
-        raise HelmError(proc_ex) from proc_ex
+        raise HelmError() from proc_ex
     except Exception as ex:
         # Catch all other exceptions, log them and re-raise as HelmError
         log.error(ex)

--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -33,6 +33,12 @@ class HelmError(APIException):
     default_detail = "Error executing Helm command"
 
 
+class HelmReleaseNotFound(HelmError):
+    status_code = 404
+    default_detail = "Helm release not found."
+    default_code = "helm_release_not_found"
+
+
 class HelmChart:
     """
     Instances represent a Helm chart.
@@ -85,49 +91,41 @@ def _execute(*args, **kwargs):
             env=env,
             **kwargs,
         )
-        if "upgrade" in args or "uninstall" in args:
-            # The following lines will make sure the completion of helm command
-            stdout = proc.stdout.read()
-            stderr = proc.stderr.read()
-            if stdout:
-                log.info(stdout)
-            if stderr:
-                log.error(stderr)
-                if should_raise_error(stderr, stdout):
-                    log.error("Raising error")
-                    raise HelmError(stderr)
-                log.info("Error ignored, continuing with subprocess")
 
+        # ensures we get a returncode
+        # if process does timeout exception will be caught and reraised below
+        if wait:
+            proc.wait(timeout)
     except subprocess.CalledProcessError as proc_ex:
         # Subprocess specific exception handling should capture stderr too.
         log.error(proc_ex)
         log.error(proc_ex.stderr.read())
-        raise HelmError(proc_ex)
+        raise HelmError(proc_ex) from proc_ex
     except Exception as ex:
         # Catch all other exceptions, log them and re-raise as HelmError
-        # exceptions.
         log.error(ex)
-        raise HelmError(ex)
-    if wait:
-        # Wait for blocking helm commands.
-        try:
-            proc.wait(timeout)
-        except subprocess.TimeoutExpired as ex:
-            # Raise if timed out.
-            log.warning(ex)
-            raise HelmError(ex)
-    if proc.returncode:
-        # The helm command returned a non-0 return code. Log all the things!
-        log.warning(f"Proc return code: {proc.returncode}")
-        stdout = proc.stdout.read()
-        stderr = proc.stderr.read()
-        log.warning(stderr)
-        log.warning(stdout)
-        raise HelmError(stderr)
-    log.info(f"Returning the subprocess object {id(proc)}")
-    return proc
+        raise HelmError() from ex
+
+    # check the returncode to determine if the process succeeded
+    stdout = proc.stdout.read()
+    if proc.returncode == 0:
+        log.info(stdout)
+        log.info(f"Subprocess {id(proc)} succeeded with returncode: {proc.returncode}")
+        return proc
+
+    # something went went wrong, log the error and raise an exception
+    stderr = proc.stderr.read()
+    log.warning(stdout)
+    log.error(stderr)
+
+    if "error: uninstall: release not loaded" in str(stderr).lower():
+        raise HelmReleaseNotFound(detail=stderr)
+
+    log.error(f"Subprocess {id(proc)} failed with returncode: {proc.returncode}")
+    raise HelmError(stderr)
 
 
+# TODO want to test if this is still necessary, remove if not
 def should_raise_error(stderr, stdout):
     lower_error_string = stderr.lower()
     lower_out_string = stdout.lower()

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -8,6 +8,7 @@ from django_extensions.db.models import TimeStampedModel
 
 # First-party/Local
 from controlpanel.api import cluster, helm
+from controlpanel.api.tasks.tools import retire_tool
 
 log = structlog.getLogger(__name__)
 
@@ -80,6 +81,9 @@ class Tool(TimeStampedModel):
         # Consider removing
         if not self.description:
             self.description = helm.get_chart_app_version(self.chart_name, self.version) or ""
+
+        if self.is_retired:
+            retire_tool.delay_on_commit(self.pk)
 
         super().save(*args, **kwargs)
         return self

--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -150,12 +150,14 @@ class Tool(TimeStampedModel):
     def uninstall_deployments(self):
         """
         Sends task to uninstall the tool from all users namespaces. If DELAY_TOOL_UNINSTALL is True,
-        tasks will be sent to be run at3am the next day. This is to avoid uninstalling the tool when
-        users are actively using it.
+        tasks will be sent to be run at 3am the next day. This is to avoid uninstalling the tool
+        when users are actively using it.
         """
         eta = None
         if settings.DELAY_TOOL_UNINSTALL:
-            eta = timezone.now().replace(hour=3, minute=0, second=0) + timedelta(seconds=1)
+            eta = timezone.now().replace(hour=3, minute=0, second=0, microsecond=0) + timedelta(
+                days=1
+            )
         uninstall_tool.apply_async_on_commit(args=[self.pk], eta=eta)
 
 

--- a/controlpanel/api/tasks/tools.py
+++ b/controlpanel/api/tasks/tools.py
@@ -1,0 +1,37 @@
+# Third-party
+from celery import shared_task
+
+
+# TODO do we need to use acks_late?
+@shared_task(acks_on_failure_or_timeout=False)
+def retire_tool(tool_pk):
+    # First-party/Local
+    from controlpanel.api.models.tool import Tool
+
+    try:
+        tool = Tool.objects.get(pk=tool_pk, is_retired=True)
+    except Tool.DoesNotExist:
+        return
+
+    for tool_deployment in tool.tool_deployments.active():
+        uninstall_tool_deployment.delay(tool_deployment.pk)
+
+
+# TODO do we need to use acks_late? Not sure we can
+@shared_task(acks_on_failure_or_timeout=False)
+def uninstall_tool_deployment(tool_deployment_pk):
+    # First-party/Local
+    from controlpanel.api.cluster import ToolDeploymentError
+    from controlpanel.api.models.tool import ToolDeployment
+
+    try:
+        tool_deployment = ToolDeployment.objects.active().get(pk=tool_deployment_pk)
+    except ToolDeployment.DoesNotExist:
+        return
+
+    try:
+        tool_deployment.uninstall()
+    except ToolDeploymentError as e:
+        # TODO update this to catch an error specificly about release not found, and let other
+        # errors bubble up e.g. connection/authentication errors
+        print(e)

--- a/controlpanel/api/tasks/tools.py
+++ b/controlpanel/api/tasks/tools.py
@@ -3,7 +3,7 @@ from celery import shared_task
 from django.apps import apps
 
 # First-party/Local
-from controlpanel.api.helm import HelmReleaseNotFound
+from controlpanel.api import cluster, helm
 
 
 def _get_model(model_name):
@@ -17,7 +17,7 @@ def _get_model(model_name):
 
 # TODO do we need to use acks_late?
 @shared_task(acks_on_failure_or_timeout=False)
-def retire_tool(tool_pk):
+def uninstall_tool(tool_pk):
     Tool = _get_model("Tool")
     try:
         tool = Tool.objects.get(pk=tool_pk, is_retired=True)
@@ -25,19 +25,12 @@ def retire_tool(tool_pk):
         return
 
     for tool_deployment in tool.tool_deployments.active():
-        uninstall_tool_deployment.delay(tool_deployment.pk)
+        uninstall_helm_release.delay(tool_deployment.k8s_namespace, tool_deployment.release_name)
 
 
-# TODO do we need to use acks_late? Not sure we can
 @shared_task(acks_on_failure_or_timeout=False)
-def uninstall_tool_deployment(tool_deployment_pk):
-    ToolDeployment = _get_model("ToolDeployment")
+def uninstall_helm_release(namespace, release_name):
     try:
-        tool_deployment = ToolDeployment.objects.active().get(pk=tool_deployment_pk)
-    except ToolDeployment.DoesNotExist:
-        return
-
-    try:
-        tool_deployment.uninstall()
-    except HelmReleaseNotFound as e:
+        helm.delete(namespace, release_name)
+    except helm.HelmReleaseNotFound as e:
         print(e)

--- a/controlpanel/api/tasks/tools.py
+++ b/controlpanel/api/tasks/tools.py
@@ -15,12 +15,12 @@ def _get_model(model_name):
     return apps.get_model("api", model_name)
 
 
-# TODO do we need to use acks_late?
+# TODO do we need to use acks_late? try without first
 @shared_task(acks_on_failure_or_timeout=False)
 def uninstall_tool(tool_pk):
     Tool = _get_model("Tool")
     try:
-        tool = Tool.objects.get(pk=tool_pk, is_retired=True)
+        tool = Tool.objects.get(pk=tool_pk)
     except Tool.DoesNotExist:
         return
 

--- a/controlpanel/api/tasks/tools.py
+++ b/controlpanel/api/tasks/tools.py
@@ -2,6 +2,9 @@
 from celery import shared_task
 from django.apps import apps
 
+# First-party/Local
+from controlpanel.api.helm import HelmReleaseNotFound
+
 
 def _get_model(model_name):
     """
@@ -15,7 +18,6 @@ def _get_model(model_name):
 # TODO do we need to use acks_late?
 @shared_task(acks_on_failure_or_timeout=False)
 def retire_tool(tool_pk):
-    # First-party/Local
     Tool = _get_model("Tool")
     try:
         tool = Tool.objects.get(pk=tool_pk, is_retired=True)
@@ -29,8 +31,6 @@ def retire_tool(tool_pk):
 # TODO do we need to use acks_late? Not sure we can
 @shared_task(acks_on_failure_or_timeout=False)
 def uninstall_tool_deployment(tool_deployment_pk):
-    # First-party/Local
-
     ToolDeployment = _get_model("ToolDeployment")
     try:
         tool_deployment = ToolDeployment.objects.active().get(pk=tool_deployment_pk)
@@ -39,7 +39,5 @@ def uninstall_tool_deployment(tool_deployment_pk):
 
     try:
         tool_deployment.uninstall()
-    except ToolDeployment.Error as e:
-        # TODO update this to catch an error specificly about release not found, and let other
-        # errors bubble up e.g. connection/authentication errors
+    except HelmReleaseNotFound as e:
         print(e)

--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -14,14 +14,14 @@ from django.db import transaction
 
 # First-party/Local
 from controlpanel.api import cluster
-from controlpanel.api.cluster import (  # TOOL_IDLED,; TOOL_READY,
+from controlpanel.api.cluster import (
     HOME_RESET_FAILED,
     HOME_RESETTING,
     TOOL_DEPLOY_FAILED,
     TOOL_DEPLOYING,
-    TOOL_READY,
     TOOL_RESTARTING,
 )
+from controlpanel.api.helm import HelmReleaseNotFound
 from controlpanel.api.models import App, HomeDirectory, IPAllowlist, Tool, ToolDeployment, User
 from controlpanel.utils import PatchedAsyncHttpConsumer, sanitize_dns_label, send_sse
 
@@ -169,9 +169,10 @@ class BackgroundTaskConsumer(SyncConsumer):
         if previous_deployment:
             try:
                 previous_deployment.uninstall()
-            except ToolDeployment.Error as err:
+            # TODO update this
+            except (ToolDeployment.Error, HelmReleaseNotFound) as err:
                 # if something went wrong, log the error but continue to try to deploy the new tool
-                log.error(err)
+                log.warning(err)
                 pass
 
         try:

--- a/settings.yaml
+++ b/settings.yaml
@@ -145,3 +145,10 @@ S3_FOLDER_BUCKET_NAME:
 WORKER_HEALTH_FILENAME: "/tmp/worker_health.txt"
 USE_LOCAL_MESSAGE_BROKER: false
 BROKER_URL: "sqs://"
+
+
+DELAY_TOOL_UNINSTALL:
+  _DEFAULT: true
+  _HOST_test: false
+  _HOST_dev: false
+  _HOST_alpha: true

--- a/tests/api/tasks/test_tools.py
+++ b/tests/api/tasks/test_tools.py
@@ -1,0 +1,105 @@
+# Standard library
+from unittest.mock import patch
+
+# Third-party
+import pytest
+from model_bakery import baker
+
+# First-party/Local
+from controlpanel.api import helm
+from controlpanel.api.models import Tool, ToolDeployment
+from controlpanel.api.tasks.tools import uninstall_helm_release, uninstall_tool
+
+
+@pytest.fixture
+def tool():
+    return baker.make(
+        Tool,
+        chart_name="test-chart",
+        name="Test Tool",
+        version="1.0.0",
+        description="Test description",
+        is_retired=True,
+    )
+
+
+@pytest.fixture
+def tool_deployment(tool):
+    return baker.make(
+        ToolDeployment, tool=tool, tool_type=ToolDeployment.ToolType.JUPYTER, is_active=True
+    )
+
+
+@pytest.mark.django_db
+@patch("controlpanel.api.tasks.tools.uninstall_helm_release.delay")
+def test_uninstall_tool(mock_uninstall_helm_release, tool, tool_deployment):
+    # Call the task with took pk
+    uninstall_tool(tool.pk)
+
+    mock_uninstall_helm_release.assert_called_once_with(
+        tool_deployment.k8s_namespace, tool_deployment.release_name
+    )
+
+
+@pytest.mark.django_db
+@patch("controlpanel.api.tasks.tools.uninstall_helm_release.delay")
+def test_uninstall_tool_inactive_deployment(mock_uninstall_helm_release, tool, tool_deployment):
+    # Make the deployment inactve
+    tool_deployment.is_active = False
+    tool_deployment.save()
+
+    # Call the task
+    uninstall_tool(tool.pk)
+
+    mock_uninstall_helm_release.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("controlpanel.api.tasks.tools.uninstall_helm_release.delay")
+def test_uninstall_tool_not_found(mock_uninstall_helm_release):
+    # Call the task with a non-existent tool PK
+    uninstall_tool(1000)
+
+    mock_uninstall_helm_release.assert_not_called()
+
+
+@patch("controlpanel.api.tasks.tools.helm.delete")
+def test_uninstall_helm_release(mock_helm_delete):
+    namespace = "test-namespace"
+    release_name = "test-release"
+
+    # Call the task
+    uninstall_helm_release(namespace, release_name)
+
+    # Check that the helm.delete method was called with the correct arguments
+    mock_helm_delete.assert_called_once_with(namespace, release_name)
+
+
+@patch("controlpanel.api.tasks.tools.helm.delete")
+def test_uninstall_helm_release_not_found(mock_helm_delete):
+    namespace = "test-namespace"
+    release_name = "test-release"
+
+    # Simulate HelmReleaseNotFound exception
+    mock_helm_delete.side_effect = helm.HelmReleaseNotFound("Release not found")
+
+    # Call the task
+    result = uninstall_helm_release(namespace, release_name)
+
+    mock_helm_delete.assert_called_once_with(namespace, release_name)
+
+    assert result is None
+
+
+@patch("controlpanel.api.tasks.tools.helm.delete")
+def test_uninstall_helm_other_error_raises(mock_helm_delete):
+    namespace = "test-namespace"
+    release_name = "test-release"
+
+    # Simulate HelmReleaseNotFound exception
+    mock_helm_delete.side_effect = helm.HelmError("Some other error")
+
+    # Call the task
+    with pytest.raises(helm.HelmError):
+        uninstall_helm_release(namespace, release_name)
+        mock_helm_delete.assert_called_once_with(namespace, release_name)

--- a/tests/api/test_helm.py
+++ b/tests/api/test_helm.py
@@ -96,6 +96,7 @@ def test_helm_upgrade_release():
             "--wait",
             "--force",
             *upgrade_args,
+            timeout=300,
         )
 
 
@@ -221,6 +222,7 @@ def test_delete():
             "baz",
             "--namespace",
             "my_namespace",
+            "--wait",
             timeout=settings.HELM_DELETE_TIMEOUT,
             dry_run=False,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from model_bakery import baker
 
 # First-party/Local
 from controlpanel.api import auth0
+from controlpanel.api.helm import HelmError, HelmReleaseNotFound
 from controlpanel.api.models import (
     QUICKSIGHT_EMBED_AUTHOR_PERMISSION,
     QUICKSIGHT_EMBED_READER_PERMISSION,
@@ -72,6 +73,9 @@ def helm():
     Mock calls to Helm
     """
     with patch("controlpanel.api.cluster.helm") as helm:
+        # patch the actual exceptions
+        helm.HelmReleaseNotFound = HelmReleaseNotFound
+        helm.HelmError = HelmError
         yield helm
 
 


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR relates to https://github.com/ministryofjustice/analytical-platform/issues/6705

The main aim of the PR is to reduce the number of users using old releases. When a tool is marked as retired, a celery task will be triggered to uninstall all active deployments of that tool. This is done using a helm uninstall command. In order to avoid removing releases in the middle of users using them, the task is set to run at 3am the next day (in prod only - in dev it is immediate, to make it easier for us to test).

As part of the changes, I have refactored some of the code related to running helm commands. This is because I encountered some bugs discovered that we were implicitly waiting for helm to run commands in some scenarios - therefore I have made it explicit that when we upgrade/uninstall a helm release, we wait for the return code.

The changes in this PR are needed because we currently have a long list of old and deprecated tools, we want to reduce this right down to just the fewest versions as possible. But currently even after a tool is retired, users can still keep using it if it is deployed by hitting the tool URL directly. By uninstalling the release at the point of retiring the tool, this will no longer be possible, and will mean users have to go to the control panel and install a new release. Further reasons are outlined in this [ticket](https://github.com/ministryofjustice/analytical-platform/issues/6599), which includes the comms that we will send out to our users.

## :mag: What should the reviewer concentrate on?
- The tasks to uninstall tool releases
- Celery implementation - this differs to the existing celery tasks. It is less custom and using celery as it is intended.
- Changes to helm to check if any new bugs could be introduced

## :technologist: How should the reviewer test these changes?
- Pull the code
- Run the server, celery and background worker together
- Create a tool release if there is not one in your local DB already
- Deploy the tool and wait for it to succeed - use kubectl to confirm that the tool was installed in your namespace
- Go to the manage tool page, and mark the tool as retired
- Check celery worker log output
- Use kubectl to confirm that the tool was uninstalled from your namespace. The URL of your tool should not be accessible either
- Go to the "Your tools" page - a message should be displayed to say that your previous release was uninstalled

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
