### PR TITLE
Rename dashboard customers to users

### DIFF
--- a/controlpanel/frontend/jinja2/dashboard-user-list.html
+++ b/controlpanel/frontend/jinja2/dashboard-user-list.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
 {% from "modal-dialog/macro.html" import modal_dialog %}
-{% from "customers/macro.html" import display_dashboard_customer %}
+{% from "customers/macro.html" import display_dashboard_user %}
 {% from "menus/customers.html" import displayCustomerMenu %}
 
-{% set page_title = "Dashboard customers" %}
-{% set page_name = "customers" %}
+{% set page_title = "Dashboard users" %}
+{% set page_name = "Dashboard users" %}
 {% set remove_perm = request.user.has_perm('api.remove_dashboard_customer', dashboard) %}
 
 {% set dashboard_customers_html %}
@@ -15,7 +15,7 @@
 {% block content %}
 
 <h2 class="govuk-heading-m">
-    Customer management for {{ dashboard.name }}
+    User management for {{ dashboard.name }}
 </h2>
 
 <h2 class="govuk-heading-s">
@@ -27,7 +27,7 @@
 </p>
 
 <h2 class="govuk-heading-s">
-  Dashboard customers
+  Dashboard users
   {{ modal_dialog(dashboard_customers_html|safe) }}
 </h2>
 
@@ -38,14 +38,14 @@
           name="submit"
           disabled="disabled"
           value="submit">
-    Remove all selected customers
+    Remove all selected users
   </button>
 
   <table class="govuk-table selectable-rows">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" ></th>
-        <th class="govuk-table__header" colspan="2">Customer email</th>
+        <th class="govuk-table__header" colspan="2">User email</th>
 
         <th class="govuk-table__header">
           <span class="govuk-visually-hidden">Actions</span>
@@ -54,8 +54,8 @@
     </thead>
     <tbody class="govuk-table__body" id="list-customers-paginated">
       {% for customer in customers %}
-        {{ display_dashboard_customer(
-            customer = customer,
+        {{ display_dashboard_user(
+            user = customer,
             has_remove_perm= remove_perm
           ) }}
       {% endfor %}
@@ -90,7 +90,7 @@
       {{ csrf_input }}
       <div class="govuk-form-group {% if errors and errors.customer_email %}govuk-form-group--error{% endif %}">
         <label class="govuk-label" for="customer_email">
-          Add customers by entering their email addresses (separated by spaces)
+          Add users by entering their email addresses (separated by spaces)
         </label>
         {% if errors and errors.customer_email %}
           {% for error in errors.customer_email %}
@@ -102,7 +102,7 @@
         <input id="customer_email" class="govuk-input cpanel-input" name="customer_email" autocomplete="off">
       </div>
       <div class="govuk-form-group">
-        <button class="govuk-button">Add customer</button>
+        <button class="govuk-button">Add user</button>
       </div>
     </form>
   {% endif %}
@@ -112,12 +112,12 @@
       {{ csrf_input }}
       <div class="govuk-form-group">
         <label class="govuk-label" for="{{ remove_customer_form.email.id_for_label }}">
-          Remove a customer by entering their email address
+          Remove a user by entering their email address
         </label>
         {{ remove_customer_form.email }}
       </div>
       <div class="govuk-form-group">
-        <button class="govuk-button">Remove customer</button>
+        <button class="govuk-button">Remove user</button>
       </div>
     </form>
   {% endif %}

--- a/controlpanel/frontend/jinja2/includes/admin-dashboard-list.html
+++ b/controlpanel/frontend/jinja2/includes/admin-dashboard-list.html
@@ -21,7 +21,7 @@
       </th>
       {%- endif %}
       <th class="govuk-table__header">
-        <span class="govuk-visually-hidden">Customers</span>
+        <span class="govuk-visually-hidden">Users</span>
       </th>
       <th class="govuk-table__header">
         <span class="govuk-visually-hidden">Actions</span>
@@ -52,9 +52,9 @@
           {% endif %}
         {% endfor %}
       </td>
-      {%- endif %} 
+      {%- endif %}
       <td class="govuk-table__cell">
-        <a href="{{ url('dashboard-customers', kwargs={ 'pk': dashboard.id, 'page_no': '1' }) }}" class="govuk-button govuk-button--secondary right">Manage customers</a>
+        <a href="{{ url('dashboard-customers', kwargs={ 'pk': dashboard.id, 'page_no': '1' }) }}" class="govuk-button govuk-button--secondary right">Manage users</a>
       </td>
       <td class="govuk-table__cell">
         <a class="govuk-button govuk-button--secondary right {%- if not request.user.has_perm('api.retrieve_dashboard', dashboard) %} govuk-visually-hidden{% endif %}"

--- a/controlpanel/frontend/jinja2/includes/dashboard-list.html
+++ b/controlpanel/frontend/jinja2/includes/dashboard-list.html
@@ -16,7 +16,7 @@
         {{ modal_dialog(admin_access_html|safe) }}
       </th>
       <th class="govuk-table__header">
-        <span class="govuk-visually-hidden">Customers</span>
+        <span class="govuk-visually-hidden">Users</span>
       </th>
       <th class="govuk-table__header">
         <span class="govuk-visually-hidden">Actions</span>
@@ -37,7 +37,7 @@
         {{ yes_no(user.is_dashboard_admin(dashboard.id)) }}
       </td>
       <td class="govuk-table__cell">
-        <a href="{{ url('dashboard-customers', kwargs={ 'pk': dashboard.id, 'page_no': '1' }) }}" class="govuk-button govuk-button--secondary right">Manage customers</a>
+        <a href="{{ url('dashboard-customers', kwargs={ 'pk': dashboard.id, 'page_no': '1' }) }}" class="govuk-button govuk-button--secondary right">Manage users</a>
       </td>
       <td class="govuk-table__cell">
         <a class="govuk-button govuk-button--secondary right {%- if not request.user.has_perm('api.retrieve_dashboard', dashboard) %} govuk-visually-hidden{% endif %}"

--- a/controlpanel/frontend/jinja2/modals/dashboard_customers.html
+++ b/controlpanel/frontend/jinja2/modals/dashboard_customers.html
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m">Dashboard customers</h2>
+<h2 class="govuk-heading-m">Dashboard users</h2>
 <p class="govuk-body">
   Dashboard users are able to view the dashboard. They do not have to be Control
   Panel users and any email address can be added.

--- a/controlpanel/frontend/jinja2/modals/dashboard_customers.html
+++ b/controlpanel/frontend/jinja2/modals/dashboard_customers.html
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">Dashboard customers</h2>
 <p class="govuk-body">
-  Dashboard customers are able to view the dashboard. They do not have to be Control
+  Dashboard users are able to view the dashboard. They do not have to be Control
   Panel users and any email address can be added.
 </p>

--- a/controlpanel/frontend/static/components/customers/macro.html
+++ b/controlpanel/frontend/static/components/customers/macro.html
@@ -24,25 +24,25 @@
 
 {% endmacro %}
 
-{% macro display_dashboard_customer(
-  customer = None,
+{% macro display_dashboard_user(
+  user = None,
   has_remove_perm = False
 ) %}
 
 <tr class="govuk-table__row result_rows" >
   <td class="govuk-table__cell checkbox-cell">
     <div class="govuk-checkboxes__item" >
-      <input type="checkbox" class="row-selector customer-checkbox govuk-checkboxes__input" name="customer" value="{{ customer.id }}" autocomplete="off" />
+      <input type="checkbox" class="row-selector customer-checkbox govuk-checkboxes__input" name="customer" value="{{ user.id }}" autocomplete="off" />
     </div>
   </td>
-  <td class="govuk-table__cell">{{ customer.email }}</td>
+  <td class="govuk-table__cell">{{ user.email }}</td>
 
   <td class="govuk-table__cell">
     {% if has_remove_perm %}
     <button class="govuk-button govuk-button--secondary right"
           name="customer"
-          value="{{ customer.id }}">
-      Remove customer
+          value="{{ user.id }}">
+      Remove user
     </button>
     {% endif %}
   </td>

--- a/controlpanel/frontend/views/dashboard.py
+++ b/controlpanel/frontend/views/dashboard.py
@@ -212,14 +212,14 @@ class AddDashboardCustomers(
 
     def form_invalid(self, form):
         self.request.session["customer_form_errors"] = form.errors
-        messages.error(self.request, "Could not add customer(s)")
+        messages.error(self.request, "Could not add user(s)")
         return HttpResponseRedirect(self.get_success_url())
 
     def form_valid(self, form):
         not_notified = self.get_object().add_customers(
             form.cleaned_data["customer_email"], self.request.user.justice_email
         )
-        messages.success(self.request, "Successfully added customers")
+        messages.success(self.request, "Successfully added users")
 
         if len(not_notified) > 0:
             messages.error(
@@ -249,9 +249,9 @@ class RemoveDashboardCustomerById(UpdateDashboardBaseView):
             dashboard.delete_customers_by_id(user_ids)
         except DeleteCustomerError as e:
             sentry_sdk.capture_exception(e)
-            messages.error(self.request, f"Failed removing customer{pluralize(user_ids)}")
+            messages.error(self.request, f"Failed removing user{pluralize(user_ids)}")
         else:
-            messages.success(self.request, f"Successfully removed customer{pluralize(user_ids)}")
+            messages.success(self.request, f"Successfully removed user{pluralize(user_ids)}")
 
 
 @method_decorator(feature_flag_required("register_dashboard"), name="dispatch")
@@ -278,10 +278,10 @@ class RemoveDashboardCustomerByEmail(UpdateDashboardBaseView):
         except DeleteCustomerError as e:
             sentry_sdk.capture_exception(e)
             return messages.error(
-                self.request, str(e) or f"Couldn't remove customer with email {email}"
+                self.request, str(e) or f"Couldn't remove user with email {email}"
             )
 
-        messages.success(self.request, f"Successfully removed customer {email}")
+        messages.success(self.request, f"Successfully removed user {email}")
 
 
 @method_decorator(feature_flag_required("register_dashboard"), name="dispatch")

--- a/controlpanel/frontend/views/dashboard.py
+++ b/controlpanel/frontend/views/dashboard.py
@@ -184,7 +184,7 @@ class DashboardCustomers(OIDCLoginRequiredMixin, PermissionRequiredMixin, Detail
     context_object_name = "dashboard"
     model = Dashboard
     permission_required = "api.retrieve_dashboard"
-    template_name = "dashboard-customers-list.html"
+    template_name = "dashboard-user-list.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tests/frontend/views/test_dashboard.py
+++ b/tests/frontend/views/test_dashboard.py
@@ -288,12 +288,12 @@ def test_add_customers_fail_notify(
 
 def remove_customer_success(client, response):
     messages = [str(m) for m in get_messages(response.wsgi_request)]
-    return "Successfully removed customer" in messages
+    return "Successfully removed user" in messages
 
 
 def remove_customer_failure(client, response):
     messages = [str(m) for m in get_messages(response.wsgi_request)]
-    return "Failed removing customer" in messages
+    return "Failed removing user" in messages
 
 
 @pytest.mark.parametrize(
@@ -345,9 +345,9 @@ def test_delete_cutomer_by_email_invalid_email(client, dashboard, users):
 @pytest.mark.parametrize(
     "side_effect, expected_message",
     [
-        (None, "Successfully removed customer email@example.com"),
+        (None, "Successfully removed user email@example.com"),
         # fallback to display generic message if raised without one
-        (DeleteCustomerError(), "Couldn't remove customer with email email@example.com"),
+        (DeleteCustomerError(), "Couldn't remove user with email email@example.com"),
         # specific error message displayed
         (DeleteCustomerError("API error"), "API error"),
     ],


### PR DESCRIPTION
Display"users" instead of "customers" in the dashboard management pages. Changes discussed in this [slack conversation](https://mojdt.slack.com/archives/C04M8224WCV/p1747389953579179). Screenshots below:


![image](https://github.com/user-attachments/assets/54487813-b5e9-4eaf-8712-49af6a9fb099)

![image](https://github.com/user-attachments/assets/e8e0793a-ce6b-4500-8f4c-4311921513fe)

![image](https://github.com/user-attachments/assets/8a1e86fd-5cc6-4d0c-9036-bbbab5884a2d)

![image](https://github.com/user-attachments/assets/3352f142-f39e-4127-8ff2-91b28fff0cec)

![image](https://github.com/user-attachments/assets/555b8ef8-c555-4e06-aeea-045f958f668f)

![image](https://github.com/user-attachments/assets/b8dc14ca-2e44-4c27-8f4d-1480a29b4e37)

![image](https://github.com/user-attachments/assets/267177e4-8b7e-4ab8-8057-e9dabaf68c0e)
