### PR TITLE
Fix link to app guidance

### DIFF
--- a/controlpanel/frontend/jinja2/webapp-create.html
+++ b/controlpanel/frontend/jinja2/webapp-create.html
@@ -51,7 +51,7 @@
 <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 <p class="govuk-body">
   After <a
-    href="{{ user_guidance_base_url }}/rshiny-app.html">creating
+    href="{{ user_guidance_base_url }}/apps/rshiny-app.html">creating
     an app in Github</a>, use this form to register your app and connect it to
   sensitive data in S3.
 </p>


### PR DESCRIPTION
Fix a typo in the link to the user guidance for registering apps