### PR TITLE
Update tool URL when changing tool choice

### DIFF
--- a/controlpanel/api/models/tool.py
+++ b/controlpanel/api/models/tool.py
@@ -15,6 +15,7 @@ from django_extensions.db.models import TimeStampedModel
 # First-party/Local
 from controlpanel.api import cluster, helm
 from controlpanel.api.tasks.tools import uninstall_helm_release
+from controlpanel.utils import build_tool_url
 
 log = structlog.getLogger(__name__)
 
@@ -245,11 +246,7 @@ class ToolDeployment(TimeStampedModel):
 
     @property
     def url(self):
-        tool = self.tool.tool_domain or self.tool.chart_name
-        url = f"https://{self.user.slug}-{tool}.{settings.TOOLS_DOMAIN}/"
-        if self.tool_type == self.ToolType.VSCODE:
-            url = f"{url}?folder=/home/analyticalplatform/workspace"
-        return url
+        return build_tool_url(tool=self.tool, user=self.user)
 
     @property
     def k8s_namespace(self):

--- a/controlpanel/frontend/jinja2/tool-list.html
+++ b/controlpanel/frontend/jinja2/tool-list.html
@@ -55,7 +55,7 @@
 
     <button class="govuk-button govuk-button--secondary govuk-!-margin-right-1 govuk-!-margin-top-0 tool-action"
       data-action-name="open"
-      onclick="window.open('{{ tool_form.deployment.url }}', '_blank');"
+      onclick="window.open('{{ tool_form.tool_url }}', '_blank');"
       rel="noopener"
       target="_blank"
       id="open-{{ tool_form.tool_type }}"

--- a/controlpanel/frontend/static/javascripts/modules/tool-status.js
+++ b/controlpanel/frontend/static/javascripts/modules/tool-status.js
@@ -145,7 +145,6 @@ moj.Modules.toolStatus = {
   versionSelectChanged(target) {
     const selected = target.options[target.options.selectedIndex];
     const classes = selected.className.split(" ");
-
     const notInstalledSelected = classes.indexOf(this.versionNotInstalledClass) !== -1;
     const installedSelected = classes.indexOf(this.versionInstalledClass) !== -1;
 
@@ -158,6 +157,8 @@ moj.Modules.toolStatus = {
     // the "Deploy" button needs to be disabled
     deployButton.disabled = notInstalledSelected || installedSelected;
     openButton.disabled = !installedSelected;
+    const toolUrl = selected.attributes["data-tool-url"].value;
+    openButton.setAttribute("onclick", `window.open('${toolUrl}', '_blank');`);
     restartButton.disabled = !installedSelected;
 
     this.toggleDeprecationMessage(selected, targetTool);

--- a/controlpanel/utils.py
+++ b/controlpanel/utils.py
@@ -317,3 +317,11 @@ def format_uk_time(dt):
     if not dt:
         return None
     return localtime(dt, timezone=UK_TZ).strftime("%-d %b %Y, %H:%M")
+
+
+def build_tool_url(tool, user):
+    domain_part = tool.tool_domain or tool.chart_name
+    url = f"https://{user.slug}-{domain_part}.{settings.TOOLS_DOMAIN}/"
+    if tool.chart_name == tool.VSCODE_CHART_NAME:
+        url += "?folder=/home/analyticalplatform/workspace"
+    return url


### PR DESCRIPTION
## :memo: Summary
This PR resolves https://github.com/ministryofjustice/analytical-platform/issues/8187

Use JS to update the URL of the deployed tool whenever a tool choice is made in the form.

Refactors logic to a util function so that it can be used in form and models. Update the ToolChoice widget to use the new util function. This ensures that if any tool used a different URL for some reason (due to the `tool_domain` value being set differently on the `Tool`) the correct url will be used.

Merging this PR will have the following side-effects:
- Should not be any

## :mag: What should the reviewer concentrate on?
- Feedback on specific parts of the code
- Check side effects, if any

## :technologist: How should the reviewer test these changes?
- Run the server/background worker/celery locally
- Delete your current `ToolDeployment` for one of the tools (you can do this via the django admin)
- Load the "Your tools" page - you should not have any existing tool selected
- Select a tool, click deploy and wait for it to be available
- Ensure that the tool release you are deploying is configured correctly - copy one you know that works from the dev site if necessary
- When ready click the "Open" button - it should take you to the correct tool URL in a new tab

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [x] No changes to the documentation are required
- [ ] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
