### PR TITLE
Set textract/comprehend by default when creating a new user. 

### DIFF
--- a/controlpanel/api/cluster.py
+++ b/controlpanel/api/cluster.py
@@ -56,6 +56,7 @@ BASE_ASSUME_ROLE_POLICY = {
 
 BEDROCK_POLICY_NAME = "analytical-platform-bedrock-integration"
 TEXTRACT_POLICY_NAME = "analytical-platform-textract-integration"
+COMPREHEND_POLICY_NAME = "analytical-platform-comprehend-integration"
 
 
 class AWSRoleCategory(str, Enum):
@@ -190,6 +191,8 @@ class User(EntityResource):
 
     ATTACH_POLICIES = [
         READ_INLINE_POLICIES,
+        TEXTRACT_POLICY_NAME,
+        COMPREHEND_POLICY_NAME,
         "airflow-dev-ui-access",
         "airflow-prod-ui-access",
     ]

--- a/controlpanel/api/tasks/__init__.py
+++ b/controlpanel/api/tasks/__init__.py
@@ -11,3 +11,4 @@ from controlpanel.api.tasks.s3bucket import (
     S3BucketRevokeAppAccess,
     S3BucketRevokeUserAccess,
 )
+from controlpanel.api.tasks.update_policy import update_policy

--- a/controlpanel/api/tasks/update_policy.py
+++ b/controlpanel/api/tasks/update_policy.py
@@ -1,0 +1,14 @@
+# Third-party
+import structlog
+from celery import shared_task
+from django.core.management import call_command
+
+log = structlog.getLogger(__name__)
+
+
+@shared_task(acks_on_failure_or_timeout=False)
+def update_policy(policy_name, attach=True):
+    """
+    This will add/remove a policy for all users
+    """
+    call_command("update_policy_for_all_users", "--policy-name", policy_name, "--attach", attach)

--- a/controlpanel/cli/management/commands/update_policy_for_all_users.py
+++ b/controlpanel/cli/management/commands/update_policy_for_all_users.py
@@ -1,0 +1,50 @@
+# Third-party
+import botocore
+from django.core.management.base import BaseCommand
+
+# First-party/Local
+from controlpanel.api import cluster
+from controlpanel.api.models.user import User
+
+
+class Command(BaseCommand):
+    help = "Attaches a policy to all users"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--policy-name",
+            "-pn",
+            type=str,
+            help="Name of the policy to attach to all users",
+        )
+
+        parser.add_argument(
+            "--attach",
+            "-a",
+            default=True,
+            type=lambda x: (str(x).lower() == "true"),
+            help="whether to attach or remove policy",
+        )
+
+    def handle(self, *args, **options):
+        policy_name = options.get("policy_name", None)
+        attach = options.get("attach")
+
+        if not policy_name:
+            self.stdout.write("Please provide a policy name using --policy-name")
+            return
+
+        users = User.objects.filter(auth0_id__startswith="github|")
+
+        for user in users:
+            try:
+                cluster.User(user).update_policy_attachment(policy=policy_name, attach=attach)
+            except botocore.exceptions.ClientError as e:
+                if e.response["Error"]["Code"] == "NoSuchEntity":
+                    self.stdout.write(f"Failed to attach policy to user '{user.username}': {e}")
+
+                    if "does not exist or is not attachable" in e.response["Error"]["Message"]:
+                        raise e
+                elif e.response["Error"]["Code"] == "InvalidInput":
+                    self.stdout.write(f"Policy name is invalid: {e}")
+                    raise e

--- a/tests/api/fixtures/aws.py
+++ b/tests/api/fixtures/aws.py
@@ -229,6 +229,29 @@ def textract_policy(iam):
 
 
 @pytest.fixture(autouse=True)
+def comprehend_policy(iam):
+    result = iam.meta.client.create_policy(
+        PolicyName="analytical-platform-comprehend-integration",
+        PolicyDocument=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "ComprehendEnable",
+                        "Effect": "Allow",
+                        "Action": ["iam:AllowComprehend"],
+                        "Resource": [
+                            "arn:aws:iam::{settings.AWS_DATA_ACCOUNT_ID}:role/{settings.ENV}_user_*"  # noqa: E501
+                        ],
+                    },
+                ],
+            }
+        ),
+    )
+    return result["Policy"]
+
+
+@pytest.fixture(autouse=True)
 def test_policy(iam):
     result = iam.meta.client.create_policy(
         PolicyName="a-test-policy",

--- a/tests/api/tasks/test_update_policy_for_all_users.py
+++ b/tests/api/tasks/test_update_policy_for_all_users.py
@@ -1,0 +1,29 @@
+# Third-party
+import botocore
+import pytest
+
+# First-party/Local
+from controlpanel.api.models import User
+from controlpanel.api.tasks.update_policy import update_policy
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "policy, attach", [("a-test-policy", True), ("analytical-platform-textract-integration", False)]
+)
+def test_update_policy(iam, users, policy, attach):
+    base_arn = "arn:aws:iam::123456789012:policy"
+    update_policy(policy, attach)
+    role = iam.Role(users["superuser"].iam_role_name)
+    attached_policies = list(role.attached_policies.all())
+    arns = [policy.arn for policy in attached_policies]
+    if attach:
+        assert f"{base_arn}/{policy}" in arns
+    else:
+        assert f"{base_arn}/{policy}" not in arns
+
+
+@pytest.mark.django_db
+def test_update_policy_error(users):
+    with pytest.raises(botocore.exceptions.ClientError):
+        update_policy("non-existant-policy", True)

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -98,7 +98,9 @@ def test_create_app_role(iam):
     assert ec2_assume_role(pd["Statement"][0])
 
 
-def test_create_user_role(iam, managed_policy, airflow_dev_policy, airflow_prod_policy):
+def test_create_user_role(
+    iam, managed_policy, airflow_dev_policy, airflow_prod_policy, textract_policy, comprehend_policy
+):
     """
     Ensure EKS settngs are in the policy document when running on that
     infrastructure.
@@ -122,11 +124,13 @@ def test_create_user_role(iam, managed_policy, airflow_dev_policy, airflow_prod_
     assert eks_assume_role(pd["Statement"][2], user)
 
     attached_policies = list(role.attached_policies.all())
-    assert len(attached_policies) == 3
+    assert len(attached_policies) == 5
     arns = [policy.arn for policy in attached_policies]
     assert managed_policy["Arn"] in arns
     assert airflow_dev_policy["Arn"] in arns
     assert airflow_prod_policy["Arn"] in arns
+    assert textract_policy["Arn"] in arns
+    assert comprehend_policy["Arn"] in arns
 
 
 @pytest.fixture
@@ -609,7 +613,7 @@ def test_delete_policy(iam, superuser, group):
     role = iam.Role("test_user_alice")
     aws.AWSPolicy().update_policy_members(group.arn, set([role.name]))
 
-    assert len(list(role.attached_policies.all())) == 4
+    assert len(list(role.attached_policies.all())) == 6
 
     try:
         aws.AWSPolicy().delete_policy(group.arn)
@@ -622,7 +626,7 @@ def test_delete_policy(iam, superuser, group):
     # with pytest.raises(iam.meta.client.exceptions.NoSuchEntityException):
     #     iam.Policy(group_arn).load()
 
-    assert len(list(role.attached_policies.all())) == 3
+    assert len(list(role.attached_policies.all())) == 5
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR is linked to ministryofjustice/analytical-platform#8027

This PR grants textract and comprehend to users on creation. It also implements a management command that can add or remove a policy to all IAM users. A celery task has also been implemented to perform the task via django admin

The changes in this PR are needed because users should be able to access this by default.

Merging this PR will have the following side-effects:
- <!-- Users who could previously could only do Y will now also be able to do Z -->

## :mag: What should the reviewer concentrate on?

- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Pull down branch and run
- Run the task against your existing user in the control panel

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] Documentation will be added in the future
