### PR TITLE
Bugfix/register dashboard

### DIFF
--- a/controlpanel/api/models/dashboard.py
+++ b/controlpanel/api/models/dashboard.py
@@ -7,7 +7,6 @@ from django_extensions.db.models import TimeStampedModel
 from controlpanel.api.aws import AWSQuicksight, arn
 from controlpanel.api.exceptions import DeleteCustomerError
 from controlpanel.api.models.dashboard_viewer import DashboardViewer
-from controlpanel.utils import get_domain_from_email
 
 
 class Dashboard(TimeStampedModel):

--- a/controlpanel/frontend/forms.py
+++ b/controlpanel/frontend/forms.py
@@ -809,6 +809,12 @@ class RegisterDashboardForm(forms.ModelForm):
         ):
             raise ValidationError("You do not have permission to register this dashboard")
 
+        existing_dashboard = Dashboard.objects.filter(quicksight_id=quicksight_id).first()
+        if existing_dashboard:
+            raise ValidationError(
+                f"This dashboard is already registered by {existing_dashboard.created_by.justice_email}. Please contact them to request access."  # noqa
+            )
+
         return quicksight_id
 
 

--- a/controlpanel/frontend/views/dashboard.py
+++ b/controlpanel/frontend/views/dashboard.py
@@ -57,6 +57,11 @@ class RegisterDashboard(OIDCLoginRequiredMixin, PermissionRequiredMixin, CreateV
     permission_required = "api.register_dashboard"
     template_name = "dashboard-register.html"
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
+
     def get_success_url(self):
         messages.success(
             self.request,

--- a/tests/frontend/views/test_dashboard.py
+++ b/tests/frontend/views/test_dashboard.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 # Third-party
 import pytest
+from django.conf import settings
 from django.contrib.messages import get_messages
 from django.urls import reverse
 from model_bakery import baker
@@ -355,3 +356,72 @@ def test_revoke_dashboard_domain(client, dashboard, users, add_dashboard_domain)
     assert response.status_code == 302
     updated_dashboard = Dashboard.objects.get(pk=dashboard.id)
     assert updated_dashboard.whitelist_domains.count() == 0
+
+
+@pytest.mark.parametrize(
+    "dashboard_url",
+    [
+        ("https://not-quicksight.com/sn/dashboards/abc-123"),
+        ("https://eu-west-1.quicksight.com/sn/dashboards/abc-123"),
+        (f"https://{settings.QUICKSIGHT_ACCOUNT_REGION}.aws.amazon.com/sn/dashboards/"),
+    ],
+)
+def test_register_dashboard_invalid_url(dashboard_url, client, users):
+    client.force_login(users["superuser"])
+    url = reverse("register-dashboard")
+    response = client.post(
+        url,
+        data={
+            "name": "Test Dashboard",
+            "quicksight_id": dashboard_url,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "The URL entered is not a valid Quicksight dashboard URL" in str(response.content)
+
+
+def test_register_dashboard_not_permitted(client, users):
+    with patch(
+        "controlpanel.api.aws.AWSQuicksight.has_update_dashboard_permissions"
+    ) as has_update_permissions:
+        has_update_permissions.return_value = False
+        client.force_login(users["superuser"])
+        url = reverse("register-dashboard")
+        response = client.post(
+            url,
+            data={
+                "name": "Test Dashboard",
+                "quicksight_id": f"https://{settings.QUICKSIGHT_ACCOUNT_REGION}.quicksight.aws.amazon.com/sn/dashboards/abc-123",  # noqa
+            },
+        )
+        has_update_permissions.assert_called_once_with(
+            dashboard_id="abc-123", user=users["superuser"]
+        )
+        assert response.status_code == 200
+        assert "You do not have permission to register this dashboard" in str(response.content)
+
+
+def test_register_dashboard_success(client, users, ExtendedAuth0):
+    with patch(
+        "controlpanel.api.aws.AWSQuicksight.has_update_dashboard_permissions"
+    ) as has_update_permissions:
+        has_update_permissions.return_value = True
+        client.force_login(users["superuser"])
+        url = reverse("register-dashboard")
+        response = client.post(
+            url,
+            data={
+                "name": "Test Dashboard",
+                "quicksight_id": f"https://{settings.QUICKSIGHT_ACCOUNT_REGION}.quicksight.aws.amazon.com/sn/dashboards/abc-123",  # noqa
+            },
+        )
+        has_update_permissions.assert_called_once_with(
+            dashboard_id="abc-123", user=users["superuser"]
+        )
+        assert response.status_code == 302
+        assert response.url == reverse("manage-dashboard", kwargs={"pk": 1})
+        ExtendedAuth0.add_dashboard_member_by_email.assert_called_once_with(
+            email=users["superuser"].justice_email.lower(),
+            user_options={"connection": "email"},
+        )


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR resolves this task https://github.com/ministryofjustice/analytical-platform/issues/7698 related to the Dashboard Service. Full details in the linked ticket.

In summary, the changes restrict who can register a dashboard to dashboard owners.
It also updates the error messages that are displayed to be more specific, and adds extra validation of the dashboard URL.

## :mag: What should the reviewer concentrate on?
- Code changes to handle validation in the form

## :technologist: How should the reviewer test these changes?
- Attempt to register a dashboard that you are the "Owner" of (or have been shared as an admin). This should succeed.
- Attempt to register a dashboard that you are only a "Viewer" of - this should fail with a relevant error message.
- Attempt to add a made up dashboard URL - this should fail with a relevant error message
- Attempt to re-register a dashboard - this should fail with a relevant error message

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [x] Documentation will be added in the future because ... (see issue [#7699](https://github.com/ministryofjustice/analytical-platform/issues/7699))
