### PR TITLE
Refactor API auth tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ boto3==1.36.18
 celery[sqs]==5.4.0
 channels==4.2.2
 channels-redis==4.2.1
+cryptography==45.0.2
 daphne==4.1.2
 Django==5.1.4
 django-celery-beat==2.7.0


### PR DESCRIPTION
Dynamically generate test keys to remove need for hardcoded values.

The old key should only have been used in tests, but seems better to remove this and replace with dynamic keys to be on the safe side. 

There should be no need to test this locally, as long as the tests in CI pass we should be ok to merge.

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
