### PR TITLE
Pinned numpy as above 2.0 clashes with elasticsearch. Added pipdeptree

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,7 +4,9 @@ flake8==7.0.0
 ipdb==0.13.13
 ipython==8.29.0
 isort==5.13.2
+numpy==1.26.0
 pandas==2.2.3
+pipdeptree==2.25.0
 pre-commit==4.0.1
 pylint==3.3.2
 pylint-django==2.6.1


### PR DESCRIPTION
Fixed issue caused by pandas pulling in a version of numpy incompatible with our elasticsearch package.