### PR TITLE
Revert numpy version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "numpy"
+        versions: [ ">=2.0.0" ]
     groups:
       production-dependencies:
         dependency-type: "production"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,7 +4,7 @@ flake8==7.3.0
 ipdb==0.13.13
 ipython==8.29.0
 isort==6.0.1
-numpy==2.0.2
+numpy==1.26.0
 pandas==2.3.1
 pipdeptree==2.28.0
 pre-commit==4.2.0


### PR DESCRIPTION
Updating to 2.0.0 causes breaking changes when running locally. This reverts the version and ignores dependabot updates for numpy.
