### PR TITLE
Add DASHBOARD_SERVICE_DOMAINS setting for local dev

### DIFF
--- a/controlpanel/settings/development.py
+++ b/controlpanel/settings/development.py
@@ -38,3 +38,5 @@ SESSION_COOKIE_SECURE = False
 
 # -- Structured logging
 LOGGING["loggers"]["controlpanel"]["level"] = "INFO"  # noqa: F405
+
+DASHBOARD_SERVICE_DOMAINS = ["http://localhost:8001"]


### PR DESCRIPTION
Minor settings change, to help when running Control Panel alongside the dashboard service in local development