### PR TITLE
Update logging errors to warnings

### DIFF
--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -116,14 +116,13 @@ def _execute(*args, **kwargs):
         log.info(f"Subprocess {id(proc)} succeeded with returncode: {proc.returncode}")
         return proc
 
-    # something went went wrong, log the error and raise an exception
+    # something went went wrong, check the outputs
     outs, errs = proc.communicate()
-    log.warning(outs)
-    log.error(errs)
-
     if "error: uninstall: release not loaded" in str(errs).lower():
         raise HelmReleaseNotFound(detail=outs)
 
+    log.warning(outs)
+    log.error(errs)
     log.error(f"Subprocess {id(proc)} failed with returncode: {proc.returncode}")
     raise HelmError(errs)
 

--- a/controlpanel/api/helm.py
+++ b/controlpanel/api/helm.py
@@ -100,14 +100,14 @@ def _execute(*args, **kwargs):
         # If timeout reached kill the child process, then log outputs and reraise HelmError
         proc.kill()
         outs, errs = proc.communicate()
-        log.warning(outs)
+        log.info(outs)
         log.error(errs)
         raise HelmError() from timeout_ex
     except subprocess.SubprocessError as proc_ex:
         # Catch general subprocess errors and reraise as HelmError
         proc.kill()
         outs, errs = proc.communicate()
-        log.warning(outs)
+        log.info(outs)
         log.error(errs)
         raise HelmError() from proc_ex
 
@@ -121,9 +121,9 @@ def _execute(*args, **kwargs):
     if "error: uninstall: release not loaded" in str(errs).lower():
         raise HelmReleaseNotFound(detail=outs)
 
-    log.warning(outs)
+    log.info(outs)
+    log.info(f"Subprocess {id(proc)} failed with returncode: {proc.returncode}")
     log.error(errs)
-    log.error(f"Subprocess {id(proc)} failed with returncode: {proc.returncode}")
     raise HelmError(errs)
 
 

--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -170,7 +170,7 @@ class BackgroundTaskConsumer(SyncConsumer):
             try:
                 previous_deployment.uninstall()
             except (ToolDeployment.Error, HelmReleaseNotFound) as err:
-                log.warning(f"Previous deployment not found with: {str(err)}. Continuing to deploy")
+                log.info(f"Previous deployment not found with: {str(err)}. Continuing to deploy")
                 pass
 
         try:

--- a/controlpanel/frontend/consumers.py
+++ b/controlpanel/frontend/consumers.py
@@ -169,10 +169,8 @@ class BackgroundTaskConsumer(SyncConsumer):
         if previous_deployment:
             try:
                 previous_deployment.uninstall()
-            # TODO update this
             except (ToolDeployment.Error, HelmReleaseNotFound) as err:
-                # if something went wrong, log the error but continue to try to deploy the new tool
-                log.warning(err)
+                log.warning(f"Previous deployment not found with: {str(err)}. Continuing to deploy")
                 pass
 
         try:


### PR DESCRIPTION
Sentry will create an issue for any log.error call. There are some cases where we log an error that is not error worthy - for example, where we try to delete a release that is not found. We handle this in the code, so update this output to a warning rather than an error to keep Sentry less noisy.
