### PR TITLE
login-fail-message

### DIFF
--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -14,6 +14,8 @@
             </a>
         </p>
 
+        <p>If you are seeing this page after multiple login attempts, you may be using your email to log into the control panel instead of using your GitHub account. Please try logging in using the Continue with GitHub button instead of filling out the email address field.</p>
+
         <p>
             If refreshing your session fails
 


### PR DESCRIPTION

<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR is linked to ministryofjustice/analytical-platform#8350

This PR adds a message to inform users that are logging in using email to use their github identity instead.

The changes in this PR are needed because we have had several instances of people using the email form instead of the github button since changing over to the universal login page.
