### PR TITLE
Fix the admin helptext on Dashboard list page

### DIFF
--- a/controlpanel/frontend/jinja2/includes/dashboard-list.html
+++ b/controlpanel/frontend/jinja2/includes/dashboard-list.html
@@ -2,7 +2,7 @@
 {% from "includes/yesno.html" import yes_no %}
 
 {% set admin_access_html %}
-{% include "modals/app_admins.html" %}
+{% include "modals/dashboard_admins.html" %}
 {% endset %}
 
 {% macro dashboard_list(dashboards, user) %}

--- a/controlpanel/frontend/jinja2/modals/dashboard_admins.html
+++ b/controlpanel/frontend/jinja2/modals/dashboard_admins.html
@@ -1,0 +1,4 @@
+<h2 class="govuk-heading-m">Dashboard admins</h2>
+<p class="govuk-body">
+  An admin of a dashboard can manage user access, grant new admins and remove the dashboard from Control Panel.
+</p>


### PR DESCRIPTION
Fix the dashboard admin modal helptext so that it refers to Dashboards, not apps:

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/7d0002e8-543f-4f73-b092-0229ad00bd62" />
