### PR TITLE
Replace django-crequest with custom middleware

### DIFF
--- a/controlpanel/api/models/user.py
+++ b/controlpanel/api/models/user.py
@@ -1,5 +1,4 @@
 # Third-party
-from crequest.middleware import CrequestMiddleware
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.signals import user_logged_in
 from django.db import models
@@ -9,6 +8,7 @@ from django.utils.functional import cached_property
 # First-party/Local
 from controlpanel.api import auth0, cluster, slack
 from controlpanel.api.signals import prometheus_login_event
+from controlpanel.middleware.current_request import get_current_request
 from controlpanel.utils import sanitize_dns_label
 
 QUICKSIGHT_EMBED_AUTHOR_PERMISSION = "quicksight_embed_author_access"
@@ -70,11 +70,9 @@ class User(AbstractUser):
         """
         Retrieve the user's Id token if they are the logged in user
         """
-        request = CrequestMiddleware.get_request()
+        request = get_current_request()
         if not request:
-            raise Exception(
-                "request not found: have you called get_id_token() in a background worker?"
-            )
+            return None
 
         if request.user == self:
             return request.session.get("oidc_id_token")
@@ -193,7 +191,7 @@ class User(AbstractUser):
 
         already_superuser = existing and existing.is_superuser
         if self.is_superuser and not already_superuser:
-            request = CrequestMiddleware.get_request()
+            request = get_current_request()
             slack.notify_superuser_created(
                 self.username,
                 by_username=request.user.username if request else None,

--- a/controlpanel/middleware/current_request.py
+++ b/controlpanel/middleware/current_request.py
@@ -1,0 +1,19 @@
+from contextvars import ContextVar
+
+_current_request: ContextVar = ContextVar("current_request", default=None)
+
+
+def get_current_request():
+    return _current_request.get()
+
+
+class CurrentRequestMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        token = _current_request.set(request)
+        try:
+            return self.get_response(request)
+        finally:
+            _current_request.reset(token)

--- a/controlpanel/settings/common.py
+++ b/controlpanel/settings/common.py
@@ -55,8 +55,6 @@ INSTALLED_APPS = [
     "django.contrib.postgres",
     # Django collect static files into a single location
     "django.contrib.staticfiles",
-    # Make current request available anywhere
-    "crequest",
     # Provides shell_plus, runserver_plus, etc
     "django_extensions",
     # Provides filter backend for use with Django REST Framework
@@ -94,7 +92,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     # Make current request available anywhere
-    "crequest.middleware.CrequestMiddleware",
+    "controlpanel.middleware.current_request.CurrentRequestMiddleware",
     # Check user's OIDC token is still valid
     "mozilla_django_oidc.middleware.SessionRefresh",
     # Structured logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "daphne==4.2.1",
     "django==5.2.14",
     "django-celery-beat==2.9.0",
-    "django-crequest==2018.5.11",
     "django-extensions==4.1",
     "django-filter==25.2",
     "django-prometheus==2.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,6 @@ dependencies = [
     { name = "daphne" },
     { name = "django" },
     { name = "django-celery-beat" },
-    { name = "django-crequest" },
     { name = "django-extensions" },
     { name = "django-filter" },
     { name = "django-prometheus" },
@@ -568,7 +567,6 @@ requires-dist = [
     { name = "daphne", specifier = "==4.2.1" },
     { name = "django", specifier = "==5.2.14" },
     { name = "django-celery-beat", specifier = "==2.9.0" },
-    { name = "django-crequest", specifier = "==2018.5.11" },
     { name = "django-extensions", specifier = "==4.1" },
     { name = "django-filter", specifier = "==25.2" },
     { name = "django-prometheus", specifier = "==2.4.1" },
@@ -720,15 +718,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/05/45/fc97bc1d9af8e7dc0
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/ae/9befa7ae37f5e5c41be636a254fcf47ff30dd5c88bd115070e252f6b9162/django_celery_beat-2.9.0-py3-none-any.whl", hash = "sha256:4a9e5ebe26d6f8d7215e1fc5c46e466016279dc102435a28141108649bdf2157", size = 105013, upload-time = "2026-02-28T16:45:32.822Z" },
 ]
-
-[[package]]
-name = "django-crequest"
-version = "2018.5.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/61/d2e95ff46d2d117b79873d6922665d711b35357b50b854a0e9cf42806431/django-crequest-2018.5.11.tar.gz", hash = "sha256:e623ec6b2933790717307d5a59cf9db39ff4928b53c506948e1d05776ef4a034", size = 4357, upload-time = "2018-05-11T09:37:55.361Z" }
 
 [[package]]
 name = "django-debug-toolbar"


### PR DESCRIPTION
[django-crequest](https://github.com/Alir3z4/django-crequest/tree/master) has not been updated since 2018, so this replaces it with a custome middleware that will make the current request available globally without relying onthread-local storage, which is not compatible with async contexts.
