### PR TITLE
Merging this PR will add the `devcontainers` ecosystem to the Dependabot manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ":dependabot: devcontainers"
+      include: "scope"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR resolves no specific issue, but allows Dependabot to keep the devcontainer up-to-date

This PR adds the `devcontainers` ecosystem to the dependabot.yml file

The changes in this PR are needed because without it any updates to the devcontainer will have to be created by hand

Merging this PR will have the following side-effects:
- Dependabot will raise PRs when devcontainer features are not the most recent version

## :mag: What should the reviewer concentrate on?
- Quick check only (for e.g. version bump)
- <!-- Feedback on specific parts of the code -->
- <!-- Check side effects, if any -->

## :technologist: How should the reviewer test these changes?
- <!-- Give a step-by-step guide here -->

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [x] This PR includes all relevant documentation
