### PR TITLE
Remove button to open dev Airflow link

### DIFF
--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -110,13 +110,6 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <button class="govuk-button govuk-button--secondary govuk-!-margin-right-1 govuk-!-margin-top-0 tool-action"
-      data-action-name="open"
-      onclick="window.open('{{ managed_airflow_dev_url }}', '_blank');"
-      rel="noopener"
-      target="_blank">
-        Open dev
-    </button>
-    <button class="govuk-button govuk-button--secondary govuk-!-margin-right-1 govuk-!-margin-top-0 tool-action"
     data-action-name="open prod"
     onclick="window.open('{{ managed_airflow_prod_url }}', '_blank');"
     rel="noopener"


### PR DESCRIPTION
We have shut down Airflow-Dev as part of our migration to new Airflow. This removes now defunct link.

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/1bee34ce-d20c-4427-aa7b-8896d56d5c9a" />
