### PR TITLE
Increase helm delete timeout to 30s

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -40,7 +40,7 @@ HELM_REPO: 'mojanalytics'
 HELM_REPOSITORY_CACHE: "/tmp/helm/cache/repository"
 
 # The number of seconds helm should wait for helm delete to complete.
-HELM_DELETE_TIMEOUT: 10
+HELM_DELETE_TIMEOUT: 30
 
 # domain where tools are deployed
 TOOLS_DOMAIN:


### PR DESCRIPTION
Previous limit of 10 secs was too short for some cases, resulted in a Sentry error when trying to remove a user. Running the delete command manually resolved the issue, retrying with 30s timeout limit.
