### PR TITLE
dashboard-auditing

### DIFF
--- a/controlpanel/api/models/dashboard.py
+++ b/controlpanel/api/models/dashboard.py
@@ -86,6 +86,7 @@ class Dashboard(TimeStampedModel):
             raise DeleteCustomerError(f"Customers with IDs {ids} not found.")
 
         self.delete_viewers(viewers)
+        return viewers
 
     def delete_customer_by_email(self, email):
         viewers = DashboardViewer.objects.filter(email=email)

--- a/controlpanel/api/views/dashboards.py
+++ b/controlpanel/api/views/dashboards.py
@@ -1,4 +1,5 @@
 # Third-party
+import structlog
 from django.db.models import Q
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -10,6 +11,8 @@ from controlpanel.api.models.dashboard import Dashboard
 from controlpanel.api.pagination import CustomPageNumberPagination
 from controlpanel.api.serializers import DashboardSerializer, DashboardUrlSerializer
 from controlpanel.utils import get_domain_from_email
+
+log = structlog.getLogger(__name__)
 
 
 class DashboardViewSet(ReadOnlyModelViewSet):
@@ -66,6 +69,7 @@ class DashboardViewSet(ReadOnlyModelViewSet):
         try:
             dashboard = self.get_object()
             serializer = DashboardUrlSerializer(dashboard)
+            log.info(f"{dashboard.name} requested by {request.query_params.get("email")}")
             return Response(serializer.data)
         except ValueError as e:
             return Response({"error": str(e)}, status=400)

--- a/controlpanel/api/views/dashboards.py
+++ b/controlpanel/api/views/dashboards.py
@@ -69,7 +69,7 @@ class DashboardViewSet(ReadOnlyModelViewSet):
         try:
             dashboard = self.get_object()
             serializer = DashboardUrlSerializer(dashboard)
-            log.info(f"{dashboard.name} requested by {request.query_params.get("email")}")
+            log.info(f"{dashboard.name} requested by {request.query_params.get('email')}")
             return Response(serializer.data)
         except ValueError as e:
             return Response({"error": str(e)}, status=400)

--- a/controlpanel/api/views/dashboards.py
+++ b/controlpanel/api/views/dashboards.py
@@ -69,7 +69,10 @@ class DashboardViewSet(ReadOnlyModelViewSet):
         try:
             dashboard = self.get_object()
             serializer = DashboardUrlSerializer(dashboard)
-            log.info(f"{dashboard.name} requested by {request.query_params.get('email')}")
+            log.info(
+                f"{dashboard.name} requested by {request.query_params.get('email')}",
+                audit="dashboard_audit",
+            )
             return Response(serializer.data)
         except ValueError as e:
             return Response({"error": str(e)}, status=400)

--- a/controlpanel/frontend/jinja2/dashboard-detail.html
+++ b/controlpanel/frontend/jinja2/dashboard-detail.html
@@ -14,14 +14,6 @@
 {% set page_name = "dashboards" %}
 {% set page_title = dashboard.name %}
 
-{% set dashboard_admins_html %}
-{% include "modals/dashboard_admins.html" %}
-{% endset %}
-
-{% set dashboard_domain_html %}
-{% include "modals/dashboard_domain_access.html" %}
-{% endset %}
-
 {% set dashboard_url_html %}
 {% include "modals/dashboard_url.html" %}
 {% endset %}
@@ -54,8 +46,9 @@
 <section class="cpanel-section">
   <h2 class="govuk-heading-m">
     Dashboard admins
-    {{ modal_dialog(dashboard_admins_html|safe) }}
   </h2>
+
+  <p class="govuk-hint">Dashboard admins can manage user access and remove the dashboard from Control Panel.</p>
 
   <table class="govuk-table app-admins form-group">
     <thead class="govuk-table__head">
@@ -133,8 +126,26 @@
 <section class="cpanel-section">
   <h2 class="govuk-heading-m">
     Domain access
-    {{ modal_dialog(dashboard_domain_html|safe) }}
   </h2>
+
+  <div role="region" class="moj-alert moj-alert--warning moj-alert--with-heading" aria-label="domain access warning" data-module="moj-alert">
+  <div>
+    <svg class="moj-alert__icon" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" height="30" width="30">
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M15 2.44922L28.75 26.1992H1.25L15 2.44922ZM13.5107 9.49579H16.4697L16.2431 17.7678H13.7461L13.5107 9.49579ZM13.1299 21.82C13.1299 21.5661 13.1787 21.3285 13.2764 21.1071C13.374 20.8793 13.5075 20.6807 13.6768 20.5114C13.8525 20.3421 14.0544 20.2087 14.2822 20.111C14.5101 20.0134 14.7542 19.9645 15.0146 19.9645C15.2686 19.9645 15.5062 20.0134 15.7275 20.111C15.9554 20.2087 16.154 20.3421 16.3232 20.5114C16.4925 20.6807 16.626 20.8793 16.7236 21.1071C16.8213 21.3285 16.8701 21.5661 16.8701 21.82C16.8701 22.0804 16.8213 22.3246 16.7236 22.5524C16.626 22.7803 16.4925 22.9789 16.3232 23.1481C16.154 23.3174 15.9554 23.4509 15.7275 23.5485C15.5062 23.6462 15.2686 23.695 15.0146 23.695C14.7542 23.695 14.5101 23.6462 14.2822 23.5485C14.0544 23.4509 13.8525 23.3174 13.6768 23.1481C13.5075 22.9789 13.374 22.7803 13.2764 22.5524C13.1787 22.3246 13.1299 22.0804 13.1299 21.82Z" fill="currentColor" />
+    </svg>
+  </div>
+  <div class="moj-alert__content">
+    Domain access allows all users with the specified email domain to see the dashboard
+    <p class="govuk-body govuk-!-font-weight-bold">Do not grant domain access to dashboards with sensitive data
+    </p>
+  </div>
+
+  <div class="moj-alert__action">
+    <button class="moj-alert__dismiss" hidden>Dismiss</button>
+  </div>
+</div>
+
+  <p class="govuk-hint"></p>
 
   <table class="govuk-table app-data-sources form-group">
     <thead class="govuk-table__head">
@@ -189,7 +200,7 @@
       {{ grant_access_form.whitelist_domain }}
     </div>
     <div class="govuk-form-group">
-      <button class="govuk-button govuk-button--secondary">
+      <button class="js-confirm govuk-button govuk-button--secondary" data-confirm-message="This will grant access to all users with an email address on this domain. If this dashboard contains sensitive data, consider who could see it. Are you sure you wish to grant domain access?">
         Grant access
       </button>
     </div>

--- a/controlpanel/frontend/jinja2/modals/dashboard_admins.html
+++ b/controlpanel/frontend/jinja2/modals/dashboard_admins.html
@@ -1,5 +1,0 @@
-<h2 class="govuk-heading-m">Dashboard admins</h2>
-<p class="govuk-body">
-  Dashboard admins are able to manage user access and can remove the dashboard
-  from Control Panel.
-</p>

--- a/controlpanel/frontend/jinja2/modals/dashboard_domain_access.html
+++ b/controlpanel/frontend/jinja2/modals/dashboard_domain_access.html
@@ -1,6 +1,0 @@
-<h3 class="govuk-heading-m" id="content-access-levels">Domain access</h3>
-<p class="govuk-body">
-  This will grant access to anybody with an email address from the domain.
-  For example, selecting justice.gov.uk will grant access to anyone with a justice email.
-</p>
-

--- a/controlpanel/frontend/views/dashboard.py
+++ b/controlpanel/frontend/views/dashboard.py
@@ -274,9 +274,9 @@ class RemoveDashboardCustomerById(UpdateDashboardBaseView):
             emails = viewers.values_list("email", flat=True)
         except DeleteCustomerError as e:
             sentry_sdk.capture_exception(e)
-            messages.error(self.request, f"Failed removing user(s) - {pluralize(user_ids)}")
+            messages.error(self.request, f"Failed removing user{pluralize(user_ids)}")
         else:
-            messages.success(self.request, f"Successfully removed user(s) {', '.join(emails)}")
+            messages.success(self.request, f"Successfully removed user{pluralize(emails)}")
             log.info(
                 f"{self.request.user.justice_email} removing {', '.join(emails)} "
                 f"access to dashboard {dashboard.name}",

--- a/controlpanel/frontend/views/dashboard.py
+++ b/controlpanel/frontend/views/dashboard.py
@@ -274,7 +274,7 @@ class RemoveDashboardCustomerById(UpdateDashboardBaseView):
             emails = viewers.values_list("email", flat=True)
         except DeleteCustomerError as e:
             sentry_sdk.capture_exception(e)
-            messages.error(self.request, f"Failed removing user(s) {', '.join(emails)}")
+            messages.error(self.request, f"Failed removing user(s) - {pluralize(user_ids)}")
         else:
             messages.success(self.request, f"Successfully removed user(s) {', '.join(emails)}")
             log.info(

--- a/controlpanel/frontend/views/dashboard.py
+++ b/controlpanel/frontend/views/dashboard.py
@@ -309,7 +309,8 @@ class RemoveDashboardCustomerByEmail(UpdateDashboardBaseView):
 
         messages.success(self.request, f"Successfully removed user {email}")
         log.info(
-            f"{self.request.user.justice_email} removing {email} access to dashboard {dashboard.name}"
+            f"{self.request.user.justice_email} removing {email} "
+            f"access to dashboard {dashboard.name}"
         )
 
 
@@ -358,6 +359,7 @@ class RevokeDomainAccess(UpdateDashboardBaseView):
         domain = DashboardDomain.objects.get(pk=kwargs["domain_id"])
         dashboard.whitelist_domains.remove(domain)
         log.info(
-            f"{self.request.user.justice_email} revoking {domain.name} wide access for dashboard {dashboard.name}"
+            f"{self.request.user.justice_email} revoking {domain.name} "
+            f"wide access for dashboard {dashboard.name}"
         )
         messages.success(self.request, f"Successfully removed {domain.name}")

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "3.3.1",
+        "@ministryofjustice/frontend": "5.1.3",
         "accessible-autocomplete": "2.0.4",
         "core-js": "3.26.1",
         "govuk-frontend": "5.8.0",
@@ -2498,18 +2498,15 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.3.1.tgz",
-      "integrity": "sha512-4npwkub8xkhp+YFUK9MIm8armTTs7hzkvT33Ijetxi6aI4Ezzym7XPv4XjQavYAewmv+CHv6WqbBCqtJrWwtmg==",
-      "dependencies": {
-        "govuk-frontend": "^5.0.0",
-        "moment": "^2.27.0"
-      },
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.3.tgz",
+      "integrity": "sha512-h6/riC6zDo5scevzZz1RByRo3AnX4k2ywFMTX47Irq9y7keyhalyfO5D0+VAJMpX0ADuNLg3f2tJh+cumH/PBA==",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "jquery": "^3.6.0"
+        "govuk-frontend": "^5.8.0",
+        "moment": "2.30.1"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -3410,9 +3407,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7214,9 +7211,10 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -10544,13 +10542,10 @@
       }
     },
     "@ministryofjustice/frontend": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.3.1.tgz",
-      "integrity": "sha512-4npwkub8xkhp+YFUK9MIm8armTTs7hzkvT33Ijetxi6aI4Ezzym7XPv4XjQavYAewmv+CHv6WqbBCqtJrWwtmg==",
-      "requires": {
-        "govuk-frontend": "^5.0.0",
-        "moment": "^2.27.0"
-      }
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.3.tgz",
+      "integrity": "sha512-h6/riC6zDo5scevzZz1RByRo3AnX4k2ywFMTX47Irq9y7keyhalyfO5D0+VAJMpX0ADuNLg3f2tJh+cumH/PBA==",
+      "requires": {}
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -11159,9 +11154,9 @@
       "optional": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -13946,9 +13941,10 @@
       }
     },
     "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/ministryofjustice/analytics-platform-control-panel.git",
   "license": "MIT",
   "dependencies": {
-    "@ministryofjustice/frontend": "3.3.1",
+    "@ministryofjustice/frontend": "5.1.3",
     "govuk-frontend": "5.8.0",
     "accessible-autocomplete": "2.0.4",
     "core-js": "3.26.1",

--- a/tests/frontend/views/test_dashboard.py
+++ b/tests/frontend/views/test_dashboard.py
@@ -289,12 +289,21 @@ def test_add_customers_fail_notify(
 
 def remove_customer_success(client, response):
     messages = [str(m) for m in get_messages(response.wsgi_request)]
-    return "Successfully removed user" in messages
+    for message in messages:
+        if "Successfully removed user(s)" in message:
+            return True
+
+    return False
 
 
 def remove_customer_failure(client, response):
     messages = [str(m) for m in get_messages(response.wsgi_request)]
-    return "Failed removing user" in messages
+    for message in messages:
+        if "Failed removing user(s)" in message:
+            return True
+
+    return False
+    return "" in messages
 
 
 @pytest.mark.parametrize(

--- a/tests/frontend/views/test_dashboard.py
+++ b/tests/frontend/views/test_dashboard.py
@@ -290,7 +290,7 @@ def test_add_customers_fail_notify(
 def remove_customer_success(client, response):
     messages = [str(m) for m in get_messages(response.wsgi_request)]
     for message in messages:
-        if "Successfully removed user(s)" in message:
+        if "Successfully removed user" in message:
             return True
 
     return False
@@ -299,7 +299,7 @@ def remove_customer_success(client, response):
 def remove_customer_failure(client, response):
     messages = [str(m) for m in get_messages(response.wsgi_request)]
     for message in messages:
-        if "Failed removing user(s)" in message:
+        if "Failed removing user" in message:
             return True
 
     return False


### PR DESCRIPTION


<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary


This PR adds logging to output when someone adds/removes admins/domains/users for dashboards. Removed modals and added messages as part of domain and dashboard admin sections

The changes in this PR are needed to audit what is happening with regards to dashboards.

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required

