### PR TITLE
Create S3 buckets without celery

### DIFF
--- a/controlpanel/api/aws.py
+++ b/controlpanel/api/aws.py
@@ -14,6 +14,7 @@ from django.conf import settings
 
 # First-party/Local
 from controlpanel.api.aws_auth import AWSCredentialSessionSet
+from controlpanel.api.exceptions import BucketAlreadyExistsError
 from controlpanel.api.models.justice_domain import JusticeDomain
 
 log = structlog.getLogger(__name__)
@@ -710,9 +711,16 @@ class AWSBucket(AWSService):
             if is_data_warehouse:
                 self._tag_bucket(bucket, {"buckettype": "datawarehouse"})
 
-        except s3_resource.meta.client.exceptions.BucketAlreadyOwnedByYou:
+        except s3_resource.meta.client.exceptions.BucketAlreadyOwnedByYou as error:
             log.warning(f"Skipping creating Bucket {bucket_name}: Already exists")
-            return
+            raise BucketAlreadyExistsError(
+                f"Bucket name '{bucket_name}' is not available"
+            ) from error
+        except s3_resource.meta.client.exceptions.BucketAlreadyExists as error:
+            log.warning(f"Skipping creating Bucket {bucket_name}: Already exists (other account)")
+            raise BucketAlreadyExistsError(
+                f"Bucket name '{bucket_name}' is not available"
+            ) from error
 
         bucket.Logging().put(
             BucketLoggingStatus={

--- a/controlpanel/api/exceptions.py
+++ b/controlpanel/api/exceptions.py
@@ -26,3 +26,9 @@ class QuicksightAccessError(Exception):
     """Raised when granting or revoking QuickSight access fails."""
 
     pass
+
+
+class BucketAlreadyExistsError(Exception):
+    """Raised when an S3 bucket name is not available."""
+
+    pass

--- a/controlpanel/api/models/s3bucket.py
+++ b/controlpanel/api/models/s3bucket.py
@@ -75,6 +75,7 @@ class S3Bucket(TimeStampedModel):
     def __init__(self, *args, **kwargs):
         """Overwrite this constructor to pass some non-field parameter"""
         self.bucket_owner = kwargs.pop("bucket_owner", cluster.AWSRoleCategory.user)
+        self._dispatch_create_task_on_save = kwargs.pop("dispatch_task", True)
         super().__init__(*args, **kwargs)
 
     def __repr__(self):
@@ -147,6 +148,13 @@ class S3Bucket(TimeStampedModel):
         if not is_create:
             return self
 
+        if self._dispatch_create_task_on_save:
+            self._dispatch_create_task(**kwargs)
+        self._grant_creator_access()
+
+        return self
+
+    def _dispatch_create_task(self, **kwargs):
         tasks.S3BucketCreate(
             entity=self,
             user=self.created_by,
@@ -155,6 +163,7 @@ class S3Bucket(TimeStampedModel):
             },
         ).create_task()
 
+    def _grant_creator_access(self):
         # created_by should always be set, but this is a failsafe
         if self.created_by:
             UserS3Bucket.objects.create(

--- a/controlpanel/api/tasks/handlers/s3.py
+++ b/controlpanel/api/tasks/handlers/s3.py
@@ -4,6 +4,7 @@ from django.db.models.deletion import Collector
 
 # First-party/Local
 from controlpanel.api import cluster, tasks
+from controlpanel.api.exceptions import BucketAlreadyExistsError
 from controlpanel.api.models import App, AppS3Bucket, S3Bucket, User, UserS3Bucket
 from controlpanel.api.models.access_to_s3bucket import AccessToS3Bucket
 from controlpanel.api.tasks.handlers.base import BaseModelTaskHandler, BaseTaskHandler
@@ -17,7 +18,12 @@ class CreateS3Bucket(BaseModelTaskHandler):
 
     def handle(self, bucket_owner=None):
         bucket_owner = bucket_owner or "USER"
-        self.object.cluster.create(owner=bucket_owner)
+        try:
+            self.object.cluster.create(owner=bucket_owner)
+        except BucketAlreadyExistsError:
+            log.warning(f"Bucket '{self.object.name}' already exists, cleaning up database record")
+            self.object.delete()
+            return
         self.complete()
 
 

--- a/controlpanel/frontend/views/app.py
+++ b/controlpanel/frontend/views/app.py
@@ -26,6 +26,7 @@ from rules.contrib.views import PermissionRequiredMixin
 
 # First-party/Local
 from controlpanel.api import auth0, cluster
+from controlpanel.api.exceptions import BucketAlreadyExistsError
 from controlpanel.api.github import GithubAPI, RepositoryNotFound
 from controlpanel.api.models import (
     App,
@@ -231,6 +232,9 @@ class CreateApp(OIDCLoginRequiredMixin, PermissionRequiredMixin, CreateView):
             self.object = AppManager().register_app(self.request.user, form.cleaned_data)
         except RepositoryNotFound as ex:
             form.add_error("namespace", str(ex))
+            return FormMixin.form_invalid(self, form)
+        except BucketAlreadyExistsError:
+            form.add_error("new_datasource_name", "Bucket name is not available")
             return FormMixin.form_invalid(self, form)
         except Exception as ex:
             form.add_error("repo_url", str(ex))

--- a/controlpanel/frontend/views/apps_mng.py
+++ b/controlpanel/frontend/views/apps_mng.py
@@ -88,11 +88,14 @@ class AppManager:
 
     def _create_or_link_datasource(self, app, user, bucket_data):
         if bucket_data.get("new_datasource_name"):
-            bucket = S3Bucket.objects.create(
-                name=bucket_data["new_datasource_name"],
-                bucket_owner="APP",
-                created_by=user,
-            )
+            with transaction.atomic():
+                bucket = S3Bucket.objects.create(
+                    name=bucket_data["new_datasource_name"],
+                    bucket_owner="APP",
+                    created_by=user,
+                    dispatch_task=False,
+                )
+                bucket.cluster.create(owner="APP")
             AppS3Bucket.objects.create(
                 app=app,
                 s3bucket=bucket,

--- a/controlpanel/frontend/views/datasource.py
+++ b/controlpanel/frontend/views/datasource.py
@@ -22,6 +22,7 @@ from rules.contrib.views import PermissionRequiredMixin
 # First-party/Local
 from controlpanel.api import cluster, tasks
 from controlpanel.api.elasticsearch import bucket_hits_aggregation
+from controlpanel.api.exceptions import BucketAlreadyExistsError
 from controlpanel.api.models import IAMManagedPolicy, PolicyS3Bucket, S3Bucket, User, UserS3Bucket
 from controlpanel.api.serializers import ESBucketHitsSerializer
 from controlpanel.frontend.forms import (
@@ -186,15 +187,21 @@ class CreateDatasource(
         datasource_type = self.request.GET.get("type")
 
         try:
-            self.object = S3Bucket.objects.create(
-                name=name,
-                created_by=self.request.user,
-                is_data_warehouse=datasource_type == "warehouse",
-            )
+            with transaction.atomic():
+                self.object = S3Bucket.objects.create(
+                    name=name,
+                    created_by=self.request.user,
+                    is_data_warehouse=datasource_type == "warehouse",
+                    dispatch_task=False,
+                )
+                self.object.cluster.create()
             messages.success(
                 self.request,
                 f"Successfully created {name} {datasource_type} data source",
             )
+        except BucketAlreadyExistsError:
+            form.add_error("name", f"Bucket name '{name}' is not available")
+            return FormMixin.form_invalid(self, form)
         except Exception as ex:
             form.add_error("name", str(ex))
             return FormMixin.form_invalid(self, form)

--- a/tests/api/models/test_s3bucket.py
+++ b/tests/api/models/test_s3bucket.py
@@ -153,7 +153,6 @@ def test_soft_delete_folder(users, sqs, helpers):
 
 
 def test_bucket_create_dispatch_task_false(sqs, superuser, helpers):
-    """When dispatch_task=False, no Celery task message should be sent."""
     bucket = S3Bucket.objects.create(
         name="test-no-task-bucket",
         created_by=superuser,
@@ -161,5 +160,4 @@ def test_bucket_create_dispatch_task_false(sqs, superuser, helpers):
     )
     messages = helpers.retrieve_messages(sqs, queue_name=settings.S3_QUEUE_NAME)
     assert len(messages) == 0
-    # UserS3Bucket should still be created
     assert UserS3Bucket.objects.filter(user=superuser, s3bucket=bucket).exists()

--- a/tests/api/models/test_s3bucket.py
+++ b/tests/api/models/test_s3bucket.py
@@ -150,3 +150,16 @@ def test_soft_delete_folder(users, sqs, helpers):
     )
     assert "archive_s3bucket" in task_names
     assert "s3bucket_revoke_all_access" in task_names
+
+
+def test_bucket_create_dispatch_task_false(sqs, superuser, helpers):
+    """When dispatch_task=False, no Celery task message should be sent."""
+    bucket = S3Bucket.objects.create(
+        name="test-no-task-bucket",
+        created_by=superuser,
+        dispatch_task=False,
+    )
+    messages = helpers.retrieve_messages(sqs, queue_name=settings.S3_QUEUE_NAME)
+    assert len(messages) == 0
+    # UserS3Bucket should still be created
+    assert UserS3Bucket.objects.filter(user=superuser, s3bucket=bucket).exists()

--- a/tests/api/tasks/test_s3.py
+++ b/tests/api/tasks/test_s3.py
@@ -39,7 +39,7 @@ def test_exception_raised_when_called_without_valid_app(complete, users, task_me
 @patch("controlpanel.api.tasks.handlers.base.BaseTaskHandler.complete")
 @patch("controlpanel.api.models.s3bucket.cluster")
 def test_bucket_created(cluster, complete, users):
-    s3bucket = baker.make("api.S3Bucket", bucket_owner="APP")
+    s3bucket = baker.make("api.S3Bucket", bucket_owner="APP")  # gitleaks:allow
 
     create_s3bucket(s3bucket.pk, users["superuser"].pk, bucket_owner=s3bucket.bucket_owner)
 
@@ -52,8 +52,8 @@ def test_bucket_created(cluster, complete, users):
 @pytest.mark.parametrize(
     "task_method, model_class, cluster_class",
     [
-        (grant_app_s3bucket_access, "api.AppS3Bucket", "App"),
-        (grant_user_s3bucket_access, "api.UserS3Bucket", "User"),
+        (grant_app_s3bucket_access, "api.AppS3Bucket", "App"),  # gitleaks:allow
+        (grant_user_s3bucket_access, "api.UserS3Bucket", "User"),  # gitleaks:allow
     ],
 )
 @patch("controlpanel.api.tasks.handlers.base.BaseTaskHandler.complete")
@@ -126,7 +126,7 @@ def test_revoke_user_access_user_does_not_exist(cluster, complete, bucket_name, 
 @patch("controlpanel.api.tasks.handlers.base.BaseTaskHandler.complete")
 @patch("controlpanel.api.tasks.handlers.s3.cluster")
 def test_revoke_app_access(cluster, complete):
-    app_bucket_access = baker.make("api.AppS3Bucket")
+    app_bucket_access = baker.make("api.AppS3Bucket")  # gitleaks:allow
     revoke_app_s3bucket_access(
         bucket_arn=app_bucket_access.s3bucket.arn,
         app_pk=app_bucket_access.app.pk,
@@ -147,8 +147,8 @@ def test_revoke_app_access(cluster, complete):
 def test_revoke_all_access(complete, users):
     bucket = baker.make("api.S3Bucket")
     user_access = baker.make("api.UserS3Bucket", s3bucket=bucket)
-    app_access = baker.make("api.AppS3Bucket", s3bucket=bucket)
-    policy_access = baker.make("api.PolicyS3Bucket", s3bucket=bucket)
+    app_access = baker.make("api.AppS3Bucket", s3bucket=bucket)  # gitleaks:allow
+    policy_access = baker.make("api.PolicyS3Bucket", s3bucket=bucket)  # gitleaks:allow
     task = baker.make("api.Task", user_id=users["superuser"].pk)
 
     revoke_all_access_s3bucket(bucket.pk, task.user_id)

--- a/tests/api/tasks/test_s3.py
+++ b/tests/api/tasks/test_s3.py
@@ -6,6 +6,7 @@ import pytest
 from model_bakery import baker
 
 # First-party/Local
+from controlpanel.api.exceptions import BucketAlreadyExistsError
 from controlpanel.api.models import AppS3Bucket, S3Bucket, UserS3Bucket
 from controlpanel.api.tasks.handlers import (
     create_s3bucket,
@@ -156,3 +157,22 @@ def test_revoke_all_access(complete, users):
     app_access.revoke_bucket_access.assert_called_once()
     policy_access.revoke_bucket_access.assert_called_once()
     complete.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("controlpanel.api.models.UserS3Bucket.revoke_bucket_access", new=MagicMock())
+@patch("controlpanel.api.models.AppS3Bucket.revoke_bucket_access", new=MagicMock())
+@patch("controlpanel.api.cluster.AWSBucket.tag_bucket")
+@patch("controlpanel.api.cluster.AWSBucket.create")
+@patch("controlpanel.api.tasks.handlers.base.BaseTaskHandler.complete")
+def test_bucket_create_already_exists_deletes_record(complete, mock_aws_create, tag_bucket, users):
+    """When the Celery handler encounters BucketAlreadyExistsError,
+    it should delete the database record and not mark the task as complete."""
+    s3bucket = baker.make("api.S3Bucket", dispatch_task=False)
+    mock_aws_create.side_effect = BucketAlreadyExistsError("Bucket name is not available")
+
+    create_s3bucket(s3bucket.pk, users["superuser"].pk, bucket_owner="USER")
+
+    mock_aws_create.assert_called_once()
+    complete.assert_not_called()
+    assert S3Bucket.objects.filter(pk=s3bucket.pk).exists() is False

--- a/tests/api/tasks/test_s3.py
+++ b/tests/api/tasks/test_s3.py
@@ -166,8 +166,6 @@ def test_revoke_all_access(complete, users):
 @patch("controlpanel.api.cluster.AWSBucket.create")
 @patch("controlpanel.api.tasks.handlers.base.BaseTaskHandler.complete")
 def test_bucket_create_already_exists_deletes_record(complete, mock_aws_create, tag_bucket, users):
-    """When the Celery handler encounters BucketAlreadyExistsError,
-    it should delete the database record and not mark the task as complete."""
     s3bucket = baker.make("api.S3Bucket", dispatch_task=False)
     mock_aws_create.side_effect = BucketAlreadyExistsError("Bucket name is not available")
 

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 # First-party/Local
 from controlpanel.api import aws
 from controlpanel.api.cluster import BASE_ASSUME_ROLE_POLICY, User
+from controlpanel.api.exceptions import BucketAlreadyExistsError
 from tests.api.fixtures.aws import *
 
 
@@ -318,6 +319,35 @@ def test_bucket_exists(s3):
         }
     )
     assert aws.AWSBucket().exists("example") is True
+
+
+@pytest.mark.parametrize(
+    "exception_name",
+    ["BucketAlreadyOwnedByYou", "BucketAlreadyExists"],
+    ids=["owned_by_you", "other_account"],
+)
+def test_create_bucket_raises_when_already_exists(exception_name):
+    mock_s3_resource = MagicMock()
+    mock_s3_resource.meta.client.exceptions.BucketAlreadyOwnedByYou = type(
+        "BucketAlreadyOwnedByYou", (ClientError,), {}
+    )
+    mock_s3_resource.meta.client.exceptions.BucketAlreadyExists = type(
+        "BucketAlreadyExists", (ClientError,), {}
+    )
+    # Make create_bucket raise the appropriate exception
+    exc = getattr(mock_s3_resource.meta.client.exceptions, exception_name)(
+        error_response={"Error": {"Code": exception_name}},
+        operation_name="CreateBucket",
+    )
+    mock_s3_resource.create_bucket.side_effect = exc
+
+    with patch(
+        "controlpanel.api.aws.AWSBucket.boto3_session", new_callable=PropertyMock
+    ) as session:
+        session.return_value.resource.return_value = mock_s3_resource
+        session.return_value.client.return_value = MagicMock()
+        with pytest.raises(BucketAlreadyExistsError):
+            aws.AWSBucket().create("test-bucket")
 
 
 def test_create_parameter(ssm):

--- a/tests/api/test_aws.py
+++ b/tests/api/test_aws.py
@@ -334,7 +334,6 @@ def test_create_bucket_raises_when_already_exists(exception_name):
     mock_s3_resource.meta.client.exceptions.BucketAlreadyExists = type(
         "BucketAlreadyExists", (ClientError,), {}
     )
-    # Make create_bucket raise the appropriate exception
     exc = getattr(mock_s3_resource.meta.client.exceptions, exception_name)(
         error_response={"Error": {"Code": exception_name}},
         operation_name="CreateBucket",

--- a/tests/frontend/views/test_datasource.py
+++ b/tests/frontend/views/test_datasource.py
@@ -9,6 +9,7 @@ from model_bakery import baker
 from rest_framework import status
 
 # First-party/Local
+from controlpanel.api.exceptions import BucketAlreadyExistsError
 from controlpanel.api.models import S3Bucket, UserS3Bucket
 from controlpanel.frontend.forms import CreateDatasourceFolderForm, CreateDatasourceForm
 from controlpanel.frontend.views import CreateDatasource
@@ -291,9 +292,9 @@ def test_list_other_datasources_admins(client, buckets, users):
 
 
 @patch("controlpanel.api.models.users3bucket.tasks.S3BucketGrantToUser")
-@patch("controlpanel.api.models.s3bucket.tasks.S3BucketCreate")
+@patch("controlpanel.api.cluster.AWSBucket.create")
 def test_bucket_creator_has_readwrite_and_admin_access(
-    create_bucket_task, grant_user_task, client, users
+    mock_aws_create, grant_user_task, client, users
 ):
     user = users["normal_user"]
     client.force_login(user)
@@ -302,7 +303,7 @@ def test_bucket_creator_has_readwrite_and_admin_access(
     ub = user.users3buckets.all()[0]
     assert ub.access_level == UserS3Bucket.READWRITE
     assert ub.is_admin
-    create_bucket_task.assert_called_once()
+    mock_aws_create.assert_called_once()
     grant_user_task.assert_called_once()
 
 
@@ -326,12 +327,10 @@ def test_create_get_form_class(rf, folders_enabled, datasource_type, form_class)
 
 
 @patch("controlpanel.api.models.users3bucket.tasks.S3BucketGrantToUser")
-@patch("controlpanel.api.models.s3bucket.tasks.S3BucketCreate")
+@patch("controlpanel.api.aws.AWSFolder.create")
 @patch("django.conf.settings.features.s3_folders.enabled", True)
 @pytest.mark.parametrize("user", ["superuser", "normal_user", "other_user"])
-def test_create_folders(
-    create_bucket_task, grant_user_task, user, client, users, root_folder_bucket
-):
+def test_create_folders(mock_aws_create, grant_user_task, user, client, users, root_folder_bucket):
     """
     Check that all users can create a folder datasource
     """
@@ -345,12 +344,12 @@ def test_create_folders(
     assert user.users3buckets.filter(
         s3bucket__name=f"{root_folder_bucket.name}/{folder_name}"
     ).exists()
-    # make sure tasks are sent
-    create_bucket_task.assert_called_once()
+    # make sure AWS create is called
+    mock_aws_create.assert_called_once()
     grant_user_task.assert_called_once()
 
     # create another folder to catch any errors updating IAM policy
-    create_bucket_task.reset_mock()
+    mock_aws_create.reset_mock()
     grant_user_task.reset_mock()
     folder_name = f"test-{user.username}-folder-2"
     response = create(client, name=folder_name)
@@ -360,8 +359,8 @@ def test_create_folders(
     assert user.users3buckets.filter(
         s3bucket__name=f"{root_folder_bucket.name}/{folder_name}"
     ).exists()
-    # tasks to create are sent again for the second folder
-    create_bucket_task.assert_called_once()
+    # AWS create is called again for the second folder
+    mock_aws_create.assert_called_once()
     grant_user_task.assert_called_once()
 
 
@@ -514,3 +513,40 @@ def test_external_user_admin_fail(client, users, buckets):
     )
     assert response.status_code == 200
     assert "access_level" in response.context_data["form"].errors
+
+
+@patch("controlpanel.api.cluster.AWSBucket.create")
+def test_create_datasource_bucket_already_exists_shows_error(mock_aws_create, client, users):
+    """When AWS reports the bucket name is unavailable, the user sees an error
+    and no database record is persisted."""
+    mock_aws_create.side_effect = BucketAlreadyExistsError(
+        "Bucket name 'test-taken' is not available"
+    )
+
+    user = users["normal_user"]
+    client.force_login(user)
+    response = create(client, name="test-taken")
+
+    assert response.status_code == 200
+    assert S3Bucket.objects.filter(name="test-taken").exists() is False
+    assert UserS3Bucket.objects.filter(user=user, s3bucket__name="test-taken").exists() is False
+    assert "name" in response.context_data["form"].errors
+
+
+@patch("controlpanel.api.cluster.AWSBucket.create")
+def test_create_datasource_success_no_celery_task(mock_aws_create, client, users, sqs, helpers):
+    """Successful synchronous creation should NOT dispatch a Celery task."""
+    # Drain any messages sent by the autouse buckets fixture
+    helpers.retrieve_messages(sqs, queue_name=settings.S3_QUEUE_NAME)
+
+    user = users["normal_user"]
+    client.force_login(user)
+    response = create(client, name="test-sync-bucket")
+
+    assert response.status_code == 302
+    assert S3Bucket.objects.filter(name="test-sync-bucket").exists()
+    mock_aws_create.assert_called_once()
+
+    # Verify no S3 bucket creation task was sent for the new bucket
+    messages = helpers.retrieve_messages(sqs, queue_name=settings.S3_QUEUE_NAME)
+    assert len(messages) == 0

--- a/tests/frontend/views/test_datasource.py
+++ b/tests/frontend/views/test_datasource.py
@@ -39,11 +39,11 @@ def users(users):
 def buckets(db):
     with patch("controlpanel.api.aws.AWSBucket.create"):
         return {
-            "app_data1": baker.make("api.S3Bucket", is_data_warehouse=False),
-            "app_data2": baker.make("api.S3Bucket", is_data_warehouse=False),
-            "warehouse1": baker.make("api.S3Bucket", is_data_warehouse=True),
-            "warehouse2": baker.make("api.S3Bucket", is_data_warehouse=True),
-            "other": baker.make("api.S3Bucket"),
+            "app_data1": baker.make("api.S3Bucket", is_data_warehouse=False, dispatch_task=False),
+            "app_data2": baker.make("api.S3Bucket", is_data_warehouse=False, dispatch_task=False),
+            "warehouse1": baker.make("api.S3Bucket", is_data_warehouse=True, dispatch_task=False),
+            "warehouse2": baker.make("api.S3Bucket", is_data_warehouse=True, dispatch_task=False),
+            "other": baker.make("api.S3Bucket", dispatch_task=False),
         }
 
 
@@ -517,8 +517,6 @@ def test_external_user_admin_fail(client, users, buckets):
 
 @patch("controlpanel.api.cluster.AWSBucket.create")
 def test_create_datasource_bucket_already_exists_shows_error(mock_aws_create, client, users):
-    """When AWS reports the bucket name is unavailable, the user sees an error
-    and no database record is persisted."""
     mock_aws_create.side_effect = BucketAlreadyExistsError(
         "Bucket name 'test-taken' is not available"
     )
@@ -535,10 +533,6 @@ def test_create_datasource_bucket_already_exists_shows_error(mock_aws_create, cl
 
 @patch("controlpanel.api.cluster.AWSBucket.create")
 def test_create_datasource_success_no_celery_task(mock_aws_create, client, users, sqs, helpers):
-    """Successful synchronous creation should NOT dispatch a Celery task."""
-    # Drain any messages sent by the autouse buckets fixture
-    helpers.retrieve_messages(sqs, queue_name=settings.S3_QUEUE_NAME)
-
     user = users["normal_user"]
     client.force_login(user)
     response = create(client, name="test-sync-bucket")
@@ -547,6 +541,5 @@ def test_create_datasource_success_no_celery_task(mock_aws_create, client, users
     assert S3Bucket.objects.filter(name="test-sync-bucket").exists()
     mock_aws_create.assert_called_once()
 
-    # Verify no S3 bucket creation task was sent for the new bucket
     messages = helpers.retrieve_messages(sqs, queue_name=settings.S3_QUEUE_NAME)
     assert len(messages) == 0


### PR DESCRIPTION
Decouples S3 bucket creation from celery, in order to fix bug where post creation of the DB object the bucket name is not available leaving the DB and S3 out of sync.

Fixes issue https://github.com/ministryofjustice/analytical-platform/issues/9929. See the "To reproduce" section of the ticket for more context and instructions on how to test, but one way is to:
- Create a data warehouse
- Then try to create another with the same name
- 2nd one should fail with an error

In order to test with the exact bucket name that was previously uncaught (from the Sentry error) I had to locally alter the code to allow `alpha-` buckets to be created, as the default prefixes the current env. Screenshot of the error that is now seen when trying to create the bucket:
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/27e85b5d-07f4-4ace-90e8-e07b8159659f" />

