### PR TITLE
Dashboards pages should be accessible by non iam users.

### DIFF
--- a/controlpanel/api/rules.py
+++ b/controlpanel/api/rules.py
@@ -256,8 +256,8 @@ def is_dashboard_admin(user, obj):
     return False
 
 
-add_perm("api.list_dashboard", is_authenticated & is_iam_user)
-add_perm("api.register_dashboard", is_authenticated & is_iam_user)
+add_perm("api.list_dashboard", is_authenticated)
+add_perm("api.register_dashboard", is_authenticated)
 add_perm("api.retrieve_dashboard", is_authenticated & is_dashboard_admin)
 add_perm("api.update_dashboard", is_authenticated & is_dashboard_admin)
 add_perm("api.destroy_dashboard", is_authenticated & is_dashboard_admin)


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary

This PR allows non IAM users to register dashboards
The changes in this PR are needed because otherwise these users won't be able to share via the dashboard service


