### PR TITLE
Prompt users to log in with GitHub

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+## CVE-2025-47907 (usr/local/bin/helm)
+CVE-2025-47907

--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -6,24 +6,35 @@
 {% block content %}
 <div class="govuk-grid-row" id="reset-container">
     <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-l">Your session has expired</h2>
+        {% if show_github_login_prompt %}
+            <h2 class="govuk-heading-l">Please log in with GitHub</h2>
 
-        <p>
-            <a href="{{ auth0_logout_url }}?returnTo={{ request.scheme }}%3A%2F%2F{{ request.get_host() }}%2Foidc%2Flogout%2F">
-                Click here to refresh your session
-            </a>
-        </p>
+            <p>
+                You must use GitHub to log in rather than your email.<a href="{{ auth0_logout_url }}?returnTo={{ request.scheme }}%3A%2F%2F{{ request.get_host() }}%2Foidc%2Flogout%2F">
+                    Click here to log in again
+                </a>
+            </p>
+        {% else %}
 
-        <p>
-            If refreshing your session fails
+            <h2 class="govuk-heading-l">Your session has expired</h2>
 
-        <ul class="govuk-list govuk-list--bullet">
-            <li>You may need to ensure you are in the <a href="https://github.com/moj-analytical-services">MoJ
-                    Analytical Services</a> team on GitHub.</li>
-            <li>You may have migrated to a newer version of the platform, so your account on this version is no longer
-                available.</li>
-        </ul>
-        </p>
+            <p>
+                <a href="{{ auth0_logout_url }}?returnTo={{ request.scheme }}%3A%2F%2F{{ request.get_host() }}%2Foidc%2Flogout%2F">
+                    Click here to refresh your session
+                </a>
+            </p>
+
+            <p>
+                If refreshing your session fails
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>You may need to ensure you are in the <a href="https://github.com/moj-analytical-services">MoJ
+                        Analytical Services</a> organisation on GitHub.</li>
+                <li>You may have migrated to a newer version of the platform, so your account on this version is no longer
+                    available.</li>
+            </ul>
+            </p>
+        {% endif %}
         <p>Alternatively, please refer to our guide for
             <a href="https://user-guidance.analytical-platform.service.justice.gov.uk/get-started.html">getting started on the
                 Analytical Platform</a>

--- a/controlpanel/frontend/jinja2/login-fail.html
+++ b/controlpanel/frontend/jinja2/login-fail.html
@@ -10,7 +10,7 @@
             <h2 class="govuk-heading-l">Please log in with GitHub</h2>
 
             <p>
-                You must use GitHub to log in rather than your email.<a href="{{ auth0_logout_url }}?returnTo={{ request.scheme }}%3A%2F%2F{{ request.get_host() }}%2Foidc%2Flogout%2F">
+                You must use GitHub to log in rather than your email. <a href="{{ auth0_logout_url }}?returnTo={{ request.scheme }}%3A%2F%2F{{ request.get_host() }}%2Foidc%2Flogout%2F">
                     Click here to log in again
                 </a>
             </p>

--- a/controlpanel/frontend/views/login_fail.py
+++ b/controlpanel/frontend/views/login_fail.py
@@ -7,11 +7,13 @@ from controlpanel.api.models.user import User  # noqa: F401
 
 
 class LoginFail(TemplateView):
+    ERROR_USE_GITHUB = "use_github"
+
     template_name = "login-fail.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["environment"] = settings.ENV
         context["auth0_logout_url"] = settings.AUTH0["logout_url"]
-
+        context["show_github_login_prompt"] = self.request.GET.get("error") == self.ERROR_USE_GITHUB
         return context

--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -1,7 +1,7 @@
 # Standard library
 import base64
 import hashlib
-from urllib.parse import urlencode
+from urllib.parse import quote_plus, urlencode
 
 # Third-party
 import structlog
@@ -107,7 +107,7 @@ class StateMismatchHandler(OIDCAuthenticationCallbackView):
     @property
     def failure_url(self):
         error = self.request.GET.get("error_description", "")
-        return f"{settings.LOGIN_REDIRECT_URL_FAILURE}?error={error}"
+        return f"{settings.LOGIN_REDIRECT_URL_FAILURE}?error={quote_plus(error)}"
 
 
 def logout(request):

--- a/controlpanel/oidc.py
+++ b/controlpanel/oidc.py
@@ -104,6 +104,11 @@ class StateMismatchHandler(OIDCAuthenticationCallbackView):
 
         return super().success_url
 
+    @property
+    def failure_url(self):
+        error = self.request.GET.get("error_description", "")
+        return f"{settings.LOGIN_REDIRECT_URL_FAILURE}?error={error}"
+
 
 def logout(request):
     params = urlencode(

--- a/tests/frontend/views/test_login_fail.py
+++ b/tests/frontend/views/test_login_fail.py
@@ -1,22 +1,77 @@
 # Third-party
 import pytest
+from django.conf import settings
 
 # First-party/Local
 from controlpanel.frontend.views.login_fail import LoginFail
 
 
-@pytest.mark.parametrize(
-    "error, should_show_prompt",
-    [(LoginFail.ERROR_USE_GITHUB, True), ("Access denied", False), ("", False), (None, False)],
-)
-def test_login_fail_show_github_error(rf, error, should_show_prompt):
-    query_params = {"error": error}
-    if not error:
-        query_params = {}
-    request = rf.get("/", query_params=query_params)
-    view = LoginFail()
-    view.request = request
+class TestLoginFailView:
+    """Test suite for the LoginFail view."""
 
-    context = view.get_context_data()
+    @pytest.mark.parametrize(
+        "error, should_show_prompt",
+        [
+            (LoginFail.ERROR_USE_GITHUB, True),
+            ("Access denied", False),
+            ("session_expired", False),
+            ("invalid_state", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_show_github_login_prompt_logic(self, rf, error, should_show_prompt):
+        """Test that GitHub login prompt is only shown for the specific GitHub error."""
+        query_params = {"error": error} if error is not None else {}
+        request = rf.get("/", query_params=query_params)
+        view = LoginFail()
+        view.request = request
 
-    assert context["show_github_login_prompt"] is should_show_prompt
+        context = view.get_context_data()
+
+        assert context["show_github_login_prompt"] is should_show_prompt
+
+    def test_context_data_values(self, rf):
+        """Test that context variables have correct values from settings."""
+        request = rf.get("/")
+        view = LoginFail()
+        view.request = request
+
+        context = view.get_context_data()
+
+        # Test the application-specific logic
+        assert context["environment"] == settings.ENV
+        assert context["auth0_logout_url"] == settings.AUTH0["logout_url"]
+        assert context["show_github_login_prompt"] is False  # No error param
+
+    def test_context_data_with_github_error(self, rf):
+        """Test context data when GitHub error is present."""
+        request = rf.get("/", query_params={"error": LoginFail.ERROR_USE_GITHUB})
+        view = LoginFail()
+        view.request = request
+
+        context = view.get_context_data()
+
+        assert context["show_github_login_prompt"] is True
+        # Verify other context remains correct
+        assert context["environment"] == settings.ENV
+        assert context["auth0_logout_url"] == settings.AUTH0["logout_url"]
+
+    @pytest.mark.parametrize(
+        "error_value, expected_show_prompt",
+        [
+            ("use_github", True),  # Exact match
+            ("USE_GITHUB", False),  # Case sensitivity
+            ("use_github_auth", False),  # Partial match
+            (" use_github ", False),  # Whitespace
+        ],
+    )
+    def test_github_error_exact_match_required(self, rf, error_value, expected_show_prompt):
+        """Test that GitHub error detection requires exact string match."""
+        request = rf.get("/", query_params={"error": error_value})
+        view = LoginFail()
+        view.request = request
+
+        context = view.get_context_data()
+
+        assert context["show_github_login_prompt"] is expected_show_prompt

--- a/tests/frontend/views/test_login_fail.py
+++ b/tests/frontend/views/test_login_fail.py
@@ -1,0 +1,22 @@
+# Third-party
+import pytest
+
+# First-party/Local
+from controlpanel.frontend.views.login_fail import LoginFail
+
+
+@pytest.mark.parametrize(
+    "error, should_show_prompt",
+    [(LoginFail.ERROR_USE_GITHUB, True), ("Access denied", False), ("", False), (None, False)],
+)
+def test_login_fail_show_github_error(rf, error, should_show_prompt):
+    query_params = {"error": error}
+    if not error:
+        query_params = {}
+    request = rf.get("/", query_params=query_params)
+    view = LoginFail()
+    view.request = request
+
+    context = view.get_context_data()
+
+    assert context["show_github_login_prompt"] is should_show_prompt

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock, patch
 # Third-party
 import pytest
 from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
+from mozilla_django_oidc.views import OIDCAuthenticationCallbackView
 
 # First-party/Local
 from controlpanel.oidc import OIDCSubAuthenticationBackend, StateMismatchHandler
@@ -70,16 +72,84 @@ def test_get_justice_email(email, expected):
 
 
 @pytest.mark.parametrize(
-    "error_description",
+    "error_description, expected_encoded",
     [
-        "use_github",
-        "access_denied",
-        "foo",
-        "",
+        ("use_github", "use_github"),
+        ("access_denied", "access_denied"),
+        ("session_expired", "session_expired"),
+        ("error with spaces", "error+with+spaces"),
+        ("error&with=special&chars", "error%26with%3Dspecial%26chars"),
+        ("", ""),
     ],
 )
-def test_failure_url(rf, error_description):
+def test_failure_url(rf, error_description, expected_encoded):
+    """
+    Test that failure_url properly formats and encodes the login failure URL with error parameter.
+    """
     request = rf.get("/", query_params={"error_description": error_description})
     view = StateMismatchHandler()
     view.request = request
-    assert view.failure_url == f"/login-fail/?error={error_description}"
+    assert view.failure_url == f"/login-fail/?error={expected_encoded}"
+
+
+@pytest.mark.parametrize(
+    "query_params, expected_error",
+    [
+        ({"error_description": "invalid_state"}, "invalid_state"),
+        ({"other_param": "value"}, ""),  # No error_description param
+        ({}, ""),  # No query params
+    ],
+)
+def test_failure_url_edge_cases(rf, query_params, expected_error):
+    """Test failure_url property handles edge cases correctly."""
+    request = rf.get("/", query_params=query_params)
+    view = StateMismatchHandler()
+    view.request = request
+    expected_url = f"{settings.LOGIN_REDIRECT_URL_FAILURE}?error={expected_error}"
+    assert view.failure_url == expected_url
+
+
+@pytest.mark.parametrize(
+    "exception_message",
+    [
+        "State mismatch detected",
+        "Invalid state parameter",
+        "CSRF verification failed",
+    ],
+)
+@patch("controlpanel.oidc.log")
+def test_state_mismatch_handler_exception_handling(mock_log, rf, exception_message):
+    """Test that StateMismatchHandler properly handles SuspiciousOperation exceptions."""
+    request = rf.get("/callback/")
+    view = StateMismatchHandler()
+    view.request = request
+
+    with patch.object(OIDCAuthenticationCallbackView, "get") as mock_super_get:
+        mock_super_get.side_effect = SuspiciousOperation(exception_message)
+
+        response = view.get(request)
+
+        # Verify logging
+        mock_log.warning.assert_called_once_with(
+            f"Caught {exception_message}: redirecting to login"
+        )
+
+        # Verify redirect
+        assert response.status_code == 302
+        assert response.url == settings.LOGIN_REDIRECT_URL_FAILURE
+
+
+def test_state_mismatch_handler_successful_flow(rf):
+    """Test that StateMismatchHandler passes through successful authentication."""
+    request = rf.get("/callback/")
+    view = StateMismatchHandler()
+    view.request = request
+
+    mock_response = Mock()
+    mock_response.status_code = 302
+    mock_response.url = "/tools/"
+
+    with patch.object(OIDCAuthenticationCallbackView, "get", return_value=mock_response):
+        response = view.get(request)
+
+        assert response == mock_response

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -67,3 +67,19 @@ def test_create_user(email, name, expected_name, expected_justice_email):
 )
 def test_get_justice_email(email, expected):
     assert OIDCSubAuthenticationBackend().get_justice_email(email) == expected
+
+
+@pytest.mark.parametrize(
+    "error_description",
+    [
+        "use_github",
+        "access_denied",
+        "foo",
+        "",
+    ],
+)
+def test_failure_url(rf, error_description):
+    request = rf.get("/", query_params={"error_description": error_description})
+    view = StateMismatchHandler()
+    view.request = request
+    assert view.failure_url == f"/login-fail/?error={error_description}"


### PR DESCRIPTION

<!-- The title of this PR should complete the sentence: “Merging this PR will ...” -->

## :memo: Summary
This PR resolves https://github.com/ministryofjustice/analytical-platform/issues/8350

Catch error description before redirecting to login fail page. Then conditionally display a message to users instructing them to log in with GitHub.

In order for this to work, I have updated the `auth0-authorization-extension` action in the auth0 dev tenant, to check if the client is Control Panel and then:
- Deny access early, to stop it getting to the point lower down in the code where it tries to check the users role and permissions. This is not necessary for Control Panel.
- Return "use_github" as the error description

The changes in this PR are needed because we recently migrated to the new Universal Login page in Auth0. This was required to enable EntraID as an auth method in Dashboard Service. However a side effect to this was it lets any users use the email field on the login page where the "Passwordless" connection is enabled. Even though we dont use this connection for logging in to Control Panel, we need to have it enabled so that app owners and dashboard admins can manage access to their apps/dashboards (when it is disabled, adding users fails).

For Control Panel, the email field is intended only for CICA users - but if other users try to use it, it will now start the "passwordless" email code login process. Users would then enter the code to log in, but get the standard "Login fail" page.  We have had a number of support requests related to this in the last few weeks.

By showing a clear error message to log in with GitHub, this should hopefully help our users and reduce the number of support queries we get related to it. Screenshot of the error page:

<img width="1840" height="1167" alt="image" src="https://github.com/user-attachments/assets/a0cca5ad-2982-4117-b04e-fec3cc6e6a09" />



## :mag: What should the reviewer concentrate on?
- Text on the error page
- Code changes

## :technologist: How should the reviewer test these changes?
- Run the app locally, ensure you are logged out
- Go to log in, enter your email address instead of using GitHub
- Check your email for the log in code, and enter it
- You should be redirected to the error page prompting you to log in with GitHub

## :books: Documentation status
<!-- If documentation is left until later, you must explain why and create a ticket for it -->
- [ ] No changes to the documentation are required
- [x] This PR includes all relevant documentation
- [ ] Documentation will be added in the future because ... (see issue #...)
