### PR TITLE
Use celery-beat to schedule tool deletes

### DIFF
--- a/controlpanel/api/tasks/tools.py
+++ b/controlpanel/api/tasks/tools.py
@@ -1,13 +1,16 @@
 # Third-party
+import structlog
 from celery import shared_task
 
 # First-party/Local
 from controlpanel.api import helm
 from controlpanel.utils import _get_model
 
+log = structlog.getLogger(__name__)
+
 
 # TODO do we need to use acks_late? try without first
-@shared_task(acks_on_failure_or_timeout=False)
+@shared_task(acks_on_failure_or_timeout=False)  # this does nothing without using acks_late
 def uninstall_tool(tool_pk):
     Tool = _get_model("Tool")
     try:
@@ -24,4 +27,4 @@ def uninstall_helm_release(namespace, release_name):
     try:
         helm.delete(namespace, release_name)
     except helm.HelmReleaseNotFound as e:
-        print(e)
+        log.info(e)

--- a/controlpanel/celery.py
+++ b/controlpanel/celery.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import dotenv
 import structlog
 from celery import Celery
+from celery.signals import beat_init
 from django.conf import settings
 from kombu import Queue
 
@@ -41,6 +42,11 @@ def debug_task(self):
 def worker_health_check(self):
     Path(settings.WORKER_HEALTH_FILENAME).touch()
     log.debug("Worker health ping task executed")
+
+
+@beat_init.connect
+def beat_ready(**_):
+    Path(settings.WORKER_HEALTH_FILENAME).touch()
 
 
 # ensures worker picks and runs tasks from all queues rather than just default queue

--- a/controlpanel/frontend/management/commands/celery_beat_health.py
+++ b/controlpanel/frontend/management/commands/celery_beat_health.py
@@ -1,0 +1,25 @@
+# Standard library
+import random
+from datetime import datetime, timedelta
+from pathlib import Path
+from sys import exit
+
+# Third-party
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+# First-party/Local
+from controlpanel.celery import worker_health_check
+
+
+class Command(BaseCommand):
+    help = "Checks if celery beat is ready by checking for heath file"
+
+    def handle(self, *args, **options):
+
+        if not Path(settings.WORKER_HEALTH_FILENAME).is_file():
+            self.stderr.write(self.style.ERROR("Health file not found"))
+            exit(-1)
+
+        self.stdout.write(self.style.SUCCESS("Health file found"))
+        exit(0)

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -79,6 +79,8 @@ INSTALLED_APPS = [
     "controlpanel.cli",
     # Health check
     "django_prometheus",
+    # for scheduled tasks
+    "django_celery_beat",
 ]
 
 MIDDLEWARE = [

--- a/doc/launch.json.example
+++ b/doc/launch.json.example
@@ -14,6 +14,21 @@
             ],
         },
         {
+            "name": "celery_beat",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "celery",
+            "args": [
+                "-A",
+                "controlpanel",
+                "beat",
+                "--loglevel=debug",
+                "--scheduler",
+                "django_celery_beat.schedulers:DatabaseScheduler",
+            ],
+            "justMyCode": false,
+        },
+        {
             "name": "runserver",
             "type": "debugpy",
             "request": "launch",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ channels==4.2.0
 channels-redis==4.2.1
 daphne==4.1.2
 Django==5.1.4
+django-celery-beat==2.7.0
 django-crequest==2018.5.11
 django-extensions==3.2.3
 django-filter==24.3

--- a/settings.yaml
+++ b/settings.yaml
@@ -145,10 +145,3 @@ S3_FOLDER_BUCKET_NAME:
 WORKER_HEALTH_FILENAME: "/tmp/worker_health.txt"
 USE_LOCAL_MESSAGE_BROKER: false
 BROKER_URL: "sqs://"
-
-
-DELAY_TOOL_UNINSTALL:
-  _DEFAULT: true
-  _HOST_test: false
-  _HOST_dev: false
-  _HOST_alpha: true


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR introduces celery beat to allow us to schedule tasks.

The example in this PR is when retiring tool releases, we want to schedule the uninstall task to run overnight. Initially I tried to use the built in `eta` functionality, however this is not recommended when scheduling tasks as far into the future (hours) as I was, and resulted in tasks being repeated by the worker hundreds of times, all of which errored.

The changes in this PR need to deployed alongside changes to the Control Panel helm chart, [made in this PR](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/794).

Merging this PR will have the following side-effects:
- None that I can think of, as we were not using scheduled tasks yet
- Will allow us to update existing cron jobs to use scheduled tasks instead - but this can come later

## :mag: What should the reviewer concentrate on?
- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Reinstall your requirements to make sure that celery beat django is installed in your dev container
- Update your `launch.json` to include celery beat - see changes to the example launch.json file
- Run the server with celery and celery beat
- Retire a tool
- Go to the django admin - you will see a section related to celery beat. Under `Periodic tasks` you should see a task to uninstall your tool at 3am tomorrow.
- You can edit this, to have it install (e.g. in a few minutes) and then wait to check that the task is sent to the celery worker at the specified time. Check your celery/celery beat debugger terminal outputs

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [x] This PR includes all relevant documentation
- [x] Documentation will be added in the future because ... I want to test this in dev, and then if it works as expected, I can update docs
