### PR TITLE
Bugfix: Make admin field required in dashboard detail page

### DIFF
--- a/controlpanel/frontend/jinja2/dashboard-detail.html
+++ b/controlpanel/frontend/jinja2/dashboard-detail.html
@@ -113,6 +113,7 @@
       "label": "Give a user admin rights to this dashboard",
       "placeholder": "Start typing to find a user...",
       "items": admin_options,
+      "required": True,
     }) %}
       <option value="{{ user.auth0_id }}">{{ user_name(user) }}</option>
     {% endcall %}

--- a/controlpanel/frontend/static/components/autocomplete/autocomplete.js
+++ b/controlpanel/frontend/static/components/autocomplete/autocomplete.js
@@ -9,9 +9,11 @@ moj.Modules.autocomplete = {
 
   bindEvents() {
     document.querySelectorAll(this.selector).forEach(select => {
+
       accessibleAutocomplete.enhanceSelectElement({
         defaultValue: '',
         selectElement: select,
+        required: select.dataset.required === "true"
       });
     });
   },

--- a/controlpanel/frontend/static/components/autocomplete/macro.html
+++ b/controlpanel/frontend/static/components/autocomplete/macro.html
@@ -49,7 +49,8 @@
         {%- if describedBy %} aria-describedBy="{{ describedBy }}"{% endif %}
         {%- if params.attributes %}
           {%- for attribute, value in params.attributes.items() %} {{ attribute }}="{{ value }}"{% endfor %}
-        {%- endif %}>
+        {%- endif %}
+        {%- if params.required %}data-required="true" {% endif %}>
     <option value=""></option>
     {% set items = params["items"] %}
     {% if items is callable %}{% set items = items() %}{% endif %}

--- a/controlpanel/frontend/views/dashboard.py
+++ b/controlpanel/frontend/views/dashboard.py
@@ -151,7 +151,16 @@ class AddDashboardAdmin(UpdateDashboardBaseView):
 
     def perform_update(self, **kwargs):
         dashboard = self.get_object()
-        user = get_object_or_404(User, pk=self.request.POST["user_id"])
+
+        user_id = self.request.POST.get("user_id")
+        if not user_id:
+            messages.error(self.request, "User not found")
+            return
+        try:
+            user = User.objects.get(pk=self.request.POST["user_id"])
+        except User.DoesNotExist:
+            messages.error(self.request, "User not found")
+            return
 
         dashboard.admins.add(user)
         dashboard.add_customers([user.justice_email])


### PR DESCRIPTION
## :memo: Summary
This PR fixes https://github.com/ministryofjustice/analytical-platform/issues/7742
This PR relates contributes to https://github.com/ministryofjustice/analytical-platform/issues/7133

It adds JS validation to ensure a choice is made in the admin select field. To enable this I had to amend the autocomplete.js to check for a required data attribute, so that I can conditionally make the field required, as the autocomplete macro can be used in other places.

Also adds server side validation to the view that creates dashboard admins, to ensure that an admin is selected, otherwise redirect with an error message. This fixes a bug where a 404 was returned if no user is selected and the form is submitted.

Merging this PR will have the following side-effects:
- N/A

## :mag: What should the reviewer concentrate on?
- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Register a dashboard
- Go to the "Manage dashboard" page
- Click "Grant admin" without selecting a user - a validation message should appear

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
