### PR TITLE
Fix bug checking permissions to register dashboard

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -1283,13 +1283,11 @@ class AWSQuicksight(AWSService):
             region=settings.QUICKSIGHT_ACCOUNT_REGION,
             account=settings.QUICKSIGHT_ACCOUNT_ID,
         )
-        user_permissions = []
         for permission_set in permissions:
-            if permission_set["Principal"].lower() == user_arn:
-                user_permissions = permission_set["Actions"]
-                break
+            if permission_set["Principal"].lower() == user_arn.lower():
+                return "quicksight:UpdateDashboardPermissions" in permission_set["Actions"]
 
-        return "quicksight:UpdateDashboardPermissions" in user_permissions
+        return False
 
     def generate_embed_url_for_anonymous_user(self, dashboard_arn, dashboard_id):
         return self.client.generate_embed_url_for_anonymous_user(


### PR DESCRIPTION
## :memo: Summary
This PR resolves a bug I came across in testing. We were lowercasing the principal ARN returned from AWS, but not the ARN that we generate based for the user with their email address. This resulted me being unable to register a dashboard that I had just created. This PR fixes that, and adds more thorough test cases.

Merging this PR will have the following side-effects:
- N/A

## :mag: What should the reviewer concentrate on?
- Code changes

## :technologist: How should the reviewer test these changes?
- Create a dashboard in QS in control panel
- Attempt to register it - it should succeed

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
