### PR TITLE
Admin actions to run user helm charts

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -211,6 +211,18 @@ class User(EntityResource):
     def _init_aws_services(self):
         self.aws_role_service = self.create_aws_service(AWSRole)
 
+    def get_helm_chart(self, chart_name):
+        """
+        Lookup helm chart dictionary by name. This is fine for now as there are not many charts,
+        but if the number of charts grows, we should consider refactoring to store them in a
+        way that allows a more efficient lookup.
+        """
+        for chart_type, charts in self.user_helm_charts.items():
+            for chart in charts:
+                if chart["chart"] == chart_name:
+                    return chart
+        return None
+
     @property
     def user_helm_charts(self):
         # The full list of the charts required for a user under different situations

--- a/controlpanel/api/tasks/tools.py
+++ b/controlpanel/api/tasks/tools.py
@@ -1,18 +1,9 @@
 # Third-party
 from celery import shared_task
-from django.apps import apps
 
 # First-party/Local
-from controlpanel.api import cluster, helm
-
-
-def _get_model(model_name):
-    """
-    This is used to avoid a circular import when calling tasks from within models. I feel like this
-    is the best worst option. For futher reading on this issue and the lack of an ideal solution:
-    https://stackoverflow.com/questions/26379026/resolving-circular-imports-in-celery-and-django
-    """
-    return apps.get_model("api", model_name)
+from controlpanel.api import helm
+from controlpanel.utils import _get_model
 
 
 # TODO do we need to use acks_late? try without first

--- a/controlpanel/api/tasks/user.py
+++ b/controlpanel/api/tasks/user.py
@@ -1,0 +1,18 @@
+# Third-party
+from celery import shared_task
+
+# First-party/Local
+from controlpanel.api import cluster
+from controlpanel.utils import _get_model
+
+
+@shared_task(acks_on_failure_or_timeout=False)
+def upgrade_user_helm_chart(username, chart_name):
+    User = _get_model("User")
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        return
+    cluster_user = cluster.User(user)
+    chart = cluster_user.get_helm_chart(chart_name)
+    cluster_user._run_helm_install_command(chart)

--- a/controlpanel/utils.py
+++ b/controlpanel/utils.py
@@ -11,6 +11,7 @@ from asgiref.sync import async_to_sync
 from channels.exceptions import StopConsumer
 from channels.generic.http import AsyncHttpConsumer
 from channels.layers import get_channel_layer
+from django.apps import apps
 from django.conf import settings
 from django.template.defaultfilters import slugify
 from nacl import encoding, public
@@ -246,3 +247,12 @@ def start_background_task(task, message):
             **message,
         },
     )
+
+
+def _get_model(model_name):
+    """
+    This is used to avoid a circular import when calling tasks from within models. I feel like this
+    is the best worst option. For futher reading on this issue and the lack of an ideal solution:
+    https://stackoverflow.com/questions/26379026/resolving-circular-imports-in-celery-and-django
+    """
+    return apps.get_model("api", model_name)

--- a/tests/api/tasks/test_user.py
+++ b/tests/api/tasks/test_user.py
@@ -1,0 +1,46 @@
+# Standard library
+from unittest.mock import MagicMock, patch
+
+# Third-party
+import pytest
+
+# First-party/Local
+from controlpanel.api.models import User
+from controlpanel.api.tasks.user import upgrade_user_helm_chart
+
+
+@pytest.fixture()
+def mock_get_user_model():
+    with patch("controlpanel.api.tasks.user._get_model") as mock_get_model:
+        mock_get_model.return_value = User
+        yield mock_get_model
+
+
+@patch("controlpanel.api.tasks.user.cluster.User")
+def test_upgrade_user_helm_chart_user_does_not_exist(mock_cluster_user, mock_get_user_model):
+    with patch.object(User.objects, "get") as mock_get:
+        mock_get.side_effect = User.DoesNotExist
+        upgrade_user_helm_chart("nonexistent_user", "chart_name")
+
+    mock_get_user_model.assert_called_once_with("User")
+    mock_cluster_user.assert_not_called()
+
+
+@patch("controlpanel.api.tasks.user.cluster.User")
+def test_upgrade_user_helm_chart_success(mock_cluster_user, mock_get_user_model):
+    cluster_user_instance = MagicMock()
+    mock_cluster_user.return_value = cluster_user_instance
+
+    chart = MagicMock()
+    cluster_user_instance.get_helm_chart.return_value = chart
+
+    user_instance = MagicMock()
+
+    with patch.object(User.objects, "get") as mock_get:
+        mock_get.return_value = user_instance
+        upgrade_user_helm_chart("existing_user", "chart_name")
+
+    mock_get_user_model.assert_called_once_with("User")
+    mock_cluster_user.assert_called_once_with(user_instance)
+    cluster_user_instance.get_helm_chart.assert_called_once_with("chart_name")
+    cluster_user_instance._run_helm_install_command.assert_called_once_with(chart)

--- a/tests/api/views/test_user.py
+++ b/tests/api/views/test_user.py
@@ -12,6 +12,7 @@ from rest_framework.reverse import reverse
 
 # First-party/Local
 from controlpanel.api.models import User
+from controlpanel.api.tasks.user import upgrade_user_helm_chart
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Closes https://github.com/ministryofjustice/analytical-platform/issues/6985

Adds admin actions that will let us upgrade user helm charts. 

Initially this is the bootstrap user chart and the reset home directory chart, but could be expanded in future.

This change was needed because the [bootstrap user chart was updated in this PR](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/793) to give the celery worker the necessary permissions to run helm commands (so that Celery can handle uninstalling user releases as part of [this ticket](https://github.com/ministryofjustice/analytical-platform/issues/6599)).

Adding the admin action removes the need to manually update all user helm charts.

## :mag: What should the reviewer concentrate on?
- code changes 
- 
## :technologist: How should the reviewer test these changes?
- Run locally, ensure Celery running
- Log in as superuser
- Got to django admin page, then Users
- Select users and then choose admin action from dropdown list
- Trigger the action

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [x] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
