### PR TITLE
Give justice email back as email at API endpoint. Added dashboard ser…

### DIFF
--- a/controlpanel/api/serializers.py
+++ b/controlpanel/api/serializers.py
@@ -549,9 +549,17 @@ class AppAuthSettingsSerializer(serializers.BaseSerializer):
 
 
 class DashboardAdminSerializer(serializers.ModelSerializer):
+    email = serializers.SerializerMethodField()
+
     class Meta:
         model = User
         fields = ("name", "email")
+
+    def get_email(self, obj):
+        if obj.justice_email:
+            return obj.justice_email
+
+        return obj.email
 
 
 class DashboardSerializer(serializers.ModelSerializer):

--- a/controlpanel/frontend/jinja2.py
+++ b/controlpanel/frontend/jinja2.py
@@ -20,6 +20,7 @@ def environment(**kwargs):
             "static": static,
             "url": reverse,
             "google_analytics_id": settings.GOOGLE_ANALYTICS_ID,
+            "dashboard_url": settings.DASHBOARD_SERVICE_URL,
             "user_guidance_base_url": settings.USER_GUIDANCE_BASE_URL,
         }
     )

--- a/controlpanel/frontend/jinja2/base.html
+++ b/controlpanel/frontend/jinja2/base.html
@@ -204,6 +204,10 @@
         'title': 'Related resources',
         'items': [
           {
+            'href': dashboard_url,
+            'text': "Dashboard Service",
+          },
+          {
             'href': user_guidance_base_url,
             'text': "User Guidance",
           },

--- a/tests/api/views/test_dashboards.py
+++ b/tests/api/views/test_dashboards.py
@@ -100,7 +100,7 @@ def test_list(
             if expected_count > 0:
                 result = response.data["results"][0]
                 assert result["quicksight_id"] == dashboard.quicksight_id
-                assert result["name"] == dashboard.name
+                assert result["admins"][0]["email"] == users["dashboard_admin"].justice_email
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
…vice URL in footer

<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR is related to ministryofjustice/analytical-platform#7655 

This PR gives the justice email back rather than the email field for the dashboard admins as the other email could be public.

