### PR TITLE
Added API endpoints to get dashboard list for a given user and an embed URL

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -1273,7 +1273,7 @@ class AWSQuicksight(AWSService):
                     "InitialDashboardId": dashboard_id,
                 }
             },
-            AllowedDomains=settings.QUICKSIGHT_DOMAINS,
+            AllowedDomains=settings.DASHBOARD_SERVICE_DOMAINS,
         )
 
 

--- a/controlpanel/api/models/dashboard.py
+++ b/controlpanel/api/models/dashboard.py
@@ -7,6 +7,7 @@ from django_extensions.db.models import TimeStampedModel
 from controlpanel.api import aws
 from controlpanel.api.exceptions import DeleteCustomerError
 from controlpanel.api.models.dashboard_viewer import DashboardViewer
+from controlpanel.utils import get_domain_from_email
 
 
 class Dashboard(TimeStampedModel):

--- a/controlpanel/api/models/dashboard.py
+++ b/controlpanel/api/models/dashboard.py
@@ -4,7 +4,7 @@ from django.db import models
 from django_extensions.db.models import TimeStampedModel
 
 # First-party/Local
-from controlpanel.api.aws import arn, AWSQuicksight
+from controlpanel.api.aws import AWSQuicksight, arn
 from controlpanel.api.exceptions import DeleteCustomerError
 from controlpanel.api.models.dashboard_viewer import DashboardViewer
 from controlpanel.utils import get_domain_from_email
@@ -61,7 +61,7 @@ class Dashboard(TimeStampedModel):
             self.viewers.remove(viewer)
         except Exception as e:
             raise DeleteCustomerError from e
-        
+
     def get_embed_url(self):
         """
         Get the QuickSight embed URL for the dashboard.

--- a/controlpanel/api/models/dashboard.py
+++ b/controlpanel/api/models/dashboard.py
@@ -4,7 +4,7 @@ from django.db import models
 from django_extensions.db.models import TimeStampedModel
 
 # First-party/Local
-from controlpanel.api import aws
+from controlpanel.api.aws import arn, AWSQuicksight
 from controlpanel.api.exceptions import DeleteCustomerError
 from controlpanel.api.models.dashboard_viewer import DashboardViewer
 from controlpanel.utils import get_domain_from_email
@@ -28,13 +28,13 @@ class Dashboard(TimeStampedModel):
 
     @property
     def arn(self):
-        arn = aws.arn(
+        dashboard_arn = arn(
             "quicksight",
             "dashboard",
             settings.QUICKSIGHT_ACCOUNT_REGION,
             settings.QUICKSIGHT_ACCOUNT_ID,
         )
-        return f"{arn}/{self.quicksight_id}"
+        return f"{dashboard_arn}/{self.quicksight_id}"
 
     def is_admin(self, user):
         return self.admins.filter(pk=user.pk).exists()
@@ -61,3 +61,21 @@ class Dashboard(TimeStampedModel):
             self.viewers.remove(viewer)
         except Exception as e:
             raise DeleteCustomerError from e
+        
+    def get_embed_url(self):
+        """
+        Get the QuickSight embed URL for the dashboard.
+        """
+        assume_role_name = settings.QUICKSIGHT_ASSUMED_ROLE
+        quicksight_region = settings.QUICKSIGHT_ACCOUNT_REGION
+        quicksight_client = AWSQuicksight(
+            assume_role_name=assume_role_name,
+            profile_name="control_panel_api",
+            region_name=quicksight_region,
+        )
+
+        response = quicksight_client.generate_embed_url_for_anonymous_user(
+            dashboard_arn=self.arn, dashboard_id=self.quicksight_id
+        )
+
+        return response

--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -564,7 +564,7 @@ class DashboardSerializer(serializers.ModelSerializer):
 
 class DashboardUrlSerializer(DashboardSerializer):
     class Meta(DashboardSerializer.Meta):
-        fields = ("name",)
+        fields = ("name", "admins")
 
     def to_representation(self, dashboard):
         data = super().to_representation(dashboard)

--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -546,10 +546,29 @@ class AppAuthSettingsSerializer(serializers.BaseSerializer):
         auth_settings = app_auth_data["auth_settings"]
         auth_settings_status = app_auth_data["auth0_clients_status"]
         return self._process_auth_settings(auth_settings, auth_settings_status)
+    
+
+class DashboardAdminSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ("name", "email") 
 
 
 class DashboardSerializer(serializers.ModelSerializer):
+    admins = DashboardAdminSerializer(many=True, read_only=True)
 
     class Meta:
         model = Dashboard
-        fields = ("name", "quicksight_id")
+        fields = ("name", "quicksight_id", "admins")
+
+
+class DashboardUrlSerializer(DashboardSerializer):
+    class Meta(DashboardSerializer.Meta):
+        fields = ("name",)
+
+    def to_representation(self, dashboard):
+        data = super().to_representation(dashboard)
+        response = dashboard.get_embed_url()
+        data["embed_url"] = response["EmbedUrl"]
+        data["anonymous_user_arn"] = response["AnonymousUserArn"]
+        return data

--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -16,6 +16,7 @@ from controlpanel.api import cluster, validators
 from controlpanel.api.models import (
     App,
     AppS3Bucket,
+    Dashboard,
     IPAllowlist,
     S3Bucket,
     ToolDeployment,
@@ -545,3 +546,10 @@ class AppAuthSettingsSerializer(serializers.BaseSerializer):
         auth_settings = app_auth_data["auth_settings"]
         auth_settings_status = app_auth_data["auth0_clients_status"]
         return self._process_auth_settings(auth_settings, auth_settings_status)
+
+
+class DashboardSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Dashboard
+        fields = ("name", "quicksight_id")

--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -568,6 +568,7 @@ class DashboardUrlSerializer(DashboardSerializer):
 
     def to_representation(self, dashboard):
         data = super().to_representation(dashboard)
+
         response = dashboard.get_embed_url()
         data["embed_url"] = response["EmbedUrl"]
         data["anonymous_user_arn"] = response["AnonymousUserArn"]

--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -546,12 +546,12 @@ class AppAuthSettingsSerializer(serializers.BaseSerializer):
         auth_settings = app_auth_data["auth_settings"]
         auth_settings_status = app_auth_data["auth0_clients_status"]
         return self._process_auth_settings(auth_settings, auth_settings_status)
-    
+
 
 class DashboardAdminSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ("name", "email") 
+        fields = ("name", "email")
 
 
 class DashboardSerializer(serializers.ModelSerializer):

--- a/controlpanel/api/urls.py
+++ b/controlpanel/api/urls.py
@@ -14,6 +14,7 @@ router.register("tools", views.ToolViewSet, basename="tool")
 router.register("userapps", views.UserAppViewSet)
 router.register("users", views.UserViewSet)
 router.register("users3buckets", views.UserS3BucketViewSet)
+router.register("dashboards", views.DashboardViewSet, basename="dashboard")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/controlpanel/api/views/__init__.py
+++ b/controlpanel/api/views/__init__.py
@@ -1,6 +1,7 @@
 # First-party/Local
 from controlpanel.api.views.apps import AppByNameViewSet
 from controlpanel.api.views.customers import AppCustomersAPIView, AppCustomersDetailAPIView
+from controlpanel.api.views.dashboards import DashboardViewSet
 from controlpanel.api.views.health_check import health_check
 from controlpanel.api.views.models import (
     AppS3BucketViewSet,

--- a/controlpanel/api/views/dashboards.py
+++ b/controlpanel/api/views/dashboards.py
@@ -5,6 +5,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 # First-party/Local
 from controlpanel.api import permissions
+from controlpanel.api.filters import DashboardFilter
 from controlpanel.api.models.dashboard import Dashboard
 from controlpanel.api.pagination import CustomPageNumberPagination
 from controlpanel.api.serializers import DashboardSerializer, DashboardUrlSerializer
@@ -22,17 +23,7 @@ class DashboardViewSet(ReadOnlyModelViewSet):
     permission_classes = [permissions.IsSuperuser | permissions.JWTTokenResourcePermissions]
     lookup_field = "quicksight_id"
     pagination_class = CustomPageNumberPagination
-
-    def get_queryset(self):
-        """
-        Filter dashboards based on the viewer's email or whitelist domain.
-        """
-        viewer_email = self.request.query_params.get("email")
-        domain = get_domain_from_email(viewer_email)
-
-        return Dashboard.objects.filter(
-            Q(viewers__email=viewer_email) | Q(whitelist_domains__name=domain)
-        ).distinct()
+    filter_backends = (DashboardFilter,)
 
     def get_object(self):
         """

--- a/controlpanel/api/views/dashboards.py
+++ b/controlpanel/api/views/dashboards.py
@@ -1,0 +1,87 @@
+# Third-party
+from django.conf import settings
+from django.db.models import Q
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+# First-party/Local
+from controlpanel.api import permissions
+from controlpanel.api.aws import AWSQuicksight
+from controlpanel.api.models.dashboard import Dashboard
+from controlpanel.api.serializers import DashboardSerializer
+from controlpanel.utils import get_domain_from_email
+
+
+class DashboardViewSet(ViewSet):
+    """
+    A ViewSet for managing dashboards.
+    """
+
+    permission_classes = [permissions.IsSuperuser]
+    lookup_field = "quicksight_id"
+
+    @action(detail=False, methods=["get"])
+    def dashboard_list(self, request):
+        """
+        Get a list of dashboards that the viewer has access to.
+        """
+        viewer_email = request.query_params.get("email")
+
+        if not viewer_email:
+            return Response({"error": "Email parameter is required."}, status=400)
+
+        domain = get_domain_from_email(viewer_email)
+
+        dashboards = Dashboard.objects.filter(
+            Q(viewers__email=viewer_email) | Q(whitelist_domains__name=domain)
+        ).distinct()
+
+        serialiser = DashboardSerializer(dashboards, many=True)
+        return Response(serialiser.data)
+
+    @action(detail=True, methods=["get"])
+    def embed_url(self, request, quicksight_id=None):
+        """
+        Get a dashboard by its QuickSight ID.
+        """
+        try:
+            viewer_email = request.query_params.get("email")
+
+            if not viewer_email:
+                return Response({"error": "Email parameter is required."}, status=400)
+
+            domain = get_domain_from_email(viewer_email)
+
+            # Query using the unique `quicksight_id` field
+            dashboard = Dashboard.objects.filter(
+                Q(quicksight_id=quicksight_id)
+                & (Q(viewers__email=viewer_email) | Q(whitelist_domains__name=domain))
+            ).first()
+
+            if not dashboard:
+                return Response(
+                    {"error": f"Dashboard {quicksight_id} not found."},
+                    status=404,
+                )
+
+            assume_role_name = settings.QUICKSIGHT_ASSUMED_ROLE
+            quicksight_region = settings.QUICKSIGHT_ACCOUNT_REGION
+            quicksight_client = AWSQuicksight(
+                assume_role_name=assume_role_name,
+                profile_name="control_panel_api",
+                region_name=quicksight_region,
+            )
+
+            response = quicksight_client.generate_embed_url_for_anonymous_user(
+                dashboard_arn=dashboard.arn, dashboard_id=quicksight_id
+            )
+
+            return Response(
+                {
+                    "embed_url": response["EmbedUrl"],
+                    "anonymous_user_arn": response["AnonymousUserArn"],
+                }
+            )
+        except Dashboard.DoesNotExist:
+            return Response({"error": "Dashboard not found."}, status=404)

--- a/controlpanel/api/views/dashboards.py
+++ b/controlpanel/api/views/dashboards.py
@@ -63,7 +63,7 @@ class DashboardViewSet(ViewSet):
                     {"error": f"Dashboard {quicksight_id} not found."},
                     status=404,
                 )
-            
+
             serialiser = DashboardUrlSerializer(dashboard)
             return Response(serialiser.data)
         except Dashboard.DoesNotExist:

--- a/controlpanel/api/views/dashboards.py
+++ b/controlpanel/api/views/dashboards.py
@@ -18,7 +18,8 @@ class DashboardViewSet(ReadOnlyModelViewSet):
 
     queryset = Dashboard.objects.all()
     serializer_class = DashboardSerializer
-    permission_classes = [permissions.IsSuperuser]
+    resource = "dashboard"
+    permission_classes = [permissions.IsSuperuser | permissions.JWTTokenResourcePermissions]
     lookup_field = "quicksight_id"
     pagination_class = CustomPageNumberPagination
 

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -266,6 +266,8 @@ try:
 except gaierror:
     pass
 
+DASHBOARD_SERVICE_DOMAINS = [os.environ.get("DASHBOARD_SERVICE_DOMAINS")]
+
 # Sets the X-XSS-Protection: 1; mode=block header
 SECURE_BROWSER_XSS_FILTER = True
 

--- a/controlpanel/utils.py
+++ b/controlpanel/utils.py
@@ -272,3 +272,12 @@ def _get_model(model_name):
     https://stackoverflow.com/questions/26379026/resolving-circular-imports-in-celery-and-django
     """
     return apps.get_model("api", model_name)
+
+
+def get_domain_from_email(email):
+    """
+    Extract the domain from an email address.
+    """
+    if "@" not in email:
+        raise ValueError("Invalid email address.")
+    return email.split("@")[-1].lower()

--- a/tests/api/views/test_dashboards.py
+++ b/tests/api/views/test_dashboards.py
@@ -75,20 +75,32 @@ def dashboard_domain(dashboard):
     ],
 )
 def test_list(
-    client, dashboard, dashboard_viewer, dashboard_domain, email, expected_status, expected_count
+    client,
+    users,
+    dashboard,
+    dashboard_viewer,
+    dashboard_domain,
+    email,
+    expected_status,
+    expected_count,
 ):
-    data = {"email": email} if email else {}
-    response = client.get(reverse("dashboard-list"), data=data)
+    with patch(
+        "controlpanel.api.permissions.JWTTokenResourcePermissions.has_permission"
+    ) as has_permission:
+        has_permission.return_value = True
+        data = {"email": email} if email else {}
+        client.force_login(users["dashboard_admin"])
+        response = client.get(reverse("dashboard-list"), data=data)
 
-    assert response.status_code == expected_status
+        assert response.status_code == expected_status
 
-    if expected_status == status.HTTP_200_OK:
-        assert response.data["count"] == expected_count
+        if expected_status == status.HTTP_200_OK:
+            assert response.data["count"] == expected_count
 
-        if expected_count > 0:
-            result = response.data["results"][0]
-            assert result["quicksight_id"] == dashboard.quicksight_id
-            assert result["name"] == dashboard.name
+            if expected_count > 0:
+                result = response.data["results"][0]
+                assert result["quicksight_id"] == dashboard.quicksight_id
+                assert result["name"] == dashboard.name
 
 
 @pytest.mark.parametrize(

--- a/tests/api/views/test_dashboards.py
+++ b/tests/api/views/test_dashboards.py
@@ -1,0 +1,139 @@
+# Standard library
+from unittest.mock import patch
+
+# Third-party
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+from rest_framework import status
+
+NUM_DASHBOARDS = 3
+
+
+@pytest.fixture()
+def ExtendedAuth0():
+    with patch("controlpanel.api.auth0.ExtendedAuth0") as ExtendedAuth0:
+        ExtendedAuth0.return_value.add_dashboard_member_by_email.return_value = None
+        yield ExtendedAuth0.return_value
+
+
+@pytest.fixture(autouse=True)
+def enable_db_for_all_tests(db):
+    pass
+
+
+@pytest.fixture
+def users(users):
+    users.update(
+        {
+            "dashboard_admin": baker.make(
+                "api.User",
+                auth0_id="github|dashboard-admin",
+                username="dashboard_admin",
+                justice_email="dashboard.admin@justice.gov.uk",
+            ),
+        }
+    )
+    return users
+
+
+@pytest.fixture
+def dashboard(users, ExtendedAuth0):
+    baker.make("api.Dashboard", NUM_DASHBOARDS - 1)
+    dashboard = baker.make(
+        "api.Dashboard",
+        name="test-dashboard",
+        quicksight_id="abc-123",
+        created_by=users["dashboard_admin"],
+    )
+
+    dashboard.admins.add(users["dashboard_admin"])
+    return dashboard
+
+
+@pytest.fixture
+def dashboard_viewer(users, dashboard):
+    viewer = baker.make("api.DashboardViewer", email=users["dashboard_admin"].justice_email)
+    dashboard.viewers.add(viewer)
+    return viewer
+
+
+@pytest.fixture
+def dashboard_domain(dashboard):
+    domain = baker.make("api.DashboardDomain", name="justice.gov.uk")
+    dashboard.whitelist_domains.add(domain)
+    return domain
+
+
+@pytest.mark.parametrize(
+    "email, expected_status, expected_count",
+    [
+        ("dashboard.admin@justice.gov.uk", status.HTTP_200_OK, 1),
+        ("domain.viewer@justice.gov.uk", status.HTTP_200_OK, 1),
+        ("no.access@test.gov.uk", status.HTTP_200_OK, 0),
+        (None, status.HTTP_400_BAD_REQUEST, 0),
+    ],
+)
+def test_list(
+    client, dashboard, dashboard_viewer, dashboard_domain, email, expected_status, expected_count
+):
+    data = {"email": email} if email else {}
+    response = client.get(reverse("dashboard-list"), data=data)
+
+    assert response.status_code == expected_status
+
+    if expected_status == status.HTTP_200_OK:
+        assert response.data["count"] == expected_count
+
+        if expected_count > 0:
+            result = response.data["results"][0]
+            assert result["quicksight_id"] == dashboard.quicksight_id
+            assert result["name"] == dashboard.name
+
+
+@pytest.mark.parametrize(
+    "email, embed_url, user_arn, expected_status",
+    [
+        (
+            "dashboard.admin@justice.gov.uk",
+            "https://quicksight-embed-url-viewer",
+            "some:viewer:arn",
+            status.HTTP_200_OK,
+        ),
+        (
+            "domain.viewer@justice.gov.uk",
+            "https://quicksight-embed-url-domain",
+            "some:domain:arn",
+            status.HTTP_200_OK,
+        ),
+        ("no.access@test.gov.uk", "", "", status.HTTP_404_NOT_FOUND),
+        ("", "", "", status.HTTP_400_BAD_REQUEST),
+    ],
+)
+def test_retrieve(
+    client,
+    dashboard,
+    dashboard_viewer,
+    dashboard_domain,
+    email,
+    embed_url,
+    user_arn,
+    expected_status,
+):
+
+    with patch("controlpanel.api.models.dashboard.Dashboard.get_embed_url") as get_embed_url:
+        get_embed_url.return_value = {
+            "EmbedUrl": embed_url,
+            "AnonymousUserArn": user_arn,
+        }
+        response = client.get(
+            reverse("dashboard-detail", args=[dashboard.quicksight_id]),
+            data={"email": email},
+        )
+
+        assert response.status_code == expected_status
+
+        if expected_status == status.HTTP_200_OK:
+            result = response.data
+            assert result["embed_url"] == embed_url
+            assert result["anonymous_user_arn"] == user_arn


### PR DESCRIPTION

## :memo: Summary
This PR is linked to ministryofjustice/analytical-platform#7530

This PR adds new API endpoints for the dashboard service to retrieve a list of dashboards for a user and an embed url for a given dashboard.

The changes in this PR are needed to provide functionality for the dashboard service

## :mag: What should the reviewer concentrate on?
- Feedback on specific parts of the code

## :technologist: How should the reviewer test these changes?
- Add dashboard(s) to the control panel
- Grant a mix of customers and domain access to your dashboards
- hit endpoints and check results

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] Documentation will be added in the future when entire epic is finished and tested
