### PR TITLE
Use hmac over == to compare token

### DIFF
--- a/controlpanel/webhooks/views.py
+++ b/controlpanel/webhooks/views.py
@@ -1,5 +1,6 @@
 # Standard library
 import json
+import hmac
 
 # Third-party
 import structlog
@@ -47,7 +48,9 @@ class PagerDutyWebhookView(View):
         return JsonResponse({"status": "ok", "action": "Created" if created else "Updated"})
 
     def _validate_token(self, request):
-        return request.GET.get("token") == settings.PAGERDUTY_WEBHOOK_SECRET
+        provided_token = request.GET.get("token", "")
+        expected_token = settings.PAGERDUTY_WEBHOOK_SECRET or ""
+        return hmac.compare_digest(provided_token, expected_token)
 
     def _parse_payload(self, request):
         try:


### PR DESCRIPTION
[Tracked as part of this ticket](https://github.com/ministryofjustice/data-platform/issues/506)

This pull request improves the security of the webhook authentication in `controlpanel/webhooks/views.py` by switching to a timing-attack-resistant comparison for validating the webhook token.

**Security improvements:**

* The `_validate_token` method now uses `hmac.compare_digest` for comparing the provided token with the expected secret, which protects against timing attacks.
* Added the `hmac` module import to support secure token comparison.This pull request improves the security of token validation in the `controlpanel/webhooks/views.py` file by switching to a timing-attack resistant comparison method. It also adds the necessary import for `hmac`.

Security improvements:

* Updated the `_validate_token` method to use `hmac.compare_digest` instead of a simple equality check, making token comparison resistant to timing attacks.

Dependency updates:

* Added an import for the `hmac` module to support secure token comparison.