### PR TITLE
Tell dependabot to ignore django 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
     ignore:
       - dependency-name: "numpy"
         versions: [ ">=2.0.0" ]
+      - dependency-name: "django"
+        versions: [ ">=6.0.0" ]
     directory: "/"
     open-pull-requests-limit: 15
     schedule:


### PR DESCRIPTION
Updating to this major version may not be compatible without significant code changes, which is not realistic at this time as the AP is on in a feature freeze to focus on data platform.

Merging should fix the broken Dependabot runs https://github.com/ministryofjustice/analytics-platform-control-panel/network/updates/30637029/jobs