### PR TITLE
Use helm timeout rather than subprocess timeout

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -40,7 +40,7 @@ HELM_REPO: 'mojanalytics'
 HELM_REPOSITORY_CACHE: "/tmp/helm/cache/repository"
 
 # The number of seconds helm should wait for helm delete to complete.
-HELM_DELETE_TIMEOUT: 30
+HELM_DELETE_TIMEOUT: "30s"
 
 # domain where tools are deployed
 TOOLS_DOMAIN:


### PR DESCRIPTION
Updates helm commands to use the `--timeout` flag when necessary, rather than relying on the subprocess timeout.

This way, if the helm command times out, it will surface as a failure, in turn completing the subprocess. Hopefully this means that the helm release should then be marked as failed, rather than left in a pending state as we were seeing in some failed deploys such as https://github.com/ministryofjustice/data-platform-support/issues/1179#issuecomment-2717617421
