### PR TITLE
Avoid 500 error when displaying dates

### DIFF
--- a/controlpanel/utils.py
+++ b/controlpanel/utils.py
@@ -313,4 +313,7 @@ def govuk_notify_send_email(email_address, template_id, personalisation, raise_e
 
 
 def format_uk_time(dt):
+    # avoid raising a 500 error due to missing value
+    if not dt:
+        return None
     return localtime(dt, timezone=UK_TZ).strftime("%-d %b %Y, %H:%M")


### PR DESCRIPTION
If a date is missing I dont want a 500 error to bring down the whole site - particularly for Pager Duty alerts, where we are reliant on those values coming upstream from Pager Duty. This change means that if a date is missing, we return `None`